### PR TITLE
If tower-buffer sees something, it now says something

### DIFF
--- a/tower-buffer/Cargo.toml
+++ b/tower-buffer/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 [dependencies]
 futures = "0.1"
 tower = { version = "0.1", path = "../" }
-log = "0.4.1"
 
 [dev-dependencies]
 tower-mock = { version = "0.1", path = "../tower-mock" }

--- a/tower-buffer/Cargo.toml
+++ b/tower-buffer/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 futures = "0.1"
 tower = { version = "0.1", path = "../" }
+log = "0.4.1"
 
 [dev-dependencies]
 tower-mock = { version = "0.1", path = "../tower-mock" }


### PR DESCRIPTION
When a `tower-buffer` `Buffer` would be closed, it now logs the inner service error that would cause it to be closed. Otherwise, the error is never surfaced, because the buffer returns the `Error::Closed` type (which doesn't wrap an underlying error) and the error that *caused* it to close is discarded.

I made this change to help debug a Conduit issue, and found it to be useful enough that I thought we probably want to make the change here.