### PR TITLE
Fix potential integer overflow in Balance

### DIFF
--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -151,7 +151,7 @@ where
         debug!("promoting to ready: {}", n);
         // Iterate through the not-ready endpoints from right to left to prevent removals
         // from reordering services in a way that could prevent a service from being polled.
-        for idx in (0..n-1).rev() {
+        for idx in (0..n.saturating_sub(1)).rev() {
             let is_ready = {
                 let (_, svc) = self.not_ready
                     .get_index_mut(idx)

--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -148,10 +148,15 @@ where
         -> Result<(), Error<<D::Service as Service>::Error, D::DiscoverError>>
     {
         let n = self.not_ready.len();
+        if n == 0 {
+            trace!("promoting to ready: not_ready is empty, skipping.");
+            return Ok(());
+        }
+
         debug!("promoting to ready: {}", n);
         // Iterate through the not-ready endpoints from right to left to prevent removals
         // from reordering services in a way that could prevent a service from being polled.
-        for idx in (0..n.saturating_sub(1)).rev() {
+        for idx in (0..n-1).rev() {
             let is_ready = {
                 let (_, svc) = self.not_ready
                     .get_index_mut(idx)


### PR DESCRIPTION
An usize overflow can occur in `Balance::promote_to_ready` when `self.not_ready` has length 0.

See my comment here: https://github.com/tower-rs/tower/pull/39#discussion_r163967979

Signed-off-by: Eliza Weisman <eliza@buoyant.io>