### PR TITLE
balance: Handle duplicate Insert events by overwriting the existing service

### DIFF
--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -147,10 +147,10 @@ where
         while let Async::Ready(change) = self.discover.poll().map_err(Error::Balance)? {
             match change {
                 Insert(key, mut svc) => {
-                    if self.ready.contains_key(&key) || self.not_ready.contains_key(&key) {
-                        // Ignore duplicate endpoints.
-                        continue;
-                    }
+                    // If the `Insert`ed service is a duplicate of a service already
+                    // in the ready list, remove the ready service first. The new
+                    // service will then be inserted into the not-ready list.
+                    self.ready.remove(&key);
 
                     self.not_ready.insert(key, svc);
                 }


### PR DESCRIPTION
When an endpoint's state changes in some way, it may need to be rebound to a 
new service, and reinserted into the load balancer. This PR changes 
`tower-balance` so that, rather than ignoring duplicate `Insert`s, the new
endpoint replaces the old endpoint. The new endpoint is always placed on the
not-ready list; if the replaced endpoint was on the ready list, it is removed
prior to inserting the new endpoint into the not-ready list.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>