### PR TITLE
Move ReadyService to a dedicated crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
   "tower-filter",
   "tower-mock",
   "tower-rate-limit",
+  "tower-ready-service",
   "tower-reconnect",
   "tower-router",
   "tower-timeout",

--- a/tower-ready-service/Cargo.toml
+++ b/tower-ready-service/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "tower-ready-service"
+version = "0.1.0"
+authors = ["Carl Lerche <me@carllerche.com>"]
+publish = false
+
+[dependencies]
+futures = "0.1"
+tower = { version = "0.1", path = "../" }

--- a/tower-ready-service/src/lib.rs
+++ b/tower-ready-service/src/lib.rs
@@ -1,0 +1,3 @@
+extern crate tower;
+
+pub use tower::ReadyService;

--- a/tower-util/Cargo.toml
+++ b/tower-util/Cargo.toml
@@ -7,3 +7,4 @@ publish = false
 [dependencies]
 futures = "0.1"
 tower = { version = "0.1", path = ".." }
+tower-ready-service = { version = "0.1", path = "../tower-ready-service" }

--- a/tower-util/src/lib.rs
+++ b/tower-util/src/lib.rs
@@ -2,6 +2,7 @@
 
 extern crate futures;
 extern crate tower;
+extern crate tower_ready_service;
 
 pub mod either;
 pub mod option;

--- a/tower-util/src/service_fn.rs
+++ b/tower-util/src/service_fn.rs
@@ -1,5 +1,6 @@
 use futures::IntoFuture;
-use tower::{Service, ReadyService, NewService};
+use tower::{Service, NewService};
+use tower_ready_service::ReadyService;
 
 use std::marker::PhantomData;
 


### PR DESCRIPTION
This is the first step to resolve #44. The move will happen in two steps
to avoid breaking any libs depending on this now.