### PR TITLE
balance: Do not require RNG to build a P2C balancer

### DIFF
--- a/tower-balance/Cargo.toml
+++ b/tower-balance/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 futures = "0.1"
 log = "0.4.1"
-rand = "0.4"
+rand = "0.5"
 tower-service = { version = "0.1", path = "../tower-service" }
 tower-discover = { version = "0.1", path = "../tower-discover" }
 indexmap = "1"

--- a/tower-balance/examples/demo.rs
+++ b/tower-balance/examples/demo.rs
@@ -194,7 +194,7 @@ fn main() {
     {
         let lb = {
             let loaded = load::WithPendingRequests::new(gen_disco(&timer));
-            power_of_two_choices(loaded, rand::thread_rng())
+            power_of_two_choices(loaded)
         };
         let send = SendRequests { lb, send_remaining: requests, responses: stream::FuturesUnordered::new() };
         let histo = core.run(compute_histo(send)).unwrap();

--- a/tower-balance/src/choose/p2c.rs
+++ b/tower-balance/src/choose/p2c.rs
@@ -1,4 +1,4 @@
-use rand::{self, rngs::SmallRng, FromEntropy, Rng, SeedableRng};
+use rand::{rngs::SmallRng, FromEntropy, Rng};
 
 use choose::{Choose, Replicas};
 use Load;
@@ -25,20 +25,15 @@ pub struct PowerOfTwoChoices {
 
 // ==== impl PowerOfTwoChoices ====
 
+impl Default for PowerOfTwoChoices {
+    fn default() -> Self {
+        Self::new(SmallRng::from_entropy())
+    }
+}
+
 impl PowerOfTwoChoices {
-    pub fn from_entropy() -> Self {
-        let rng = SmallRng::from_entropy();
+    pub fn new(rng: SmallRng) -> Self {
         Self { rng }
-    }
-
-    pub fn from_seed(seed: <SmallRng as SeedableRng>::Seed) -> Self {
-        let rng = SmallRng::from_seed(seed);
-        Self { rng }
-    }
-
-    pub fn from_rng<R: Rng>(rng: &mut R) -> Result<Self, rand::Error> {
-        let rng = SmallRng::from_rng(rng)?;
-        Ok(Self { rng })
     }
 
     /// Returns two random, distinct indices into `ready`.
@@ -91,8 +86,9 @@ mod tests {
                 return TestResult::discard();
             }
 
-            let (a, b) = PowerOfTwoChoices::from_entropy()
-                .random_pair(n);
+            let mut p2c = PowerOfTwoChoices::default();
+
+            let (a, b) = p2c.random_pair(n);
             TestResult::from_bool(a != b)
         }
     }

--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -42,7 +42,7 @@ where
     D::Service: Load,
     <D::Service as Load>::Metric: PartialOrd,
 {
-    Balance::new(loaded, choose::PowerOfTwoChoices::default())
+    Balance::new(loaded, choose::PowerOfTwoChoices::from_entropy())
 }
 
 /// Attempts to choose services sequentially.

--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -11,7 +11,6 @@ extern crate tower_service;
 
 use futures::{Future, Poll, Async};
 use indexmap::IndexMap;
-use rand::Rng;
 use std::{fmt, error};
 use std::marker::PhantomData;
 use tower_discover::Discover;
@@ -37,14 +36,13 @@ pub use load::Load;
 ///
 /// [finagle]: https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-least-loaded
 /// [p2c]: http://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf
-pub fn power_of_two_choices<D, R>(loaded: D, rng: R) -> Balance<D, choose::PowerOfTwoChoices<R>>
+pub fn power_of_two_choices<D>(loaded: D) -> Balance<D, choose::PowerOfTwoChoices>
 where
     D: Discover,
     D::Service: Load,
     <D::Service as Load>::Metric: PartialOrd,
-    R: Rng,
 {
-    Balance::new(loaded, choose::PowerOfTwoChoices::new(rng))
+    Balance::new(loaded, choose::PowerOfTwoChoices::default())
 }
 
 /// Attempts to choose services sequentially.

--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -9,10 +9,10 @@ extern crate rand;
 extern crate tower_discover;
 extern crate tower_service;
 
-use futures::{Future, Poll, Async};
+use futures::{Async, Future, Poll};
 use indexmap::IndexMap;
-use std::{fmt, error};
 use std::marker::PhantomData;
+use std::{error, fmt};
 use tower_discover::Discover;
 use tower_service::Service;
 
@@ -42,7 +42,7 @@ where
     D::Service: Load,
     <D::Service as Load>::Metric: PartialOrd,
 {
-    Balance::new(loaded, choose::PowerOfTwoChoices::from_entropy())
+    Balance::new(loaded, choose::PowerOfTwoChoices::default())
 }
 
 /// Attempts to choose services sequentially.
@@ -136,9 +136,9 @@ where
     /// Polls `discover` for updates, adding new items to `not_ready`.
     ///
     /// Removals may alter the order of either `ready` or `not_ready`.
-    fn update_from_discover(&mut self)
-        -> Result<(), Error<<D::Service as Service>::Error, D::DiscoverError>>
-    {
+    fn update_from_discover(
+        &mut self,
+    ) -> Result<(), Error<<D::Service as Service>::Error, D::DiscoverError>> {
         debug!("updating from discover");
         use tower_discover::Change::*;
 
@@ -171,9 +171,9 @@ where
     ///
     /// When `poll_ready` returns ready, the service is removed from `not_ready` and inserted
     /// into `ready`, potentially altering the order of `ready` and/or `not_ready`.
-    fn promote_to_ready(&mut self)
-        -> Result<(), Error<<D::Service as Service>::Error, D::DiscoverError>>
-    {
+    fn promote_to_ready(
+        &mut self,
+    ) -> Result<(), Error<<D::Service as Service>::Error, D::DiscoverError>> {
         let n = self.not_ready.len();
         if n == 0 {
             trace!("promoting to ready: not_ready is empty, skipping.");
@@ -185,15 +185,17 @@ where
         // from reordering services in a way that could prevent a service from being polled.
         for idx in (0..n).rev() {
             let is_ready = {
-                let (_, svc) = self.not_ready
+                let (_, svc) = self
+                    .not_ready
                     .get_index_mut(idx)
-                    .expect("invalid not_ready index");;
+                    .expect("invalid not_ready index");
                 svc.poll_ready().map_err(Error::Inner)?.is_ready()
             };
             trace!("not_ready[{:?}]: is_ready={:?};", idx, is_ready);
             if is_ready {
                 debug!("not_ready[{:?}]: promoting to ready", idx);
-                let (key, svc) = self.not_ready
+                let (key, svc) = self
+                    .not_ready
                     .swap_remove_index(idx)
                     .expect("invalid not_ready index");
                 self.ready.insert(key, svc);
@@ -211,21 +213,23 @@ where
     ///
     /// If the service exists in `ready` and does not poll as ready, it is moved to
     /// `not_ready`, potentially altering the order of `ready` and/or `not_ready`.
-    fn poll_ready_index(&mut self, idx: usize)
-        -> Option<Poll<(), Error<<D::Service as Service>::Error, D::DiscoverError>>>
-    {
+    fn poll_ready_index(
+        &mut self,
+        idx: usize,
+    ) -> Option<Poll<(), Error<<D::Service as Service>::Error, D::DiscoverError>>> {
         match self.ready.get_index_mut(idx) {
             None => return None,
-            Some((_, svc)) => {
-                match svc.poll_ready() {
-                    Ok(Async::Ready(())) => return Some(Ok(Async::Ready(()))),
-                    Err(e) => return Some(Err(Error::Inner(e))),
-                    Ok(Async::NotReady) => {}
-                }
-            }
+            Some((_, svc)) => match svc.poll_ready() {
+                Ok(Async::Ready(())) => return Some(Ok(Async::Ready(()))),
+                Err(e) => return Some(Err(Error::Inner(e))),
+                Ok(Async::NotReady) => {}
+            },
         }
 
-        let (key, svc) = self.ready.swap_remove_index(idx).expect("invalid ready index");
+        let (key, svc) = self
+            .ready
+            .swap_remove_index(idx)
+            .expect("invalid ready index");
         self.not_ready.insert(key, svc);
         Some(Ok(Async::NotReady))
     }
@@ -233,9 +237,9 @@ where
     /// Chooses the next service to which a request will be dispatched.
     ///
     /// Ensures that .
-    fn choose_and_poll_ready(&mut self)
-        -> Poll<(), Error<<D::Service as Service>::Error, D::DiscoverError>>
-    {
+    fn choose_and_poll_ready(
+        &mut self,
+    ) -> Poll<(), Error<<D::Service as Service>::Error, D::DiscoverError>> {
         loop {
             let n = self.ready.len();
             debug!("choosing from {} replicas", n);
@@ -249,7 +253,11 @@ where
             };
 
             // XXX Should we handle per-endpoint errors?
-            if self.poll_ready_index(idx).expect("invalid ready index")?.is_ready() {
+            if self
+                .poll_ready_index(idx)
+                .expect("invalid ready index")?
+                .is_ready()
+            {
                 self.chosen_ready_index = Some(idx);
                 return Ok(Async::Ready(()));
             }
@@ -279,7 +287,8 @@ where
         // to `not_ready` if appropriate.
         if let Some(idx) = self.dispatched_ready_index.take() {
             // XXX Should we handle per-endpoint errors?
-            self.poll_ready_index(idx).expect("invalid dispatched ready key")?;
+            self.poll_ready_index(idx)
+                .expect("invalid dispatched ready key")?;
         }
 
         // Update `not_ready` and `ready`.
@@ -292,7 +301,10 @@ where
 
     fn call(&mut self, request: Self::Request) -> Self::Future {
         let idx = self.chosen_ready_index.take().expect("not ready");
-        let (_, svc) = self.ready.get_index_mut(idx).expect("invalid chosen ready index");
+        let (_, svc) = self
+            .ready
+            .get_index_mut(idx)
+            .expect("invalid chosen ready index");
         self.dispatched_ready_index = Some(idx);
 
         let rsp = svc.call(request);
@@ -311,7 +323,6 @@ impl<F: Future, E> Future for ResponseFuture<F, E> {
     }
 }
 
-
 // ===== impl Error =====
 
 impl<T, U> fmt::Display for Error<T, U>
@@ -322,8 +333,7 @@ where
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::Inner(ref why) => fmt::Display::fmt(why, f),
-            Error::Balance(ref why) =>
-                write!(f, "load balancing failed: {}", why),
+            Error::Balance(ref why) => write!(f, "load balancing failed: {}", why),
             Error::NotReady => f.pad("not ready"),
         }
     }
@@ -351,13 +361,12 @@ where
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use futures::future;
     use quickcheck::*;
-    use tower_discover::Change;
     use std::collections::VecDeque;
+    use tower_discover::Change;
 
     use super::*;
 
@@ -376,7 +385,11 @@ mod tests {
         type DiscoverError = ();
 
         fn poll(&mut self) -> Poll<Change<Self::Key, Self::Service>, Self::DiscoverError> {
-            let r = self.0.pop_front().map(Async::Ready).unwrap_or(Async::NotReady);
+            let r = self
+                .0
+                .pop_front()
+                .map(Async::Ready)
+                .unwrap_or(Async::NotReady);
             debug!("polling disco: {:?}", r.is_ready());
             Ok(r)
         }


### PR DESCRIPTION
`PowerOfTwoChoices` requires a Random Number Generator. In order for
this randomization source to be configurable (i.e. for tests),
`PowerOfTwoChoices` was generic over its implementation of `rand::Rng`;
however, this leads to needless boilerplate when building P2C balancers.

In order to resolve this, the `p2c` module now uses `rand 0.5`'s `SmallRng`
type, which is smaller faster, though not cryptographically secure.
`PowerOfTwoChoices` may either be constructed with an instance of
`SmallRng`, or it may be constructed as a `Default`, using system entropy.