### PR TITLE
Add ServiceFn to utils

### DIFF
--- a/tower-util/src/lib.rs
+++ b/tower-util/src/lib.rs
@@ -10,5 +10,5 @@ mod service_fn;
 
 pub use boxed::BoxService;
 pub use either::EitherService;
-pub use service_fn::NewServiceFn;
+pub use service_fn::{ServiceFn, NewServiceFn};
 pub use option::OptionService;


### PR DESCRIPTION
Adds `ServiceFn` helper. Since the closure does not provide any way to check for readiness, `ServiceFn` implements `ReadyService`.

In the future, there will be ways to adapt a `ReadyService` to a `Service`.

Resolves #21, Continues [this](https://github.com/tower-rs/tower/pull/19#issuecomment-335673246)