### PR TITLE
balance: Move constructors under `Balance`

### DIFF
--- a/tower-balance/Cargo.toml
+++ b/tower-balance/Cargo.toml
@@ -16,6 +16,7 @@ indexmap = "1"
 log = "0.4.1"
 env_logger = { version = "0.5.3", default-features = false }
 hdrsample = "6.0"
-tokio-core = "^0.1.12"
-tokio-timer = "0.1"
+tokio = "0.1.6"
 quickcheck = { version = "0.6", default-features = false }
+tower-buffer = { version = "0.1", path = "../tower-buffer" }
+tower-in-flight-limit = { version = "0.1", path = "../tower-in-flight-limit" }

--- a/tower-balance/examples/demo.rs
+++ b/tower-balance/examples/demo.rs
@@ -19,7 +19,7 @@ use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 use tokio_core::reactor::Core;
 use tokio_timer::{Timer, TimerError, Sleep};
-use tower_balance::*;
+use tower_balance::{Balance, Choose, Error, ResponseFuture, load};
 use tower_discover::{Change, Discover};
 use tower_service::Service;
 
@@ -194,7 +194,7 @@ fn main() {
     {
         let lb = {
             let loaded = load::WithPendingRequests::new(gen_disco(&timer));
-            power_of_two_choices(loaded)
+            Balance::p2c(loaded)
         };
         let send = SendRequests { lb, send_remaining: requests, responses: stream::FuturesUnordered::new() };
         let histo = core.run(compute_histo(send)).unwrap();
@@ -202,7 +202,7 @@ fn main() {
     }
 
     {
-        let lb = round_robin(gen_disco(&timer));
+        let lb = Balance::round_robin(gen_disco(&timer));
         let send = SendRequests { lb, send_remaining: requests, responses: stream::FuturesUnordered::new() };
         let histo = core.run(compute_histo(send)).unwrap();
         report("rr", &histo)

--- a/tower-balance/examples/demo.rs
+++ b/tower-balance/examples/demo.rs
@@ -7,32 +7,175 @@ extern crate hdrsample;
 #[macro_use]
 extern crate log;
 extern crate rand;
-extern crate tokio_core;
-extern crate tokio_timer;
+extern crate tokio;
 extern crate tower_balance;
+extern crate tower_buffer;
 extern crate tower_discover;
+extern crate tower_in_flight_limit;
 extern crate tower_service;
 
-use futures::{Async, Future, Stream, Poll, future, stream};
+use futures::{future, stream, Async, Future, Poll, Stream};
 use hdrsample::Histogram;
+use rand::Rng;
 use std::collections::VecDeque;
 use std::time::{Duration, Instant};
-use tokio_core::reactor::Core;
-use tokio_timer::{Timer, TimerError, Sleep};
-use tower_balance::{Balance, Choose, Error, ResponseFuture, load};
+use tokio::{runtime, timer};
+use tower_balance as lb;
+use tower_buffer::Buffer;
 use tower_discover::{Change, Discover};
+use tower_in_flight_limit::InFlightLimit;
 use tower_service::Service;
 
-struct DelayService(Timer, Duration);
+const REQUESTS: usize = 50_000;
+const CONCURRENCY: usize = 50;
+static ENDPOINT_CAPACITY: usize = CONCURRENCY;
+static MAX_ENDPOINT_LATENCIES: [Duration; 10] = [
+    Duration::from_millis(1),
+    Duration::from_millis(10),
+    Duration::from_millis(10),
+    Duration::from_millis(10),
+    Duration::from_millis(10),
+    Duration::from_millis(100),
+    Duration::from_millis(100),
+    Duration::from_millis(100),
+    Duration::from_millis(100),
+    Duration::from_millis(1000),
+];
 
-struct Delay(Sleep, Instant);
+fn main() {
+    env_logger::init();
 
-struct Disco(VecDeque<Change<usize, DelayService>>);
+    println!("REQUESTS={}", REQUESTS);
+    println!("CONCURRENCY={}", CONCURRENCY);
+    println!("ENDPOINT_CAPACITY={}", ENDPOINT_CAPACITY);
+    print!("MAX_ENDPOINT_LATENCIES=[");
+    for max in &MAX_ENDPOINT_LATENCIES {
+        let l = max.as_secs() * 1_000 + u64::from(max.subsec_nanos() / 1_000 / 1_000);
+        print!("{}ms, ", l);
+    }
+    println!("]");
+
+    let mut rt = runtime::Runtime::new().unwrap();
+    let executor = rt.executor();
+
+    let exec = executor.clone();
+    let fut = future::lazy(move || {
+        let d = gen_disco(exec.clone());
+        let ll = lb::Balance::p2c(lb::load::WithPendingRequests::new(d));
+        run("P2C+LeastLoaded", ll, &exec)
+    });
+
+    let exec = executor;
+    let fut = fut.and_then(move |_| {
+        let rr = lb::Balance::round_robin(gen_disco(exec.clone()));
+        run("RoundRobin", rr, &exec)
+    });
+
+    rt.spawn(fut);
+    rt.shutdown_on_idle().wait().unwrap();
+}
+
+fn gen_disco(executor: runtime::TaskExecutor) -> Disco {
+    use self::Change::Insert;
+
+    let mut changes = VecDeque::new();
+    for (i, latency) in MAX_ENDPOINT_LATENCIES.iter().enumerate() {
+        changes.push_back(Insert(i, DelayService(*latency)));
+    }
+
+    Disco { changes, executor }
+}
+
+fn run<D, C>(
+    name: &'static str,
+    lb: lb::Balance<D, C>,
+    executor: &runtime::TaskExecutor,
+) -> impl Future<Item = (), Error = ()>
+where
+    D: Discover<Request = Req, Response = Rsp> + Send + 'static,
+    D::Key: Send,
+    D::Service: Send,
+    D::Error: Send,
+    D::DiscoverError: Send,
+    <D::Service as Service>::Future: Send,
+    C: lb::Choose<D::Key, D::Service> + Send + 'static,
+{
+    println!("{}", name);
+    let t0 = Instant::now();
+    compute_histo(SendRequests::new(lb, REQUESTS, CONCURRENCY, executor))
+        .map(move |h| report(&h, t0.elapsed()))
+        .map_err(|_| {})
+}
+
+fn compute_histo<S>(times: S) -> impl Future<Item = Histogram<u64>, Error = S::Error> + 'static
+where
+    S: Stream<Item = Rsp> + 'static,
+{
+    // The max delay is 2000ms. At 3 significant figures.
+    let histo = Histogram::<u64>::new_with_max(3_000, 3).unwrap();
+    times.fold(histo, |mut histo, Rsp { latency }| {
+        let ms = latency.as_secs() * 1_000;
+        let ms = ms + u64::from(latency.subsec_nanos()) / 1_000 / 1_000;
+        histo += ms;
+        future::ok(histo)
+    })
+}
+
+fn report(histo: &Histogram<u64>, elapsed: Duration) {
+    println!("  wall {:4}s", elapsed.as_secs());
+
+    if histo.len() < 2 {
+        return;
+    }
+    println!("  p50  {:4}ms", histo.value_at_quantile(0.5));
+
+    if histo.len() < 10 {
+        return;
+    }
+    println!("  p90  {:4}ms", histo.value_at_quantile(0.9));
+
+    if histo.len() < 50 {
+        return;
+    }
+    println!("  p95  {:4}ms", histo.value_at_quantile(0.95));
+
+    if histo.len() < 100 {
+        return;
+    }
+    println!("  p99  {:4}ms", histo.value_at_quantile(0.99));
+
+    if histo.len() < 1000 {
+        return;
+    }
+    println!("  p999 {:4}ms", histo.value_at_quantile(0.999));
+}
+
+#[derive(Debug)]
+struct DelayService(Duration);
+
+#[derive(Debug)]
+struct Delay {
+    delay: timer::Delay,
+    start: Instant,
+}
+
+struct Disco {
+    changes: VecDeque<Change<usize, DelayService>>,
+    executor: runtime::TaskExecutor,
+}
+
+#[derive(Debug)]
+struct Req;
+
+#[derive(Debug)]
+struct Rsp {
+    latency: Duration,
+}
 
 impl Service for DelayService {
-    type Request = ();
-    type Response = Duration;
-    type Error = TimerError;
+    type Request = Req;
+    type Response = Rsp;
+    type Error = timer::Error;
     type Future = Delay;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
@@ -40,74 +183,102 @@ impl Service for DelayService {
         Ok(Async::Ready(()))
     }
 
-    fn call(&mut self, _: ()) -> Delay {
-        Delay(self.0.sleep(self.1), Instant::now())
+    fn call(&mut self, _: Req) -> Delay {
+        let start = Instant::now();
+        let maxms = u64::from(self.0.subsec_nanos() / 1_000 / 1_000)
+            .saturating_add(self.0.as_secs().saturating_mul(1_000));
+        let latency = Duration::from_millis(rand::thread_rng().gen_range(0, maxms));
+        Delay {
+            delay: timer::Delay::new(start + latency),
+            start,
+        }
     }
 }
 
 impl Future for Delay {
-    type Item = Duration;
-    type Error = TimerError;
+    type Item = Rsp;
+    type Error = timer::Error;
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        try_ready!(self.0.poll());
-        Ok(Async::Ready(self.1.elapsed()))
+        try_ready!(self.delay.poll());
+        let rsp = Rsp {
+            latency: Instant::now() - self.start,
+        };
+        Ok(Async::Ready(rsp))
     }
 }
 
 impl Discover for Disco {
     type Key = usize;
-    type Request = ();
-    type Response = Duration;
-    type Error = TimerError;
-    type Service = DelayService;
+    type Request = Req;
+    type Response = Rsp;
+    type Error = tower_in_flight_limit::Error<tower_buffer::Error<timer::Error>>;
+    type Service = InFlightLimit<Buffer<DelayService>>;
     type DiscoverError = ();
 
     fn poll(&mut self) -> Poll<Change<Self::Key, Self::Service>, Self::DiscoverError> {
-        let r = self.0
-            .pop_front()
-            .map(Async::Ready)
-            .unwrap_or(Async::NotReady);
-        debug!("polling disco: {:?}", r.is_ready());
-        Ok(r)
+        match self.changes.pop_front() {
+            Some(Change::Insert(k, svc)) => {
+                let svc = Buffer::new(svc, &self.executor).unwrap();
+                let svc = InFlightLimit::new(svc, ENDPOINT_CAPACITY);
+                Ok(Async::Ready(Change::Insert(k, svc)))
+            }
+            Some(Change::Remove(k)) => Ok(Async::Ready(Change::Remove(k))),
+            None => Ok(Async::NotReady),
+        }
     }
-}
-
-fn gen_disco(timer: &Timer) -> Disco {
-    use self::Change::Insert;
-
-    let mut changes = VecDeque::new();
-
-    let quick = Duration::from_millis(500);
-    for i in 0..8 {
-        changes.push_back(Insert(i, DelayService(timer.clone(), quick)));
-    }
-
-    let slow = Duration::from_secs(2);
-    changes.push_back((Insert(9, DelayService(timer.clone(), slow))));
-
-    Disco(changes)
 }
 
 struct SendRequests<D, C>
 where
-    D: Discover<Request = (), Response = Duration, Error = TimerError>,
-    C: Choose<D::Key, D::Service>,
+    D: Discover<Request = Req, Response = Rsp>,
+    C: lb::Choose<D::Key, D::Service>,
 {
-    lb: Balance<D, C>,
     send_remaining: usize,
-    responses: stream::FuturesUnordered<ResponseFuture<<D::Service as Service>::Future, D::DiscoverError>>,
+    lb: InFlightLimit<Buffer<lb::Balance<D, C>>>,
+    responses: stream::FuturesUnordered<
+        tower_in_flight_limit::ResponseFuture<tower_buffer::ResponseFuture<lb::Balance<D, C>>>,
+    >,
+}
+
+impl<D, C> SendRequests<D, C>
+where
+    D: Discover<Request = Req, Response = Rsp> + Send + 'static,
+    D::Key: Send,
+    D::Service: Send,
+    D::Error: Send,
+    D::DiscoverError: Send,
+    <D::Service as Service>::Future: Send,
+    C: lb::Choose<D::Key, D::Service> + Send + 'static,
+{
+    pub fn new(
+        lb: lb::Balance<D, C>,
+        total: usize,
+        concurrency: usize,
+        executor: &runtime::TaskExecutor,
+    ) -> Self {
+        Self {
+            send_remaining: total,
+            lb: InFlightLimit::new(Buffer::new(lb, executor).ok().expect("buffer"), concurrency),
+            responses: stream::FuturesUnordered::new(),
+        }
+    }
 }
 
 impl<D, C> Stream for SendRequests<D, C>
 where
-    D: Discover<Request = (), Response = Duration, Error = TimerError>,
-    C: Choose<D::Key, D::Service>,
+    D: Discover<Request = Req, Response = Rsp>,
+    C: lb::Choose<D::Key, D::Service>,
 {
-    type Item = Duration;
-    type Error = Error<D::Error, D::DiscoverError>;
+    type Item = Rsp;
+    type Error =
+        tower_in_flight_limit::Error<tower_buffer::Error<<lb::Balance<D, C> as Service>::Error>>;
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        debug!("sending requests {} / {}", self.send_remaining, self.responses.len());
+        debug!(
+            "sending requests {} / {}",
+            self.send_remaining,
+            self.responses.len()
+        );
         while self.send_remaining > 0 {
             if !self.responses.is_empty() {
                 if let Async::Ready(Some(rsp)) = self.responses.poll()? {
@@ -115,16 +286,14 @@ where
                 }
             }
 
-            if self.send_remaining > 0 {
-                debug!("polling lb ready");
-                try_ready!(self.lb.poll_ready());
+            debug!("polling lb ready");
+            try_ready!(self.lb.poll_ready());
 
-                debug!("sending request");
-                let rsp = self.lb.call(());
-                self.responses.push(rsp);
+            debug!("sending request");
+            let rsp = self.lb.call(Req);
+            self.responses.push(rsp);
 
-                self.send_remaining -= 1;
-            }
+            self.send_remaining -= 1;
         }
 
         if !self.responses.is_empty() {
@@ -132,79 +301,5 @@ where
         }
 
         Ok(Async::Ready(None))
-    }
-}
-
-fn compute_histo<S>(times: S)
-    -> Box<Future<Item = Histogram<u64>, Error = S::Error> + 'static>
-where
-    S: Stream<Item = Duration> + 'static
-{
-    // The max delay is 2000ms. At 3 significant figures.
-    let histo = Histogram::<u64>::new_with_max(3_000, 3).unwrap();
-    let fut = times
-        .fold(histo, |mut histo, elapsed| {
-            let ns: u32 = elapsed.subsec_nanos();
-            let ms = u64::from(ns) / 1_000 / 1_000
-                + elapsed.as_secs() * 1_000;
-            histo += ms;
-
-            future::ok(histo)
-        });
-
-    Box::new(fut)
-}
-
-fn report(pfx: &str, histo: &Histogram<u64>) {
-    println!("{} samples: {}", pfx, histo.len());
-
-    if histo.len () < 2 {
-        return;
-    }
-    println!("{} p50:  {}", pfx, histo.value_at_quantile(0.5));
-
-    if histo.len () < 10 {
-        return;
-    }
-    println!("{} p90:  {}", pfx, histo.value_at_quantile(0.9));
-
-    if histo.len () < 50 {
-        return;
-    }
-    println!("{} p95:  {}", pfx, histo.value_at_quantile(0.95));
-
-    if histo.len () < 100 {
-        return;
-    }
-    println!("{} p99:  {}", pfx, histo.value_at_quantile(0.99));
-
-    if histo.len () < 1000 {
-        return;
-    }
-    println!("{} p999: {}", pfx, histo.value_at_quantile(0.999));
-}
-
-fn main() {
-    env_logger::init();
-
-    let timer = Timer::default();
-    let mut core = Core::new().unwrap();
-    let requests = 1_000_000;
-
-    {
-        let lb = {
-            let loaded = load::WithPendingRequests::new(gen_disco(&timer));
-            Balance::p2c(loaded)
-        };
-        let send = SendRequests { lb, send_remaining: requests, responses: stream::FuturesUnordered::new() };
-        let histo = core.run(compute_histo(send)).unwrap();
-        report("p2c", &histo)
-    }
-
-    {
-        let lb = Balance::round_robin(gen_disco(&timer));
-        let send = SendRequests { lb, send_remaining: requests, responses: stream::FuturesUnordered::new() };
-        let histo = core.run(compute_histo(send)).unwrap();
-        report("rr", &histo)
     }
 }

--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -11,6 +11,7 @@ extern crate tower_service;
 
 use futures::{Async, Future, Poll};
 use indexmap::IndexMap;
+use rand::{rngs::SmallRng, SeedableRng};
 use std::marker::PhantomData;
 use std::{error, fmt};
 use tower_discover::Discover;
@@ -21,36 +22,6 @@ pub mod load;
 
 pub use choose::Choose;
 pub use load::Load;
-
-/// Chooses services using the [Power of Two Choices][p2c].
-///
-/// This configuration is prefered when a load metric is known.
-///
-/// As described in the [Finagle Guide][finagle]:
-/// > The algorithm randomly picks two services from the set of ready endpoints and selects
-/// > the least loaded of the two. By repeatedly using this strategy, we can expect a
-/// > manageable upper bound on the maximum load of any server.
-/// >
-/// > The maximum load variance between any two servers is bound by `ln(ln(n))` where `n`
-/// > is the number of servers in the cluster.
-///
-/// [finagle]: https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-least-loaded
-/// [p2c]: http://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf
-pub fn power_of_two_choices<D>(loaded: D) -> Balance<D, choose::PowerOfTwoChoices>
-where
-    D: Discover,
-    D::Service: Load,
-    <D::Service as Load>::Metric: PartialOrd,
-{
-    Balance::new(loaded, choose::PowerOfTwoChoices::default())
-}
-
-/// Attempts to choose services sequentially.
-///
-/// This configuration is prefered when no load metric is known.
-pub fn round_robin<D: Discover>(discover: D) -> Balance<D, choose::RoundRobin> {
-    Balance::new(discover, choose::RoundRobin::default())
-}
 
 /// Balances requests across a set of inner services.
 #[derive(Debug)]
@@ -87,6 +58,52 @@ pub enum Error<T, U> {
 pub struct ResponseFuture<F: Future, E>(F, PhantomData<E>);
 
 // ===== impl Balance =====
+
+impl<D> Balance<D, choose::PowerOfTwoChoices>
+where
+    D: Discover,
+    D::Service: Load,
+    <D::Service as Load>::Metric: PartialOrd,
+{
+    /// Chooses services using the [Power of Two Choices][p2c].
+    ///
+    /// This configuration is prefered when a load metric is known.
+    ///
+    /// As described in the [Finagle Guide][finagle]:
+    ///
+    /// > The algorithm randomly picks two services from the set of ready endpoints and
+    /// > selects the least loaded of the two. By repeatedly using this strategy, we can
+    /// > expect a manageable upper bound on the maximum load of any server.
+    /// >
+    /// > The maximum load variance between any two servers is bound by `ln(ln(n))` where
+    /// > `n` is the number of servers in the cluster.
+    ///
+    /// [finagle]: https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-least-loaded
+    /// [p2c]: http://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf
+    pub fn p2c(discover: D) -> Self {
+        Self::new(discover, choose::PowerOfTwoChoices::default())
+    }
+
+    /// Initializes a P2C load balancer from the provided randomization source.
+    ///
+    /// This may be preferable when an application instantiates many balancers.
+    pub fn p2c_from_rng<R: rand::Rng>(
+        discover: D,
+        rng: &mut R,
+    ) -> Result<Self, rand::Error> {
+        let rng = SmallRng::from_rng(rng)?;
+        Ok(Self::new(discover, choose::PowerOfTwoChoices::new(rng)))
+    }
+}
+
+impl<D: Discover> Balance<D, choose::RoundRobin> {
+    /// Attempts to choose services sequentially.
+    ///
+    /// This configuration is prefered when no load metric is known.
+    pub fn round_robin(discover: D) -> Self {
+        Balance::new(discover, choose::RoundRobin::default())
+    }
+}
 
 impl<D, C> Balance<D, C>
 where

--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -101,7 +101,7 @@ impl<D: Discover> Balance<D, choose::RoundRobin> {
     ///
     /// This configuration is prefered when no load metric is known.
     pub fn round_robin(discover: D) -> Self {
-        Balance::new(discover, choose::RoundRobin::default())
+        Self::new(discover, choose::RoundRobin::default())
     }
 }
 

--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(dead_code)]
+
 #[macro_use]
 extern crate futures;
 #[macro_use]
@@ -11,9 +13,9 @@ extern crate tower_service;
 
 use futures::{Async, Future, Poll};
 use indexmap::IndexMap;
-use rand::{rngs::SmallRng, SeedableRng};
+use rand::{SeedableRng, rngs::SmallRng};
+use std::{fmt, error};
 use std::marker::PhantomData;
-use std::{error, fmt};
 use tower_discover::Discover;
 use tower_service::Service;
 
@@ -63,7 +65,7 @@ impl<D> Balance<D, choose::PowerOfTwoChoices>
 where
     D: Discover,
     D::Service: Load,
-    <D::Service as Load>::Metric: PartialOrd,
+    <D::Service as Load>::Metric: PartialOrd + fmt::Debug,
 {
     /// Chooses services using the [Power of Two Choices][p2c].
     ///
@@ -87,7 +89,7 @@ where
     /// Initializes a P2C load balancer from the provided randomization source.
     ///
     /// This may be preferable when an application instantiates many balancers.
-    pub fn p2c_from_rng<R: rand::Rng>(
+    pub fn p2c_with_rng<R: rand::Rng>(
         discover: D,
         rng: &mut R,
     ) -> Result<Self, rand::Error> {
@@ -125,7 +127,7 @@ where
     /// Returns true iff there are ready services.
     ///
     /// This is not authoritative and is only useful after `poll_ready` has been called.
-    fn is_ready(&self) -> bool {
+    pub fn is_ready(&self) -> bool {
         !self.ready.is_empty()
     }
 


### PR DESCRIPTION
Previously, `power_of_two_choices` and `round_robin` constructors were
exposed from the crate scope.

These have been replaced by `Balance::p2c`, `Balance::p2c_from_rng`, and
`Balance::round_robin`.

Depends on #78.