### PR TITLE
Nested errors no longer print "inner service error:" or similar

### DIFF
--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -323,8 +323,7 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Inner(ref why) =>
-                write!(f, "inner service error: {}", why),
+            Error::Inner(ref why) => fmt::Display::fmt(why, f),
             Error::Balance(ref why) =>
                 write!(f, "load balancing failed: {}", why),
             Error::NotReady => f.pad("not ready"),

--- a/tower-buffer/src/lib.rs
+++ b/tower-buffer/src/lib.rs
@@ -232,10 +232,8 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Inner(ref why) =>
-                write!(f, "inner service error: {}", why),
-            Error::Closed =>
-                write!(f, "buffer closed"),
+            Error::Inner(ref why) => fmt::Display::fmt(why, f),
+            Error::Closed => f.pad("buffer closed"),
         }
     }
 }

--- a/tower-in-flight-limit/src/lib.rs
+++ b/tower-in-flight-limit/src/lib.rs
@@ -252,10 +252,8 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Upstream(ref why) =>
-                write!(f, "upstream service error: {}", why),
-            Error::NoCapacity =>
-                write!(f, "in-flight limit exceeded"),
+            Error::Upstream(ref why) => fmt::Display::fmt(why, f),
+            Error::NoCapacity => write!(f, "in-flight limit exceeded"),
         }
     }
 }

--- a/tower-rate-limit/src/lib.rs
+++ b/tower-rate-limit/src/lib.rs
@@ -183,8 +183,7 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Upstream(ref why) =>
-                write!(f, "upstream service error: {}", why),
+            Error::Upstream(ref why) => fmt::Display::fmt(why, f)
             Error::NoCapacity =>
                 write!(f, "rate limit exceeded"),
         }

--- a/tower-reconnect/src/lib.rs
+++ b/tower-reconnect/src/lib.rs
@@ -172,10 +172,8 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Inner(ref why) =>
-                write!(f, "inner service error: {}", why),
-            Error::Connect(ref why) =>
-                write!(f, "connection failed: {}", why),
+            Error::Inner(ref why) => fmt::Display::fmt(why, f),
+            Error::Connect(ref why) => write!(f, "connection failed: {}", why),
             Error::NotReady => f.pad("not ready"),
         }
     }

--- a/tower-timeout/src/lib.rs
+++ b/tower-timeout/src/lib.rs
@@ -106,10 +106,8 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Inner(ref why) =>
-                write!(f, "inner service error: {}", why),
-            Error::Timeout =>
-                write!(f, "request timed out"),
+            Error::Inner(ref why) => fmt::Display::fmt(why, f),
+            Error::Timeout => f.pad("request timed out"),
         }
     }
 }
@@ -129,7 +127,7 @@ where
     fn description(&self) -> &str {
         match *self {
             Error::Inner(_) => "inner service error",
-            Error::NoCapacity => "request timed out",
+            Error::Timeout => "request timed out",
         }
     }
 


### PR DESCRIPTION
I've modified the `Error` implementations for Tower's error types so that nested errors (such as `Inner` or `Upstream` no longer print a message like "inner service error: " or "upstream service error: " before the wrapped error's `Display` message. These  repeated messages didn't contribute any useful information, and removing them makes long error chains much less ugly. 

Compare the following log messages from a build of Conduit that uses `fmt::Display` for printing errors:
```rust
test outbound_asks_controller_api ... ok
server h1 error: invalid HTTP version specified
ERROR 2018-02-27T22:44:20Z: conduit_proxy: inner service error: upstream service error: inner service error: inner service error: inner service error: Error caused by underlying HTTP/2 error: protocol error: frame with invalid size
test outbound_updates_newer_services ... ok
ERROR 2018-02-27T22:44:20Z: conduit_proxy: inner service error: upstream service error: operation timed out after Duration { secs: 0, nanos: 100000000 }
```

After making these changes in Tower, the log messages are now much less noisy:
```rust
test outbound_asks_controller_api ... ok
server h1 error: invalid HTTP version specified
ERROR 2018-02-27T22:57:14Z: conduit_proxy: Error caused by underlying HTTP/2 error: protocol error: frame with invalid size
test outbound_updates_newer_services ... ok
ERROR 2018-02-27T22:57:14Z: conduit_proxy: operation timed out after Duration { secs: 0, nanos: 100000000 }
test outbound_times_out ... ok
```