### PR TITLE
Change Travis test script to `cargo test --all`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - rust: nightly
 
 script:
-- cargo test
+- cargo test --all
 
 deploy:
   provider:  pages

--- a/tower-rate-limit/src/lib.rs
+++ b/tower-rate-limit/src/lib.rs
@@ -184,7 +184,7 @@ where
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::Upstream(ref why) => fmt::Display::fmt(why, f),
-            Error::NoCapacity => f.pad("rate limit exceeded"),
+            Error::RateLimit => f.pad("rate limit exceeded"),
         }
     }
 }


### PR DESCRIPTION
This will ensure that all crates are built & tested, and hopefully prevent errors like the one fixed in #58 from slipping past CI.