### PR TITLE
tower-watch: Add Error impls for tower_watch::Error

### DIFF
--- a/tower-watch/src/lib.rs
+++ b/tower-watch/src/lib.rs
@@ -4,7 +4,6 @@ extern crate futures_watch;
 extern crate tower_service;
 
 use std::{fmt, error};
-
 use futures::{Async, Future, Poll, Stream};
 use futures_watch::{Watch, WatchError};
 use tower_service::Service;
@@ -95,7 +94,7 @@ where
     fn cause(&self) -> Option<&error::Error> {
         match self {
             Error::WatchError(_) => None,
-            Error::Inner(e) => Some(e),
+            Error::Inner(e) => e.cause(),
         }
     }
 }

--- a/tower-watch/src/lib.rs
+++ b/tower-watch/src/lib.rs
@@ -3,6 +3,8 @@ extern crate futures;
 extern crate futures_watch;
 extern crate tower_service;
 
+use std::{fmt, error};
+
 use futures::{Async, Future, Poll, Stream};
 use futures_watch::{Watch, WatchError};
 use tower_service::Service;
@@ -69,6 +71,32 @@ impl<T, B: Bind<T>> Service for WatchService<T, B> {
 
     fn call(&mut self, req: Self::Request) -> Self::Future {
         ResponseFuture(self.inner.call(req))
+    }
+}
+
+// ==== impl Error ====
+
+impl<E> fmt::Display for Error<E>
+where
+    E: fmt::Display
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::WatchError(_) => f.pad("watch error"),
+            Error::Inner(e) => fmt::Display::fmt(e, f),
+        }
+    }
+}
+
+impl<E> error::Error for Error<E>
+where
+    E: error::Error,
+{
+    fn cause(&self) -> Option<&error::Error> {
+        match self {
+            Error::WatchError(_) => None,
+            Error::Inner(e) => Some(e),
+        }
     }
 }
 


### PR DESCRIPTION
This branch adds `std::fmt::Display` and `std::error::Error` impls
to `tower-watch`'s `Error` type.

This is necessary to adopt `tower-watch` in Linkerd 2's proxy
(rather than our internal implementation of a similar type), as 
the errors will be part of an error chain which requires these
traits.