### PR TITLE
InFlightLimit middleware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
   "tower-buffer",
   "tower-discover",
   "tower-filter",
+  "tower-in-flight-limit",
   "tower-mock",
   "tower-rate-limit",
   "tower-ready-service",

--- a/tower-in-flight-limit/Cargo.toml
+++ b/tower-in-flight-limit/Cargo.toml
@@ -8,3 +8,6 @@ publish = false
 futures = "0.1"
 tower = { version = "0.1", path = "../" }
 tower-ready-service = { version = "0.1", path = "../tower-ready-service" }
+
+[dev-dependencies]
+tower-mock = { version = "0.1", path = "../tower-mock" }

--- a/tower-in-flight-limit/Cargo.toml
+++ b/tower-in-flight-limit/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "tower-in-flight-limit"
+version = "0.1.0"
+authors = ["Carl Lerche <me@carllerche.com>"]
+publish = false
+
+[dependencies]
+futures = "0.1"
+tower = { version = "0.1", path = "../" }
+tower-ready-service = { version = "0.1", path = "../tower-ready-service" }

--- a/tower-in-flight-limit/README.md
+++ b/tower-in-flight-limit/README.md
@@ -1,0 +1,4 @@
+Tower In-Flight Limit
+
+A Tower middleware that limits the maximum number of in-flight requests for a
+service.

--- a/tower-in-flight-limit/src/lib.rs
+++ b/tower-in-flight-limit/src/lib.rs
@@ -1,0 +1,195 @@
+//! Tower middleware that limits the maximum number of in-flight requests for a
+//! service.
+
+#[macro_use]
+extern crate futures;
+extern crate tower;
+extern crate tower_ready_service;
+
+use tower::Service;
+use tower_ready_service::ReadyService;
+
+use futures::{Future, Poll, Async};
+use futures::task::AtomicTask;
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::SeqCst;
+
+#[derive(Debug)]
+pub struct InFlightLimit<T> {
+    inner: T,
+    state: State,
+}
+
+/// Error returned when the service has reached its limit.
+#[derive(Debug)]
+pub enum Error<T> {
+    NoCapacity,
+    Upstream(T),
+}
+
+#[derive(Debug)]
+pub struct ResponseFuture<T> {
+    inner: Option<T>,
+    shared: Arc<Shared>,
+}
+
+#[derive(Debug)]
+struct State {
+    shared: Arc<Shared>,
+    reserved: bool,
+}
+
+#[derive(Debug)]
+struct Shared {
+    max: usize,
+    curr: AtomicUsize,
+    task: AtomicTask,
+}
+
+// ===== impl InFlightLimit =====
+
+impl<T> InFlightLimit<T> {
+    /// Create a new rate limiter
+    pub fn new(inner: T, max: usize) -> Self {
+        InFlightLimit {
+            inner,
+            state: State {
+                shared: Arc::new(Shared {
+                    max,
+                    curr: AtomicUsize::new(0),
+                    task: AtomicTask::new(),
+                }),
+                reserved: false,
+            },
+        }
+    }
+
+    /// Get a reference to the inner service
+    pub fn get_ref(&self) -> &T {
+        &self.inner
+    }
+
+    /// Get a mutable reference to the inner service
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
+    /// Consume `self`, returning the inner service
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+impl<S> Service for InFlightLimit<S>
+where S: Service
+{
+    type Request = S::Request;
+    type Response = S::Response;
+    type Error = Error<S::Error>;
+    type Future = ResponseFuture<S::Future>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        if self.state.reserved {
+            return self.inner.poll_ready()
+                .map_err(Error::Upstream);
+        }
+
+        self.state.shared.task.register();
+
+        if !self.state.shared.reserve() {
+            return Ok(Async::NotReady);
+        }
+
+        self.state.reserved = true;
+
+        self.inner.poll_ready()
+            .map_err(Error::Upstream)
+    }
+
+    fn call(&mut self, request: Self::Request) -> Self::Future {
+        if !self.state.reserved {
+            return ResponseFuture {
+                inner: None,
+                shared: self.state.shared.clone(),
+            };
+        }
+
+        ResponseFuture {
+            inner: Some(self.inner.call(request)),
+            shared: self.state.shared.clone(),
+        }
+    }
+}
+
+impl<S> ReadyService for InFlightLimit<S>
+where S: Service
+{
+    type Request = S::Request;
+    type Response = S::Response;
+    type Error = Error<S::Error>;
+    type Future = ResponseFuture<S::Future>;
+
+    fn call(&mut self, request: Self::Request) -> Self::Future {
+        unimplemented!();
+    }
+}
+
+// ===== impl ResponseFuture =====
+
+impl<T> Future for ResponseFuture<T>
+where T: Future,
+{
+    type Item = T::Item;
+    type Error = Error<T::Error>;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        match self.inner {
+            Some(ref mut f) => {
+                f.poll().map_err(Error::Upstream)
+            }
+            None => Err(Error::NoCapacity),
+        }
+    }
+}
+
+// ===== impl State =====
+
+impl Drop for State {
+    fn drop(&mut self) {
+        if self.reserved {
+            self.shared.release();
+        }
+    }
+}
+
+// ===== impl Shared =====
+
+impl Shared {
+    /// Attempts to reserve capacity for a request. Returns `true` if the
+    /// reservation is successful.
+    fn reserve(&self) -> bool {
+        let mut curr = self.curr.load(SeqCst);
+
+        loop {
+            if curr == self.max {
+                return false;
+            }
+
+            let actual = self.curr.compare_and_swap(curr, curr + 1, SeqCst);
+
+            if actual == curr {
+                return true;
+            }
+
+            curr = actual;
+        }
+    }
+
+    /// Release a reserved in-flight request. This is called when either the
+    /// request has completed OR the service that made the reservation has
+    /// dropped.
+    pub fn release(&self) {
+        self.curr.fetch_add(1, SeqCst);
+    }
+}

