### PR TITLE
Make error types forward-compatible

### DIFF
--- a/gen_errors.rs
+++ b/gen_errors.rs
@@ -26,8 +26,10 @@ macro_rules! kind_error {
             $(
                 $(#[$vmeta:meta])*
                 $variant:ident$(($t:ident))* =>
-                    $(fmt: $fmt:expr,)* is: $is:ident, into: $into:ident, borrow: $borrow:ident
-            ),+
+                     $(fmt: $fmt:expr,)*
+                     doc: $doc:expr,
+                     is: $is:ident, into: $into:ident, borrow: $borrow:ident,
+            )+
     }) => {
         $(#[$m])*
         pub struct $name<$($($t,)*)+> {
@@ -77,6 +79,7 @@ macro_rules! kind_error {
 
         impl<$($($t,)*)+> $name<$($($t,)*)+> {
             $(
+                #[doc="Returns `true` if the error was "] #[doc=$doc]
                 pub fn $is(&self) -> bool {
                     match self.kind {
                         $kind_ty::$variant$((ignore_t!(_ $t)))* => true,
@@ -85,6 +88,7 @@ macro_rules! kind_error {
                 }
 
                 $(
+                    #[doc="Consumes `self` and optionally returns the inner error, if it was "] #[doc=$doc]
                     pub fn $into(self) -> Option<$t> {
                         match self.kind {
                             $kind_ty::$variant(e) => Some(e),
@@ -92,6 +96,7 @@ macro_rules! kind_error {
                         }
                     }
 
+                    #[doc="Optionally borrows the inner error, if it was "] #[doc=$doc]
                     pub fn $borrow(&self) -> Option<&$t> {
                         match self.kind {
                             $kind_ty::$variant(ref e) => Some(e),
@@ -99,6 +104,7 @@ macro_rules! kind_error {
                         }
                     }
                 )*
+
             )+
         }
     };

--- a/gen_errors.rs
+++ b/gen_errors.rs
@@ -1,3 +1,25 @@
+/// Generates public error structs internally represented by a private
+/// ErrorKind enum, with `is_$variant`, `into_$variant`, and `borrow_$variant`
+/// methods for each variant as appropriate.
+///
+/// # Usage
+///
+/// New error types are defined as follows:
+///
+/// ```rust,ignore
+/// kind_error! {
+///     pub struct $STRUCT_NAME from enum $ENUM_NAME {
+///         // ...
+///     }
+/// }
+/// ```
+/// where `$STRUCT_NAME` is the name of the public error struct, and
+/// `$ENUM_NAME` is the name of the private error kind enum.
+///
+/// Any number of attributes (including doc comments) can be placed before
+/// the `pub struct`, and they will be added to both the generated struct
+/// and the generated enum.
+///
 #[macro_use]
 macro_rules! kind_error {
     ($(#[$m:meta])* pub struct $name:ident from enum $kind_ty:ident {

--- a/gen_errors.rs
+++ b/gen_errors.rs
@@ -82,7 +82,7 @@ macro_rules! kind_error {
 
 macro_rules! arm {
     (cause: $name:ident::$variant:ident($e:ident@$ty:ident)) => {
-        $e.cause().or_else(Some($e))
+        $e.cause().or(Some($e))
     };
     (cause: $name:ident::$variant:ident) => {
         { None }

--- a/gen_errors.rs
+++ b/gen_errors.rs
@@ -1,0 +1,93 @@
+#[macro_use]
+macro_rules! kind_error {
+    ($(#[$m:meta])* pub struct $name:ident from enum $kind_ty:ident {
+            $( $variant:ident$(($t:ident))* => $(fmt: $fmt:expr,)* is: $is:ident, into: $into:ident, borrow: $borrow:ident ),+
+    }) => {
+        $(#[$m])*
+        pub struct $name<$($($t,)*)+> {
+            kind: $kind_ty<$($($t,)*)+>,
+        }
+
+        $(#[$m])*
+        enum $kind_ty<$($($t,)*)+> {
+             $( $variant$(($t))* ),+
+        }
+
+        impl<$($($t,)*)+> $crate::std::fmt::Display for $name<$($($t,)*)+>
+        where $( $($t: $crate::std::fmt::Display,)* )+
+        {
+            fn fmt(&self, f: &mut $crate::std::fmt::Formatter) -> $crate::std::fmt::Result {
+                match self.kind {
+                    $(
+                        $kind_ty::$variant$((ref e@$t))* => arm!( fmt: $kind_ty::$variant$((e@$t))*, $( $fmt, )* f ),
+                    )+
+                }
+
+            }
+        }
+
+        impl<$($($t,)*)+> $crate::std::error::Error for $name<$($($t,)*)+>
+        where $( $($t: $crate::std::error::Error + $crate::std::fmt::Display,)* )+
+        {
+            fn cause(&self) -> Option<&$crate::std::error::Error> {
+                match self.kind {
+                   $(
+                        $kind_ty::$variant$((ref e@$t))* => arm!( opt: $kind_ty::$variant$((e@$t))* ),
+                   )+
+                }
+            }
+        }
+
+        impl<$($($t,)*)+> From<$kind_ty<$($($t,)*)+>> for $name<$($($t,)*)+> {
+            fn from(kind: $kind_ty<$($($t,)*)+>) -> Self {
+                Self { kind, }
+            }
+        }
+
+        impl<$($($t,)*)+> $name<$($($t,)*)+> {
+            $(
+                pub fn $is(&self) -> bool {
+                    match self.kind {
+                        $kind_ty::$variant$((ref _e @$t))* => true,
+                        _ => false,
+                    }
+                }
+
+                $(
+                    pub fn $into(self) -> Option<$t> {
+                        match self.kind {
+                            $kind_ty::$variant(e) => Some(e),
+                            _ => None,
+                        }
+                    }
+
+                    pub fn $borrow(&self) -> Option<&$t> {
+                        match self.kind {
+                            $kind_ty::$variant(ref e) => Some(e),
+                            _ => None,
+                        }
+                    }
+                )*
+            )+
+        }
+    };
+}
+
+macro_rules! arm {
+    (opt: $name:ident::$variant:ident($e:ident@$ty:ident)) => {
+        { Some($e) }
+    };
+    (opt: $name:ident::$variant:ident) => {
+        { None }
+    };
+
+    (fmt: $name:ident::$variant:ident($e:ident@$ty:ident), $fmt:expr, $f:expr) => {
+        { write!($f, concat!($fmt, ": ", "{}"), $e) }
+    };
+    (fmt: $name:ident::$variant:ident($e:ident@$ty:ident), $f:expr) => {
+        { $crate::std::fmt::Display::fmt($e, $f) }
+    };
+    (fmt: $name:ident::$variant:ident, $fmt:expr, $f:expr) => {
+        { $f.pad($fmt) }
+    };
+}

--- a/gen_errors.rs
+++ b/gen_errors.rs
@@ -26,7 +26,8 @@ macro_rules! kind_error {
             fn fmt(&self, f: &mut $crate::std::fmt::Formatter) -> $crate::std::fmt::Result {
                 match self.kind {
                     $(
-                        $kind_ty::$variant$((ref e@$t))* => arm!( fmt: $kind_ty::$variant$((e@$t))*, $( $fmt, )* f ),
+                        $kind_ty::$variant$((ignore_t!(ref e $t)))* =>
+                            arm!( fmt: $kind_ty::$variant$((e@$t))*, $( $fmt, )* f ),
                     )+
                 }
 
@@ -39,7 +40,8 @@ macro_rules! kind_error {
             fn cause(&self) -> Option<&$crate::std::error::Error> {
                 match self.kind {
                    $(
-                        $kind_ty::$variant$((ref e@$t))* => arm!( cause: $kind_ty::$variant$((e@$t))* ),
+                        $kind_ty::$variant$((ignore_t!(ref e $t)))* =>
+                            arm!( cause: $kind_ty::$variant$((e@$t))* ),
                    )+
                 }
             }
@@ -55,7 +57,7 @@ macro_rules! kind_error {
             $(
                 pub fn $is(&self) -> bool {
                     match self.kind {
-                        $kind_ty::$variant$((ref _e @$t))* => true,
+                        $kind_ty::$variant$((ignore_t!(_ $t)))* => true,
                         _ => false,
                     }
                 }
@@ -78,6 +80,11 @@ macro_rules! kind_error {
             )+
         }
     };
+}
+
+macro_rules! ignore_t {
+    (ref $e:tt $t:ident) => { ref $e };
+    ($e:tt $t:ident) => { $e };
 }
 
 macro_rules! arm {

--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -61,9 +61,16 @@ kind_error! {
     /// Errors produced by `Balance`.
     #[derive(Debug)]
     pub struct Error from enum ErrorKind {
-        Inner(T) => is: is_inner, into: into_inner, borrow: borrow_inner,
-        Balance(U) => is: is_balance, into: into_balance, borrow: borrow_balance,
-        NotReady => fmt: "not ready", is: is_not_ready, into: UNUSED, borrow: UNUSED
+        Inner(T) =>
+            doc: "returned by the inner service.",
+            is: is_inner, into: into_inner, borrow: borrow_inner,
+        Balance(U) =>
+            doc: "internal to the load balancer.",
+            is: is_balance, into: into_balance, borrow: borrow_balance,
+        NotReady =>
+            fmt: "not ready",
+            doc: "caused by a lack of ready endpoints.",
+            is: is_not_ready, into: UNUSED, borrow: UNUSED,
     }
 }
 

--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -15,7 +15,7 @@ extern crate tower_service;
 use futures::{Async, Future, Poll};
 use indexmap::IndexMap;
 use rand::{SeedableRng, rngs::SmallRng};
-use std::{fmt, error};
+use std::fmt;
 use std::marker::PhantomData;
 use tower_discover::Discover;
 use tower_service::Service;

--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -334,7 +334,7 @@ impl<F: Future, E> Future for ResponseFuture<F, E> {
     type Error = Error<F::Error, E>;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.0.poll().map_err(Error::inner)
+        self.0.poll().map_err(|e| ErrorKind::Inner(e).into())
     }
 }
 

--- a/tower-buffer/src/lib.rs
+++ b/tower-buffer/src/lib.rs
@@ -179,7 +179,7 @@ where T: Service
                     match rx.poll() {
                         Ok(Async::Ready(f)) => fut = f,
                         Ok(Async::NotReady) => return Ok(Async::NotReady),
-                        Err(_) => Err(ErrorKind::Closed)?,
+                        Err(_) => return Err(ErrorKind::Closed.into()),
                     }
                 }
                 Poll(ref mut fut) => {

--- a/tower-buffer/src/lib.rs
+++ b/tower-buffer/src/lib.rs
@@ -51,8 +51,13 @@ kind_error!{
     /// Errors produced by `Buffer`.
     #[derive(Debug)]
     pub struct Error from enum ErrorKind {
-        Inner(T) => is: is_inner, into: into_inner, borrow: borrow_inner,
-        Closed => fmt: "buffer closed", is: is_closed, into: UNUSED, borrow: UNUSED
+        Inner(T) =>
+            doc: "returned by the inner service.",
+            is: is_inner, into: into_inner, borrow: borrow_inner,
+        Closed =>
+            fmt: "buffer closed",
+            doc: "caused by the buffer being closed.",
+            is: is_closed, into: UNUSED, borrow: UNUSED,
     }
 }
 

--- a/tower-filter/src/lib.rs
+++ b/tower-filter/src/lib.rs
@@ -47,14 +47,21 @@ kind_error!{
     #[derive(Debug)]
     pub struct Error from enum ErrorKind {
         /// The predicate rejected the request.
-        Rejected(T) => fmt: "rejected by predicate",
+        Rejected(T) =>
+            fmt: "rejected by predicate",
+            doc: "due to the predicate rejecting the request.",
             is: is_rejected, into: into_rejected, borrow: borrow_rejected,
 
         /// The inner service produced an error.
-        Inner(U) => is: is_inner, into: into_inner, borrow: borrow_inner,
+        Inner(U) =>
+            doc: "returned by the inner service.",
+            is: is_inner, into: into_inner, borrow: borrow_inner,
 
         /// The service is out of capacity.
-        NoCapacity => fmt: "filter at capacity", is: is_at_capacity, into: UNUSED, borrow: UNUSED
+        NoCapacity =>
+            fmt: "filter at capacity",
+            doc: "due to the filter service being out of capacity.",
+            is: is_at_capacity, into: UNUSED, borrow: UNUSED,
     }
 }
 

--- a/tower-filter/src/lib.rs
+++ b/tower-filter/src/lib.rs
@@ -37,17 +37,25 @@ where S: Service,
     counts: Arc<Counts>,
 }
 
-/// Errors produced by `Filter`
-#[derive(Debug)]
-pub enum Error<T, U> {
-    /// The predicate rejected the request.
-    Rejected(T),
+#[macro_use]
+mod macros {
+    include! { concat!(env!("CARGO_MANIFEST_DIR"), "/../gen_errors.rs") }
+}
 
-    /// The inner service produced an error.
-    Inner(U),
+kind_error!{
+    /// Errors produced by `Filter`
+    #[derive(Debug)]
+    pub struct Error from enum ErrorKind {
+        /// The predicate rejected the request.
+        Rejected(T) => fmt: "rejected by predicate",
+            is: is_rejected, into: into_rejected, borrow: borrow_rejected,
 
-    /// The service is out of capacity.
-    NoCapacity,
+        /// The inner service produced an error.
+        Inner(U) => is: is_inner, into: into_inner, borrow: borrow_inner,
+
+        /// The service is out of capacity.
+        NoCapacity => fmt: "filter at capacity", is: is_at_capacity, into: UNUSED, borrow: UNUSED
+    }
 }
 
 /// Checks a request

--- a/tower-filter/src/lib.rs
+++ b/tower-filter/src/lib.rs
@@ -184,7 +184,7 @@ where T: Future,
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         match self.inner {
             Some(ref mut inner) => inner.poll(),
-            None => Err(Error::NoCapacity),
+            None => Err(ErrorKind::NoCapacity.into()),
         }
     }
 }
@@ -230,7 +230,7 @@ where T: Future,
                             return Ok(Async::NotReady);
                         }
                         Err(e) => {
-                            return Err(Error::Rejected(e));
+                            Err(ErrorKind::Rejected(e))?;
                         }
                     }
                 }
@@ -250,20 +250,20 @@ where T: Future,
                         Err(e) => {
                             self.inc_rem();
 
-                            return Err(Error::Inner(e));
+                            Err(ErrorKind::Inner(e))?;
                         }
                     }
                 }
                 WaitResponse(mut response) => {
                     let ret = response.poll()
-                        .map_err(Error::Inner);
+                        .map_err(|e| ErrorKind::Inner(e).into());
 
                     self.state = WaitResponse(response);
 
                     return ret;
                 }
                 NoCapacity => {
-                    return Err(Error::NoCapacity);
+                    Err(ErrorKind::NoCapacity)?;
                 }
             }
         }

--- a/tower-in-flight-limit/src/lib.rs
+++ b/tower-in-flight-limit/src/lib.rs
@@ -8,7 +8,6 @@ use tower_service::Service;
 
 use futures::{Future, Poll, Async};
 use futures::task::AtomicTask;
-use std::{error, fmt};
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;

--- a/tower-in-flight-limit/src/lib.rs
+++ b/tower-in-flight-limit/src/lib.rs
@@ -99,7 +99,7 @@ where S: Service
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         if self.state.reserved {
             return self.inner.poll_ready()
-                .map_err(Error::Upstream);
+                .map_err(|e| ErrorKind::Upstream(e).into());
         }
 
         self.state.shared.task.register();
@@ -111,7 +111,7 @@ where S: Service
         self.state.reserved = true;
 
         self.inner.poll_ready()
-            .map_err(Error::Upstream)
+            .map_err(|e| ErrorKind::Upstream(e).into())
     }
 
     fn call(&mut self, request: Self::Request) -> Self::Future {

--- a/tower-in-flight-limit/src/lib.rs
+++ b/tower-in-flight-limit/src/lib.rs
@@ -48,8 +48,13 @@ kind_error!{
     /// TODO: Consider returning the original request
     #[derive(Debug)]
     pub struct Error from enum ErrorKind {
-        NoCapacity => fmt: "in-flight limit exceeded", is: is_at_capacity, into: UNUSED, borrow: UNUSED,
-        Upstream(T) => is: is_upstream, into: into_upstream, borrow: borrow_upstream
+        NoCapacity =>
+            fmt: "in-flight limit exceeded",
+            doc: "because the in-flight limit was exceeded.",
+            is: is_at_capacity, into: UNUSED, borrow: UNUSED,
+        Upstream(T) =>
+            doc: "returned by the upstream service.",
+            is: is_upstream, into: into_upstream, borrow: borrow_upstream,
     }
 }
 

--- a/tower-mock/src/lib.rs
+++ b/tower-mock/src/lib.rs
@@ -165,7 +165,7 @@ impl<T, U, E> Service for Mock<T, U, E> {
             respond: Respond { tx },
         };
 
-        match self.tx.lock().unwrap().unbounded_send((request)) {
+        match self.tx.lock().unwrap().unbounded_send(request) {
             Ok(_) => {}
             Err(_) => {
                 // TODO: Can this be reached

--- a/tower-rate-limit/src/lib.rs
+++ b/tower-rate-limit/src/lib.rs
@@ -54,8 +54,13 @@ kind_error!{
     /// TODO: Consider returning the original request
     #[derive(Debug)]
     pub struct Error from enum ErrorKind {
-        RateLimit => fmt: "rate limit exceeded", is: is_rate_limit, into: UNUSED, borrow: UNUSED,
-        Upstream(T) => is: is_upstream, into: into_upstream, borrow: borrow_upstream
+        RateLimit =>
+            fmt: "rate limit exceeded",
+            doc: "because the request was rate-limited.",
+            is: is_rate_limit, into: UNUSED, borrow: UNUSED,
+        Upstream(T) =>
+            doc: "returned by the upstream service.",
+            is: is_upstream, into: into_upstream, borrow: borrow_upstream,
     }
 }
 

--- a/tower-rate-limit/src/lib.rs
+++ b/tower-rate-limit/src/lib.rs
@@ -12,7 +12,6 @@ use futures::{Future, Poll};
 use tower_service::Service;
 use tokio_timer::{Timer, Sleep};
 
-use std::{error, fmt};
 use std::time::{Duration, Instant};
 
 #[derive(Debug)]

--- a/tower-reconnect/src/lib.rs
+++ b/tower-reconnect/src/lib.rs
@@ -39,9 +39,17 @@ mod macros {
 kind_error!{
     #[derive(Debug)]
     pub struct Error from enum ErrorKind {
-        Inner(T) => is: is_inner, into: into_inner, borrow: borrow_inner,
-        Connect(U) => fmt: "error connecting", is: is_connect, into: into_connect, borrow: borrow_connect,
-        NotReady => fmt: "not ready", is: is_not_ready, into: UNUSED, borrow: UNUSED
+        Inner(T) =>
+            doc: "returned by the inner service.",
+            is: is_inner, into: into_inner, borrow: borrow_inner,
+        Connect(U) =>
+            fmt: "error connecting",
+            doc: "caused by an error connecting.",
+            is: is_connect, into: into_connect, borrow: borrow_connect,
+        NotReady =>
+            fmt: "not ready",
+            doc: "because the connection has yet to be established.",
+            is: is_not_ready, into: UNUSED, borrow: UNUSED,
     }
 }
 // ===== impl Reconnect =====

--- a/tower-reconnect/src/lib.rs
+++ b/tower-reconnect/src/lib.rs
@@ -16,7 +16,12 @@ where T: NewService,
 }
 
 #[derive(Debug)]
-pub enum Error<T, U> {
+pub struct Error<T, U> {
+    kind: ErrorKind<T, U>,
+}
+
+#[derive(Debug)]
+enum ErrorKind<T, U> {
     Inner(T),
     Connect(U),
     NotReady,
@@ -85,7 +90,7 @@ where T: NewService
                         Err(e) => {
                             trace!("poll_ready; error");
                             state = Idle;
-                            ret = Err(Error::Connect(e));
+                            ret = Err(Error::connect(e));
                             break;
                         }
                     }
@@ -155,9 +160,9 @@ impl<T: NewService> Future for ResponseFuture<T> {
 
         match self.inner {
             Some(ref mut f) => {
-                f.poll().map_err(Error::Inner)
+                f.poll().map_err(Error::inner)
             }
-            None => Err(Error::NotReady),
+            None => Err(Error::not_ready()),
         }
     }
 }
@@ -171,10 +176,10 @@ where
     U: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::Inner(ref why) => fmt::Display::fmt(why, f),
-            Error::Connect(ref why) => write!(f, "connection failed: {}", why),
-            Error::NotReady => f.pad("not ready"),
+        match self.kind {
+            ErrorKind::Inner(ref why) => fmt::Display::fmt(why, f),
+            ErrorKind::Connect(ref why) => write!(f, "connection failed: {}", why),
+            ErrorKind::NotReady => f.pad("not ready"),
         }
     }
 }
@@ -185,18 +190,88 @@ where
     U: error::Error,
 {
     fn cause(&self) -> Option<&error::Error> {
-        match *self {
-            Error::Inner(ref why) => Some(why),
-            Error::Connect(ref why) => Some(why),
+        match self.kind {
+            ErrorKind::Inner(ref why) => Some(why),
+            ErrorKind::Connect(ref why) => Some(why),
             _ => None,
         }
     }
 
     fn description(&self) -> &str {
-        match *self {
-            Error::Inner(_) => "inner service error",
-            Error::Connect(_) => "connection failed",
-            Error::NotReady => "not ready",
+        match self.kind {
+            ErrorKind::Inner(_) => "inner service error",
+            ErrorKind::Connect(_) => "connection failed",
+            ErrorKind::NotReady => "not ready",
+        }
+    }
+}
+
+impl<T, U> Error<T, U> {
+
+    pub fn is_connect(&self) -> bool {
+        match self.kind {
+            ErrorKind::Connect(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_service(&self) -> bool {
+        match self.kind {
+            ErrorKind::Inner(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_not_ready(&self) -> bool {
+        match self.kind {
+            ErrorKind::NotReady => true,
+            _ => false,
+        }
+    }
+
+    pub fn into_connect(self) -> Option<U> {
+        match self.kind {
+            ErrorKind::Connect(e) => Some(e),
+            _ => None,
+        }
+    }
+
+    pub fn into_service(self) -> Option<T> {
+        match self.kind {
+            ErrorKind::Inner(e) => Some(e),
+            _ => None,
+        }
+    }
+
+    pub fn borrow_connect(&self) -> Option<&U> {
+        match self.kind {
+            ErrorKind::Connect(ref e) => Some(e),
+            _ => None,
+        }
+    }
+
+    pub fn borrow_service(&self) -> Option<&T> {
+        match self.kind {
+            ErrorKind::Inner(ref e) => Some(e),
+            _ => None,
+        }
+    }
+
+    fn inner(t: T) -> Self {
+        Self {
+            kind: ErrorKind::Inner(t),
+        }
+    }
+
+    fn connect(c: U) -> Self {
+        Self {
+            kind: ErrorKind::Connect(c),
+        }
+    }
+
+    fn not_ready() -> Self {
+        Self {
+            kind: ErrorKind::NotReady,
         }
     }
 }

--- a/tower-router/src/lib.rs
+++ b/tower-router/src/lib.rs
@@ -166,8 +166,8 @@ where T: Recognize,
         loop {
             match self.state {
                 Dispatched(ref mut inner) => {
-                    inner.poll()
-                        .map_err(ErrorKind::Inner)?;
+                    return inner.poll()
+                        .map_err(|e| ErrorKind::Inner(e).into());
                 }
                 Queued { ref mut service, .. } => {
                     let res = service.poll_ready()

--- a/tower-router/src/lib.rs
+++ b/tower-router/src/lib.rs
@@ -71,12 +71,19 @@ kind_error!{
     pub struct Error from enum ErrorKind {
 
         /// Error produced by inner service.
-        Inner(T) => is: is_inner, into: into_inner, borrow: borrow_inner,
+        Inner(T) =>
+            doc: "returned by the inner service.",
+            is: is_inner, into: into_inner, borrow: borrow_inner,
         /// Error produced during route recognition.
-        Route(U) => is: is_route, into: into_route, borrow: borrow_route,
+        Route(U) =>
+            doc: "caused by an error during route recognition.",
+            is: is_route_error, into: into_route_error, borrow: borrow_route_error,
 
         /// Request sent when not ready.
-        NotReady => fmt: "router not ready", is: is_not_ready, into: UNUSED, borrow: UNUSED
+        NotReady =>
+            fmt: "router not ready",
+            doc: "because the router was not ready.",
+            is: is_not_ready, into: UNUSED, borrow: UNUSED,
     }
 }
 

--- a/tower-timeout/src/lib.rs
+++ b/tower-timeout/src/lib.rs
@@ -67,7 +67,7 @@ where S: Service,
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         self.inner.poll_ready()
-            .map_err(Error::Inner)
+            .map_err(|e| ErrorKind::Inner(e).into())
     }
 
     fn call(&mut self, request: Self::Request) -> Self::Future {

--- a/tower-timeout/src/lib.rs
+++ b/tower-timeout/src/lib.rs
@@ -32,9 +32,14 @@ kind_error!{
     #[derive(Debug)]
     pub struct Error from enum ErrorKind {
         /// The inner service produced an error
-        Inner(T) => is: is_inner, into: into_inner, borrow: borrow_inner,
+        Inner(T) =>
+            doc: "returned by the inner service",
+            is: is_inner, into: into_inner, borrow: borrow_inner,
         /// The request did not complete within the specified timeout.
-        Timeout => fmt: "request timed out", is: is_timeout, into: UNUSED, borrow: UNUSED
+        Timeout =>
+            fmt: "request timed out",
+            doc: "because the request did not complete within the specified timeout.",
+            is: is_timeout, into: UNUSED, borrow: UNUSED,
     }
 }
 

--- a/tower-util/src/lib.rs
+++ b/tower-util/src/lib.rs
@@ -3,10 +3,17 @@
 extern crate futures;
 extern crate tower_service;
 
+#[macro_use]
+mod macros {
+    include! { concat!(env!("CARGO_MANIFEST_DIR"), "/../gen_errors.rs") }
+}
+
 pub mod either;
 pub mod option;
 pub mod boxed;
 mod service_fn;
+
+
 
 pub use boxed::BoxService;
 pub use either::EitherService;

--- a/tower-watch/src/lib.rs
+++ b/tower-watch/src/lib.rs
@@ -128,7 +128,7 @@ where
     fn cause(&self) -> Option<&error::Error> {
         match self.kind {
             ErrorKind::Inner(ref e) => e.cause().or(Some(e)),
-            ErrorKind::Watch(ref e) => None,
+            ErrorKind::Watch(_) => None,
         }
     }
 }

--- a/tower-watch/src/lib.rs
+++ b/tower-watch/src/lib.rs
@@ -127,7 +127,7 @@ where
 {
     fn cause(&self) -> Option<&error::Error> {
         match self.kind {
-            ErrorKind::Inner(ref e) => e.cause().or_else(Some(e)),
+            ErrorKind::Inner(ref e) => e.cause().or(Some(e)),
             ErrorKind::Watch(ref e) => None,
         }
     }


### PR DESCRIPTION
This branch obsoletes and closes #90.

Currently, a number of Tower crates expose public error types which are
`enum`. This can lead to forward-compatibility issues, as enum matching
is exhaustive, and if additional variants are added, this becomes a
breaking change for any consumer of the library who is matching on the
enum's variants. 

This branch reworks the error types to consist of public `struct`s with
a single field, which is a private `ErrorKind` enum. The structs provide
methods to check whether the error is a given kind (so that, for
example, if I have a `pub struct Error` and 
`enum ErrorKind { Connect,... }`, `Error` has a method `is_connect`
that returns `true` if its' kind is `ErrorKind::Connect`). Furthermore,
if one of the enum variants wraps another error type, it also has
methods which consume it and return the inner type optionally if the
error is that kind, and which borrow the inner type optionally. 

Since this code ended up being very repetitive, I made this change using
a macro to generate the various error types.

This is a breaking change for any downstream consumers who are matching
against Tower's old enum error types, so we may not want to merge it
right away.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>