### PR TITLE
balance: Add debug logging for p2c decisions

### DIFF
--- a/tower-balance/src/choose/p2c.rs
+++ b/tower-balance/src/choose/p2c.rs
@@ -1,7 +1,7 @@
 use rand::Rng;
 
-use Load;
 use choose::{Choose, Replicas};
+use Load;
 
 /// Chooses nodes using the [Power of Two Choices][p2c].
 ///
@@ -51,7 +51,7 @@ impl<R: Rng> PowerOfTwoChoices<R> {
 impl<K, L, R> Choose<K, L> for PowerOfTwoChoices<R>
 where
     L: Load,
-    L::Metric: PartialOrd,
+    L::Metric: PartialOrd + ::std::fmt::Debug,
     R: Rng,
 {
     /// Chooses two distinct nodes at random and compares their load.
@@ -59,7 +59,17 @@ where
     /// Returns the index of the lesser-loaded node.
     fn choose(&mut self, replicas: Replicas<K, L>) -> usize {
         let (a, b) = self.random_pair(replicas.len());
-        if replicas[a].load() <= replicas[b].load() {
+
+        let aload = replicas[a].load();
+        let bload = replicas[b].load();
+        debug!(
+            "choose node[{a}]={aload:?} node[{b}]={bload:?}",
+            a = a,
+            b = b,
+            aload = aload,
+            bload = bload
+        );
+        if aload <= bload {
             a
         } else {
             b

--- a/tower-balance/src/choose/p2c.rs
+++ b/tower-balance/src/choose/p2c.rs
@@ -67,16 +67,16 @@ where
     fn choose(&mut self, replicas: Replicas<K, L>) -> usize {
         let (a, b) = self.random_pair(replicas.len());
 
-        let aload = replicas[a].load();
-        let bload = replicas[b].load();
+        let a_load = replicas[a].load();
+        let b_load = replicas[b].load();
         debug!(
-            "choose node[{a}]={aload:?} node[{b}]={bload:?}",
+            "choose node[{a}]={a_load:?} node[{b}]={b_load:?}",
             a = a,
             b = b,
-            aload = aload,
-            bload = bload
+            a_load = a_load,
+            b_load = b_load
         );
-        if aload <= bload {
+        if a_load <= b_load {
             a
         } else {
             b

--- a/tower-balance/src/choose/p2c.rs
+++ b/tower-balance/src/choose/p2c.rs
@@ -69,7 +69,7 @@ where
 
         let a_load = replicas[a].load();
         let b_load = replicas[b].load();
-        debug!(
+        trace!(
             "choose node[{a}]={a_load:?} node[{b}]={b_load:?}",
             a = a,
             b = b,

--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -41,7 +41,7 @@ pub fn power_of_two_choices<D, R>(loaded: D, rng: R) -> Balance<D, choose::Power
 where
     D: Discover,
     D::Service: Load,
-    <D::Service as Load>::Metric: PartialOrd,
+    <D::Service as Load>::Metric: PartialOrd + fmt::Debug,
     R: Rng,
 {
     Balance::new(loaded, choose::PowerOfTwoChoices::new(rng))


### PR DESCRIPTION
When debugging load balancer behavior, it's convenient to observe the
individual node selection decisions. To that end, this change requires
that `Load::Metric` implement `fmt::Debug` when used by
`PowerOfTwoChoices`.