### PR TITLE
in-flight-limit: Add missing task notification.

### DIFF
--- a/tower-in-flight-limit/Cargo.toml
+++ b/tower-in-flight-limit/Cargo.toml
@@ -9,4 +9,5 @@ futures = "0.1"
 tower-service = { version = "0.1", path = "../tower-service" }
 
 [dev-dependencies]
+tokio-test = { git = "https://github.com/carllerche/tokio-test" }
 tower-mock = { version = "0.1", path = "../tower-mock" }

--- a/tower-in-flight-limit/src/lib.rs
+++ b/tower-in-flight-limit/src/lib.rs
@@ -220,7 +220,7 @@ impl Shared {
     pub fn release(&self) {
         let prev = self.curr.fetch_sub(1, SeqCst);
 
-        // Cannot go abovee the max number of in-flight
+        // Cannot go above the max number of in-flight
         debug_assert!(prev <= self.max);
 
         if prev == self.max {

--- a/tower-in-flight-limit/src/lib.rs
+++ b/tower-in-flight-limit/src/lib.rs
@@ -218,7 +218,14 @@ impl Shared {
     /// request has completed OR the service that made the reservation has
     /// dropped.
     pub fn release(&self) {
-        self.curr.fetch_sub(1, SeqCst);
+        let prev = self.curr.fetch_sub(1, SeqCst);
+
+        // Cannot go abovee the max number of in-flight
+        debug_assert!(prev <= self.max);
+
+        if prev == self.max {
+            self.task.notify();
+        }
     }
 }
 


### PR DESCRIPTION
Previously, there was no notification when capacity is made available by
requests completing. This patch fixes the bug.

This also switches the tests to use [`MockTask`](https://github.com/carllerche/tokio-test/blob/master/src/lib.rs) from tokio-test.

Fixes #70