--- a/tower-in-flight-limit/src/lib.rs
+++ b/tower-in-flight-limit/src/lib.rs
@@ -90,7 +90,6 @@ where S: Service
     type Future = ResponseFuture<S::Future>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        println!("poll_ready; reserved={:?}", self.state.reserved);
         if self.state.reserved {
             return self.inner.poll_ready()
                 .map_err(Error::Upstream);
@@ -99,7 +98,6 @@ where S: Service
         self.state.shared.task.register();
 
         if !self.state.shared.reserve() {
-            println!("failed to reserve");
             return Ok(Async::NotReady);
         }
 
@@ -110,7 +108,6 @@ where S: Service
     }
 
     fn call(&mut self, request: Self::Request) -> Self::Future {
-        println!("call; reserved={:?}", self.state.reserved);
         if !self.state.reserved {
             return ResponseFuture {
                 inner: None,
@@ -213,7 +210,6 @@ impl Shared {
         let mut curr = self.curr.load(SeqCst);
 
         loop {
-            println!("reserve; curr={}; max={}", curr, self.max);
             if curr == self.max {
                 return false;
             }

--- a/tower-in-flight-limit/tests/in_flight_limit.rs
+++ b/tower-in-flight-limit/tests/in_flight_limit.rs
@@ -1,0 +1,198 @@
+extern crate futures;
+extern crate tower;
+extern crate tower_mock;
+extern crate tower_in_flight_limit;
+
+use tower_in_flight_limit::InFlightLimit;
+use tower::Service;
+use futures::future::{Future, poll_fn};
+
+#[test]
+fn basic_limit_functionality() {
+    let (mut service, mut handle) =
+        new_service(2);
+
+    poll_fn(|| service.poll_ready()).wait().unwrap();
+    let r1 = service.call("hello 1");
+
+    poll_fn(|| service.poll_ready()).wait().unwrap();
+    let r2 = service.call("hello 2");
+
+    with_task(|| {
+        assert!(service.poll_ready().unwrap().is_not_ready());
+    });
+
+    // The request gets passed through
+    let request = handle.next_request().unwrap();
+    assert_eq!(*request, "hello 1");
+    request.respond("world 1");
+
+    // The next request gets passed through
+    let request = handle.next_request().unwrap();
+    assert_eq!(*request, "hello 2");
+    request.respond("world 2");
+
+    // There are no more requests
+    with_task(|| {
+        assert!(handle.poll_request().unwrap().is_not_ready());
+    });
+
+    assert_eq!(r1.wait().unwrap(), "world 1");
+
+    // Another request can be sent
+    poll_fn(|| service.poll_ready()).wait().unwrap();
+    let r3 = service.call("hello 3");
+
+    with_task(|| {
+        assert!(service.poll_ready().unwrap().is_not_ready());
+    });
+
+    assert_eq!(r2.wait().unwrap(), "world 2");
+
+    // The request gets passed through
+    let request = handle.next_request().unwrap();
+    assert_eq!(*request, "hello 3");
+    request.respond("world 3");
+
+    assert_eq!(r3.wait().unwrap(), "world 3");
+}
+
+#[test]
+fn request_without_capacity() {
+    let (mut service, mut handle) =
+        new_service(0);
+
+    with_task(|| {
+        assert!(service.poll_ready().unwrap().is_not_ready());
+    });
+
+    let response = service.call("hello");
+
+    // There are no more requests
+    with_task(|| {
+        assert!(handle.poll_request().unwrap().is_not_ready());
+    });
+
+    response.wait().unwrap_err();
+}
+
+#[test]
+fn reserve_capacity_without_sending_request() {
+    let (mut s1, mut handle) =
+        new_service(1);
+
+    let mut s2 = s1.clone();
+
+    // Reserve capacity in s1
+    with_task(|| {
+        assert!(s1.poll_ready().unwrap().is_ready());
+    });
+
+    // Service 2 cannot get capacity
+    with_task(|| {
+        assert!(s2.poll_ready().unwrap().is_not_ready());
+    });
+
+    // s1 sends the request, then s2 is able to get capacity
+    let r1 = s1.call("hello");
+    let request = handle.next_request().unwrap();
+    request.respond("world");
+
+    with_task(|| {
+        assert!(s2.poll_ready().unwrap().is_not_ready());
+    });
+
+    r1.wait().unwrap();
+
+    with_task(|| {
+        assert!(s2.poll_ready().unwrap().is_ready());
+    });
+}
+
+#[test]
+fn service_drop_frees_capacity() {
+    let (mut s1, _handle) =
+        new_service(1);
+
+    let mut s2 = s1.clone();
+
+    // Reserve capacity in s1
+    with_task(|| {
+        assert!(s1.poll_ready().unwrap().is_ready());
+    });
+
+    // Service 2 cannot get capacity
+    with_task(|| {
+        assert!(s2.poll_ready().unwrap().is_not_ready());
+    });
+
+    drop(s1);
+
+    with_task(|| {
+        assert!(s2.poll_ready().unwrap().is_ready());
+    });
+}
+
+#[test]
+fn response_error_releases_capacity() {
+    let (mut s1, mut handle) =
+        new_service(1);
+
+    let mut s2 = s1.clone();
+
+    // Reserve capacity in s1
+    with_task(|| {
+        assert!(s1.poll_ready().unwrap().is_ready());
+    });
+
+    // s1 sends the request, then s2 is able to get capacity
+    let r1 = s1.call("hello");
+    let request = handle.next_request().unwrap();
+    request.error(());
+
+    r1.wait().unwrap_err();
+
+    with_task(|| {
+        assert!(s2.poll_ready().unwrap().is_ready());
+    });
+}
+
+#[test]
+fn response_future_drop_releases_capacity() {
+    let (mut s1, _handle) =
+        new_service(1);
+
+    let mut s2 = s1.clone();
+
+    // Reserve capacity in s1
+    with_task(|| {
+        assert!(s1.poll_ready().unwrap().is_ready());
+    });
+
+    // s1 sends the request, then s2 is able to get capacity
+    let r1 = s1.call("hello");
+
+    with_task(|| {
+        assert!(s2.poll_ready().unwrap().is_not_ready());
+    });
+
+    drop(r1);
+
+    with_task(|| {
+        assert!(s2.poll_ready().unwrap().is_ready());
+    });
+}
+
+type Mock = tower_mock::Mock<&'static str, &'static str, ()>;
+type Handle = tower_mock::Handle<&'static str, &'static str, ()>;
+
+fn new_service(max: usize) -> (InFlightLimit<Mock>, Handle) {
+    let (service, handle) = Mock::new();
+    let service = InFlightLimit::new(service, max);
+    (service, handle)
+}
+
+fn with_task<F: FnOnce() -> U, U>(f: F) -> U {
+    use futures::future::{Future, lazy};
+    lazy(|| Ok::<_, ()>(f())).wait().unwrap()
+}


### PR DESCRIPTION
This PR adds an `InFlightLimit` middleware that enforces a max number if in-flight requests for the inner service as well as all clones.

This middleware works for both `Service` and `ReadyService`.