### PR TITLE
Upgrade to env_logger 0.5 and log 0.4 so that projects that use those

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ members = [
 futures = "0.1"
 
 [dev-dependencies]
-log = "0.3"
-env_logger = "0.4"
+log = "0.4.1"
+env_logger = { version = "0.5.3", default-features = false }
 tokio-timer = "0.1"
 futures-cpupool = "0.1"

--- a/examples/channel_service.rs
+++ b/examples/channel_service.rs
@@ -149,7 +149,7 @@ impl Future for ResponseFuture {
 }
 
 pub fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
 
     let new_service = NewChannelService::new(5, CpuPool::new(1));
 

--- a/tower-balance/Cargo.toml
+++ b/tower-balance/Cargo.toml
@@ -6,16 +6,16 @@ publish = false
 
 [dependencies]
 futures = "0.1"
-log = "0.3"
+log = "0.4.1"
 rand = "0.4"
 tower = { version = "0.1", path = "../" }
 tower-discover = { version = "0.1", path = "../tower-discover" }
 ordermap = "0.2"
 
 [dev-dependencies]
-log = "0.3"
-env_logger = "0.4"
+log = "0.4.1"
+env_logger = { version = "0.5.3", default-features = false }
 hdrsample = "6.0"
 tokio-core = "^0.1.12"
 tokio-timer = "0.1"
-quickcheck = "0.6"
+quickcheck = { version = "0.6", default-features = false }

--- a/tower-balance/examples/demo.rs
+++ b/tower-balance/examples/demo.rs
@@ -185,7 +185,7 @@ fn report(pfx: &str, histo: &Histogram<u64>) {
 }
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
 
     let timer = Timer::default();
     let mut core = Core::new().unwrap();

--- a/tower-reconnect/Cargo.toml
+++ b/tower-reconnect/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Carl Lerche <me@carllerche.com>"]
 publish = false
 
 [dependencies]
-log = "0.3"
+log = "0.4.1"
 futures = "0.1"
 tower = { version = "0.1", path = "../" }


### PR DESCRIPTION
versions don't have to build both those versions and the older ones
that h2 is currently using.

Don't enable the regex support in env_logger. Applications that want
the regex support can enable it themselves; this will happen
automatically when they add their env_logger dependency.

Disable the env_logger dependency in quickcheck.

The result of this is that there are fewer dependencies. For example,
regex and its dependencies are no longer required at all, as can be
seen by observing the changes to the Cargo.lock. That said,
env_logger 0.5 does add more dependencies itself; however it seems
applications are going to use env_logger 0.5 anyway so this is still
a net gain.

Submitted on behalf of Buoyant, Inc.

Signed-off-by: Brian Smith <brian@briansmith.org>