### PR TITLE
Standardize naming scheme

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ use std::sync::Arc;
 /// use tokio_timer::Timer;
 ///
 /// pub struct Timeout<T> {
-///     upstream: T,
+///     inner: T,
 ///     delay: Duration,
 ///     timer: Timer,
 /// }
@@ -104,9 +104,9 @@ use std::sync::Arc;
 /// pub struct Expired;
 ///
 /// impl<T> Timeout<T> {
-///     pub fn new(upstream: T, delay: Duration) -> Timeout<T> {
+///     pub fn new(inner: T, delay: Duration) -> Timeout<T> {
 ///         Timeout {
-///             upstream: upstream,
+///             inner: inner,
 ///             delay: delay,
 ///             timer: Timer::default(),
 ///         }
@@ -130,7 +130,7 @@ use std::sync::Arc;
 ///         let timeout = self.timer.sleep(self.delay)
 ///             .and_then(|_| Err(Self::Error::from(Expired)));
 ///
-///         self.upstream.call(req)
+///         self.inner.call(req)
 ///             .select(timeout)
 ///             .map(|(v, _)| v)
 ///             .map_err(|(e, _)| e)

--- a/tower-timeout/src/lib.rs
+++ b/tower-timeout/src/lib.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 /// Applies a timeout to requests.
 #[derive(Debug)]
 pub struct Timeout<T> {
-    upstream: T,
+    inner: T,
     timer: Timer,
     timeout: Duration,
 }
@@ -42,9 +42,9 @@ pub struct ResponseFuture<T> {
 // ===== impl Timeout =====
 
 impl<T> Timeout<T> {
-    pub fn new(upstream: T, timer: Timer, timeout: Duration) -> Self {
+    pub fn new(inner: T, timer: Timer, timeout: Duration) -> Self {
         Timeout {
-            upstream,
+            inner,
             timer,
             timeout,
         }
@@ -60,13 +60,13 @@ where S: Service,
     type Future = ResponseFuture<S::Future>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        self.upstream.poll_ready()
+        self.inner.poll_ready()
             .map_err(Error::Inner)
     }
 
     fn call(&mut self, request: Self::Request) -> Self::Future {
         ResponseFuture {
-            response: self.upstream.call(request),
+            response: self.inner.call(request),
             sleep: self.timer.sleep(self.timeout),
         }
     }


### PR DESCRIPTION
This PR changes `tower-timeout` to follow the same naming scheme as the rest of `tower`, where the service wrapped by a middleware is called `inner` rather than `upstream`.