### PR TITLE
Add a `ReadyService` trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,28 @@ pub trait Service {
     fn call(&mut self, req: Self::Request) -> Self::Future;
 }
 
+/// An asynchronous function from `Request` to a `Response`.
+///
+/// `ReadyService` is similar to `Service`, except that it is always able to
+/// accept a request. This request may either complete successfully or resolve
+/// to an error.
+pub trait ReadyService {
+    /// Requests handled by the service.
+    type Request;
+
+    /// Responses returned by the service.
+    type Response;
+
+    /// Errors produced by the service.
+    type Error;
+
+    /// The future response value.
+    type Future: Future<Item = Self::Response, Error = Self::Error>;
+
+    /// Process the request and return the response asynchronously.
+    fn call(&mut self, req: Self::Request) -> Self::Future;
+}
+
 /// Future yielding a `Service` once the service is ready to process a request
 pub struct Ready<T> {
     inner: Option<T>,


### PR DESCRIPTION
This PR adds a `ReadyService` trait. A `ReadyService` is similar to `Service` except that it is always "ready" to accept a request. A `ReadyService` implementation can immediately error the response if it is "at capacity", but it has no strategy by which to notify the caller that it becomes ready again.

It is expected that types will usually implement either `Service` OR `ReadyService` (though, there may be cases in which a type can implement both). It is also expected that server implementations will only accept `Service` values.

## Adapting

### `ReadyService` -> `Service`

In order to adapt a `ReadyService` to a `Service`, I can think of a couple strategies off the top of my head.

#### Don't do anything special.

In this case, there will be some type `AdaptReadyService` (naming TBD) that takes a `ReadyService` and implements `Service` such that `poll_ready` always returns `Ready`. This requires the user to make an explicit step to say that the server will not have any mechanism to handle back pressure.

#### Add a limiter

In this case, a `ReadyService` value is passed to `Limit::new(my_ready_service, n)`. This type ensures that there are only `n` in-flight requests. This limiter can be scoped to the connection (`n` in-flight requests per connection) or per "app" so that the number of in-flight requests are limited across many connections.

### `Service` -> `ReadyService`

There are reasons to want to adapt the other direction as well. For example a router (a single service that routes a request to one of many possible inner services) cannot easily provide a back pressure strategy. In this case, a router would want to be initialized with a set of `ReadyService` values.

To adapt a `ReadyService` to `Service`, the primary strategy would be to add a buffering layer. This buffer would ideally have an upper limit. When the upper limit is reached, the buffer starts erroring requests immediately.

## Higher level frameworks

Obviously, introducing a new trait adds non trivial complexity. That said, I would expect that `ReadyService` would provide a better suited trait for reducing initial friction. I would not necessarily expect frameworks to ask their users to implement `ReadyService`, but frameworks could use this trait internally and build up a tower stack using `Router`, `Limit`, `Buffer`, etc... and eventually provide a `Service` representing the entire stack and pass that to a server.

## Alternatives

There are two alternatives to introducing `ReadyService`.

### Keep things as is.

In this case, a "ready service" would be a type that implements `Service` such that `poll_ready` always returns `Ready`. The service would need to document that `poll_ready` does not need to be called before `call` (as there are some services that *require* `poll_ready` to return `Ready` before calling `call`).

The router type would accept a set of `Service` values, documenting that these must be "ready service" values and as such `poll_ready` will *not* be called. This means, if a service that requires` poll_ready` to be called is passed, it would just hang (for example, `Reconnect`).

### Remove `poll_ready` from `Service`.

If `ReadyService` is needed, is `poll_ready` actually helpful? I would say *yes* as *most* middleware implementations so far heavily rely on `poll_ready` to do the "right thing". The only middleware that I have written that requires a "ready service" is the router.