### PR TITLE
Rename `tower-route` -> `tower-router`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
   "tower-mock",
   "tower-rate-limit",
   "tower-reconnect",
-  "tower-route",
+  "tower-router",
   "tower-timeout",
   "tower-util",
 ]

--- a/tower-router/Cargo.toml
+++ b/tower-router/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tower-route"
+name = "tower-router"
 version = "0.1.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
 

--- a/tower-router/README.md
+++ b/tower-router/README.md
@@ -1,11 +1,11 @@
-Tower Route
+Tower Router
 
 A Tower middleware that routes requests to one of a set of inner services using
 a request predicate.
 
 # License
 
-`tower-route` is primarily distributed under the terms of both the MIT license
+`tower-router` is primarily distributed under the terms of both the MIT license
 and the Apache License (Version 2.0), with portions covered by various BSD-like
 licenses.
 

--- a/tower-router/src/lib.rs
+++ b/tower-router/src/lib.rs
@@ -16,7 +16,7 @@ use std::mem;
 use self::ResponseState::*;
 
 /// Routes requests to an inner service based on the request.
-pub struct Route<T> {
+pub struct Router<T> {
     recognize: Borrow<T>,
 }
 
@@ -60,7 +60,7 @@ where T: Recognize,
     state: ResponseState<T>,
 }
 
-/// Error produced by the `Route` service
+/// Error produced by the `Router` service
 ///
 /// TODO: Make variants priv
 #[derive(Debug)]
@@ -88,18 +88,18 @@ where T: Recognize
     Invalid,
 }
 
-// ===== impl Route =====
+// ===== impl Router =====
 
-impl<T> Route<T>
+impl<T> Router<T>
 where T: Recognize
 {
     /// Create a new router
     pub fn new(recognize: T) -> Self {
-        Route { recognize: Borrow::new(recognize) }
+        Router { recognize: Borrow::new(recognize) }
     }
 }
 
-impl<T> Service for Route<T>
+impl<T> Service for Router<T>
 where T: Recognize,
 {
     type Request = T::Request;

--- a/tower-router/tests/router.rs
+++ b/tower-router/tests/router.rs
@@ -1,10 +1,10 @@
 extern crate futures;
 extern crate futures_test;
 extern crate tower;
-extern crate tower_route;
+extern crate tower_router;
 
 use tower::Service;
-use tower_route::*;
+use tower_router::*;
 
 use futures::*;
 use futures::future::FutureResult;
@@ -34,7 +34,7 @@ fn basic_routing() {
     recognize.map.insert("one".into(), StringService::ok("hello"));
     recognize.map.insert("two".into(), StringService::ok("world"));
 
-    let mut service = Route::new(recognize);
+    let mut service = Router::new(recognize);
 
     // Router is ready by default
     assert_ready!(&mut service);
@@ -61,7 +61,7 @@ fn inner_service_err() {
     recognize.map.insert("one".into(), StringService::ok("hello"));
     recognize.map.insert("two".into(), StringService::err());
 
-    let mut service = Route::new(recognize);
+    let mut service = Router::new(recognize);
 
     let resp = service.call("two".into());
     assert!(resp.wait().is_err());
@@ -78,7 +78,7 @@ fn inner_service_not_ready() {
     recognize.map.insert("one".into(), MaybeService::new("hello"));
     recognize.map.insert("two".into(), MaybeService::none());
 
-    let mut service = Route::new(recognize);
+    let mut service = Router::new(recognize);
 
     let resp = service.call("two".into());
     let mut resp = Harness::new(resp);


### PR DESCRIPTION
`Route` as a verb is easily confused with the noun.