### PR TITLE
balance: Make Balance::is_ready public

### DIFF
--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(dead_code)]
+
 #[macro_use]
 extern crate futures;
 #[macro_use]
@@ -110,7 +112,7 @@ where
     /// Returns true iff there are ready services.
     ///
     /// This is not authoritative and is only useful after `poll_ready` has been called.
-    fn is_ready(&self) -> bool {
+    pub fn is_ready(&self) -> bool {
         !self.ready.is_empty()
     }
 


### PR DESCRIPTION
`Balance::is_ready` is erroneously private. This causes `dead_code`
warnings.

Make `is_ready` public and prohibit `dead_code`.