### PR TITLE
add a CloneService helper for sharing a Service

### DIFF
--- a/tower-util/src/clone.rs
+++ b/tower-util/src/clone.rs
@@ -1,0 +1,86 @@
+//! Contains a `CloneService` type.
+
+use std::sync::{Arc, Mutex};
+use futures::{Async, Poll};
+use futures::task::{self, Task};
+use tower::Service;
+
+/// Be able to clone a `Service`.
+#[derive(Debug)]
+pub struct CloneService<T> {
+    inner: Arc<Mutex<Inner<T>>>,
+    send_task: Arc<Mutex<Option<Task>>>,
+}
+
+#[derive(Debug)]
+struct Inner<T> {
+    service: T,
+    tasks: Vec<Arc<Mutex<Option<Task>>>>,
+}
+
+impl<T> CloneService<T> {
+    /// Wrap a service in a cloneable `CloneService`.
+    pub fn new(inner: T) -> Self {
+        CloneService {
+            inner: Arc::new(Mutex::new(Inner {
+                service: inner,
+                tasks: Vec::new(),
+            })),
+            send_task: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+impl<T> Clone for CloneService<T> {
+    fn clone(&self) -> Self {
+        CloneService {
+            inner: self.inner.clone(),
+            send_task: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+impl<T> Service for CloneService<T>
+where T: Service,
+{
+    type Request = T::Request;
+    type Response = T::Response;
+    type Error = T::Error;
+    type Future = T::Future;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        let mut inner = self.inner.lock().unwrap();
+        let async = inner.service.poll_ready()?;
+        if async.is_ready() {
+            for task in inner.tasks.drain(..) {
+                task.lock()
+                    .unwrap()
+                    .take()
+                    .map(|t| t.notify());
+            }
+            Ok(Async::Ready(()))
+        } else {
+            let should_push = {
+                let mut task = self.send_task.lock().unwrap();
+                if task.is_none() {
+                    *task = Some(task::current());
+                    true
+                } else {
+                    false
+                }
+            };
+            if should_push {
+                inner.tasks.push(self.send_task.clone());
+            }
+            Ok(Async::NotReady)
+        }
+    }
+
+    fn call(&mut self, req: Self::Request) -> Self::Future {
+        self.inner
+            .lock()
+            .unwrap()
+            .service
+            .call(req)
+    }
+}

--- a/tower-util/src/lib.rs
+++ b/tower-util/src/lib.rs
@@ -3,12 +3,14 @@
 extern crate futures;
 extern crate tower;
 
+pub mod boxed;
+mod clone;
 pub mod either;
 pub mod option;
-pub mod boxed;
 mod service_fn;
 
 pub use boxed::BoxService;
+pub use clone::CloneService;
 pub use either::EitherService;
 pub use service_fn::NewServiceFn;
 pub use option::OptionService;


### PR DESCRIPTION
I haven't spent much time optimizing, as I wanted to open this and see how you felt about the concept in general.

The idea is after having wrapped up a bunch of services, you could want to use the same service in a couple of places (such as different gRPC methods). This provides a safe way of being able to clone a `Service`, by tracking a `Task` for each clone.