### PR TITLE
Implement std::error::Error for Tower error types

### DIFF
--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -318,15 +318,15 @@ impl<F: Future, E> Future for ResponseFuture<F, E> {
 
 impl<T, U> fmt::Display for Error<T, U>
 where
-    T: fmt::Debug,
-    U: fmt::Debug,
+    T: fmt::Display,
+    U: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::Inner(ref why) =>
-                write!(f, "inner service error: {:?}", why),
+                write!(f, "inner service error: {}", why),
             Error::Balance(ref why) =>
-                write!(f, "load balancing failed: {:?}", why),
+                write!(f, "load balancing failed: {}", why),
             Error::NotReady => f.pad("not ready"),
         }
     }

--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -12,6 +12,7 @@ extern crate tower_discover;
 use futures::{Future, Poll, Async};
 use ordermap::OrderMap;
 use rand::Rng;
+use std::{fmt, error};
 use std::marker::PhantomData;
 use tower::Service;
 use tower_discover::Discover;
@@ -311,6 +312,48 @@ impl<F: Future, E> Future for ResponseFuture<F, E> {
         self.0.poll().map_err(Error::Inner)
     }
 }
+
+
+// ===== impl Error =====
+
+impl<T, U> fmt::Display for Error<T, U>
+where
+    T: fmt::Debug,
+    U: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::Inner(ref why) =>
+                write!(f, "inner service error: {:?}", why),
+            Error::Balance(ref why) =>
+                write!(f, "load balancing failed: {:?}", why),
+            Error::NotReady => f.pad("not ready"),
+        }
+    }
+}
+
+impl<T, U> error::Error for Error<T, U>
+where
+    T: error::Error,
+    U: error::Error,
+{
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::Inner(ref why) => Some(why),
+            Error::Balance(ref why) => Some(why),
+            _ => None,
+        }
+    }
+
+    fn description(&self) -> &str {
+        match *self {
+            Error::Inner(_) => "inner service error",
+            Error::Balance(_) => "load balancing failed",
+            Error::NotReady => "not ready",
+        }
+    }
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/tower-buffer/src/lib.rs
+++ b/tower-buffer/src/lib.rs
@@ -228,12 +228,12 @@ where T: Service,
 
 impl<T> fmt::Display for Error<T>
 where
-    T: fmt::Debug,
+    T: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::Inner(ref why) =>
-                write!(f, "inner service error: {:?}", why),
+                write!(f, "inner service error: {}", why),
             Error::Closed =>
                 write!(f, "buffer closed"),
         }

--- a/tower-in-flight-limit/src/lib.rs
+++ b/tower-in-flight-limit/src/lib.rs
@@ -248,12 +248,12 @@ impl Shared {
 
 impl<T> fmt::Display for Error<T>
 where
-    T: fmt::Debug,
+    T: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::Upstream(ref why) =>
-                write!(f, "upstream service error: {:?}", why),
+                write!(f, "upstream service error: {}", why),
             Error::NoCapacity =>
                 write!(f, "in-flight limit exceeded"),
         }

--- a/tower-reconnect/src/lib.rs
+++ b/tower-reconnect/src/lib.rs
@@ -167,15 +167,15 @@ impl<T: NewService> Future for ResponseFuture<T> {
 
 impl<T, U> fmt::Display for Error<T, U>
 where
-    T: fmt::Debug,
-    U: fmt::Debug,
+    T: fmt::Display,
+    U: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::Inner(ref why) =>
-                write!(f, "inner service error: {:?}", why),
+                write!(f, "inner service error: {}", why),
             Error::Connect(ref why) =>
-                write!(f, "connection failed: {:?}", why),
+                write!(f, "connection failed: {}", why),
             Error::NotReady => f.pad("not ready"),
         }
     }


### PR DESCRIPTION
I've implemented `std::error::Error` for the error types in the `tower-balance`, `tower-buffer`, `tower-in-flight-limit`, and `tower-reconnect` middleware crates.

This is required upstream for runconduit/conduit#442, and also just generally seems like the right thing to do as a library.