### PR TITLE
Support weighted balancing

### DIFF
--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -18,9 +18,11 @@ use tower_discover::Discover;
 
 pub mod choose;
 pub mod load;
+pub mod weight;
 
 pub use choose::Choose;
 pub use load::Load;
+pub use weight::{Weight, Weighted};
 
 /// Chooses services using the [Power of Two Choices][p2c].
 ///
@@ -109,7 +111,7 @@ where
     /// Returns true iff there are ready services.
     ///
     /// This is not authoritative and is only useful after `poll_ready` has been called.
-    fn is_ready(&self) -> bool {
+    pub fn is_ready(&self) -> bool {
         !self.ready.is_empty()
     }
 

--- a/tower-balance/src/load/pending_requests.rs
+++ b/tower-balance/src/load/pending_requests.rs
@@ -1,10 +1,11 @@
 use futures::{Future, Poll, Async};
+use std::ops;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tower::Service;
 use tower_discover::{Change, Discover};
 
-use Load;
+use {Load, Weight};
 
 /// Expresses load based on the number of currently-pending requests.
 #[derive(Debug, Clone)]
@@ -34,6 +35,16 @@ struct Handle {
 pub struct ResponseFuture<S: Service> {
     inner: S::Future,
     pending: Option<Handle>,
+}
+
+// ===== impl Count =====
+
+impl ops::Div<Weight> for Count {
+    type Output = f64;
+
+    fn div(self, weight: Weight) -> f64 {
+        self.0 / weight
+    }
 }
 
 // ===== impl PendingRequests =====

--- a/tower-balance/src/weight.rs
+++ b/tower-balance/src/weight.rs
@@ -127,7 +127,11 @@ impl ops::Div<Weight> for f64 {
     type Output = f64;
 
     fn div(self, w: Weight) -> f64 {
-        self / w.0
+        if w.0 == 0.0 {
+            ::std::f64::INFINITY
+        } else {
+            self / w.0
+        }
     }
 }
 
@@ -137,4 +141,11 @@ impl ops::Div<Weight> for usize {
     fn div(self, w: Weight) -> f64 {
         (self as f64) / w
     }
+}
+
+#[test]
+fn div_min() {
+    assert_eq!(10.0 / Weight::MIN, ::std::f64::INFINITY);
+    assert_eq!(10 / Weight::MIN, ::std::f64::INFINITY);
+    assert_eq!(0 / Weight::MIN, ::std::f64::INFINITY);
 }

--- a/tower-balance/src/weight.rs
+++ b/tower-balance/src/weight.rs
@@ -1,0 +1,140 @@
+use futures::{Async, Poll};
+use std::ops;
+use tower::Service;
+use tower_discover::{Change, Discover};
+
+use Load;
+
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
+pub struct Weight(f64);
+
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Weighted<T> {
+    inner: T,
+    weight: Weight
+}
+
+// ===== impl Weighted =====
+
+impl<T> Weighted<T> {
+    pub fn new(inner: T) -> Self {
+        Self {
+            inner,
+            weight: Weight::DEFAULT,
+        }
+    }
+
+    pub fn weight(&self) -> Weight {
+        self.weight
+    }
+
+    pub fn weighted(self, weight: Weight) -> Self {
+        Self {
+            weight: weight,
+            .. self
+        }
+    }
+
+    pub fn map<F, U>(self, map: F) -> Weighted<U>
+    where
+        F: FnOnce(T) -> U
+    {
+        Weighted {
+            inner: map(self.inner),
+            weight: self.weight,
+        }
+    }
+}
+
+impl<L> Load for Weighted<L>
+where
+    L: Load,
+    L::Metric: ops::Div<Weight>,
+    <L::Metric as ops::Div<Weight>>::Output: PartialOrd,
+{
+    type Metric = <L::Metric as ops::Div<Weight>>::Output;
+
+    fn load(&self) -> Self::Metric {
+        self.inner.load() / self.weight
+    }
+}
+
+impl<S: Service> Service for Weighted<S> {
+    type Request = S::Request;
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.inner.poll_ready()
+    }
+
+    fn call(&mut self, req: Self::Request) -> Self::Future {
+        self.inner.call(req)
+    }
+}
+
+impl<D: Discover> Discover for Weighted<D> {
+    type Key = D::Key;
+    type Request = D::Request;
+    type Response = D::Response;
+    type Error = D::Error;
+    type Service = Weighted<D::Service>;
+    type DiscoverError = D::DiscoverError;
+
+    fn poll(&mut self) -> Poll<Change<D::Key, Self::Service>, D::DiscoverError> {
+        use self::Change::*;
+
+        let change = match try_ready!(self.inner.poll()) {
+            Insert(k, svc) => Insert(k, Weighted::new(svc).weighted(self.weight)),
+            Remove(k) => Remove(k),
+        };
+
+        Ok(Async::Ready(change))
+    }
+}
+
+// ===== impl Weight =====
+
+impl Weight {
+    pub const MIN: Weight = Weight(0.0);
+    pub const DEFAULT: Weight = Weight(1.0);
+}
+
+impl Default for Weight {
+    fn default() -> Self {
+        Weight::DEFAULT
+    }
+}
+
+impl From<f64> for Weight {
+    fn from(w: f64) -> Self {
+        if w < 0.0 {
+            Weight::MIN
+        } else {
+            Weight(w)
+        }
+    }
+}
+
+impl Into<f64> for Weight {
+    fn into(self) -> f64 {
+        self.0
+    }
+}
+
+impl ops::Div<Weight> for f64 {
+    type Output = f64;
+
+    fn div(self, w: Weight) -> f64 {
+        self / w.0
+    }
+}
+
+impl ops::Div<Weight> for usize {
+    type Output = f64;
+
+    fn div(self, w: Weight) -> f64 {
+        (self as f64) / w
+    }
+}


### PR DESCRIPTION
In order to implement red-line testing, blue-green deployments, and
other operational use cases, many service discovery and routing schemes
support weighting.

In this iteration, we provide a decorator type, `Weighted`, that may be
used to wrap load-bearing services to alter their load according to a
weight.  The `Weighted` type may also be used to wrap `Discover`
implementations, in which case it will wrap all new services with
`Weighted`.

The demo has been updated as well:
```
p2c + pending requests
  p50	152
  p90	193
  p95	201
  p99	1947
  p999	2013
p2c + pending requests + weighted
  p50	151
  p90	193
  p95	202
  p99	230
  p999	1972
round robin
  p50	156
  p90	1929
  p95	1966
  p99	2000
  p999	2027
```