### PR TITLE
Add trace logging to tower-reconnect

### DIFF
--- a/tower-reconnect/Cargo.toml
+++ b/tower-reconnect/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["Carl Lerche <me@carllerche.com>"]
 publish = false
 
 [dependencies]
+log = "0.3"
 futures = "0.1"
 tower = { version = "0.1", path = "../" }

--- a/tower-reconnect/src/lib.rs
+++ b/tower-reconnect/src/lib.rs
@@ -83,7 +83,7 @@ where T: NewService
                             return Ok(Async::NotReady);
                         }
                         Err(e) => {
-                            trace!("poll_ready; connecting error: {:?}", e);
+                            trace!("poll_ready; error");
                             state = Idle;
                             ret = Err(Error::Connect(e));
                             break;
@@ -102,6 +102,7 @@ where T: NewService
                             return Ok(Async::NotReady);
                         }
                         Err(_) => {
+                            trace!("poll_ready; error");
                             state = Idle;
                         }
                     }

--- a/tower-reconnect/src/lib.rs
+++ b/tower-reconnect/src/lib.rs
@@ -1,4 +1,6 @@
 extern crate futures;
+#[macro_use]
+extern crate log;
 extern crate tower;
 
 use futures::{Future, Async, Poll};


### PR DESCRIPTION
It's useful to be able to debug the state of a reconnecting client.