### PR TITLE
Test `Balance::poll_ready`

### DIFF
--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -107,21 +107,29 @@ where
     }
 
     /// Returns true iff there are ready services.
-    pub fn is_ready(&self) -> bool {
+    ///
+    /// This is not authoritative and is only useful after `poll_ready` has been called.
+    fn is_ready(&self) -> bool {
         !self.ready.is_empty()
     }
 
     /// Returns true iff there are no ready services.
+    ///
+    /// This is not authoritative and is only useful after `poll_ready` has been called.
     pub fn is_not_ready(&self) -> bool {
         self.ready.is_empty()
     }
 
     /// Counts the number of services considered to be ready.
+    ///
+    /// This is not authoritative and is only useful after `poll_ready` has been called.
     pub fn num_ready(&self) -> usize {
         self.ready.len()
     }
 
     /// Counts the number of services not considered to be ready.
+    ///
+    /// This is not authoritative and is only useful after `poll_ready` has been called.
     pub fn num_not_ready(&self) -> usize {
         self.not_ready.len()
     }

--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -107,18 +107,22 @@ where
     }
 
     /// Returns true iff there are ready services.
-    pub fn is_empty(&self) -> bool {
+    pub fn is_ready(&self) -> bool {
+        !self.ready.is_empty()
+    }
+
+    /// Returns true iff there are no ready services.
+    pub fn is_not_ready(&self) -> bool {
         self.ready.is_empty()
     }
 
     /// Counts the number of services considered to be ready.
-    pub fn len(&self) -> usize {
+    pub fn num_ready(&self) -> usize {
         self.ready.len()
     }
 
-
     /// Counts the number of services not considered to be ready.
-    pub fn not_ready_len(&self) -> usize {
+    pub fn num_not_ready(&self) -> usize {
         self.not_ready.len()
     }
 
@@ -394,15 +398,18 @@ mod tests {
                     }
                 }
 
-                if balancer.len() != ready {
+                if balancer.num_ready() != ready {
                     return TestResult::failed();
                 }
 
-                if balancer.not_ready_len() != pending {
+                if balancer.num_not_ready() != pending {
                     return TestResult::failed();
                 }
 
-                if balancer.is_empty() != (ready == 0) {
+                if balancer.is_ready() != (ready > 0) {
+                    return TestResult::failed();
+                }
+                if balancer.is_not_ready() != (ready == 0) {
                     return TestResult::failed();
                 }
 

--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -382,20 +382,14 @@ mod tests {
             let services = service_tries.len();
             for pending in pending_at.iter().map(|p| *p) {
                 assert!(pending <= services);
-
-                let poll = match balancer.poll_ready() {
-                    Ok(p) => p,
-                    Err(_) => return TestResult::error("poll_ready failed"),
-                };
-
                 let ready = services - pending;
-                if ready == 0 {
-                    if poll.is_ready() {
-                        return TestResult::failed();
-                    }
-                } else {
-                    if poll.is_not_ready() {
-                        return TestResult::failed();
+
+                match balancer.poll_ready() {
+                    Err(_) => return TestResult::error("poll_ready failed"),
+                    Ok(p) => {
+                        if p.is_ready() != (ready > 0) {
+                            return TestResult::failed();
+                        }
                     }
                 }
 


### PR DESCRIPTION
Test `Balance::poll_ready` by creating a random number of services, each
of which must be polled a random number of times before becoming ready.
As the balancer is polled, the test ensures that it does not become
ready prematurely and that services are promoted from not_ready to
ready.

`Balance::num_ready()` and `Balance::is_ready()` have been added to
expose the number of ready services, as well as `Balance::num_not_ready()`
to expose the number of pending services.