### PR TITLE
Update tower-rate-limit to work with new tokio_timer

### DIFF
--- a/tower-rate-limit/Cargo.toml
+++ b/tower-rate-limit/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 futures = "0.1"
 tower-service = { version = "0.1", path = "../tower-service" }
-tokio-timer = "0.2"
+tokio-timer = "0.2.6"
 
 [dev-dependencies]
 tower-mock = { version = "0.1", path = "../tower-mock" }

--- a/tower-rate-limit/Cargo.toml
+++ b/tower-rate-limit/Cargo.toml
@@ -7,7 +7,8 @@ publish = false
 [dependencies]
 futures = "0.1"
 tower-service = { version = "0.1", path = "../tower-service" }
-tokio-timer = "0.1"
+tokio-timer = "0.2"
 
 [dev-dependencies]
 tower-mock = { version = "0.1", path = "../tower-mock" }
+tokio = "0.1"

--- a/tower-rate-limit/src/lib.rs
+++ b/tower-rate-limit/src/lib.rs
@@ -10,7 +10,7 @@ extern crate tokio_timer;
 
 use futures::{Future, Poll};
 use tower_service::Service;
-use tokio_timer::{timer, Delay};
+use tokio_timer::Delay;
 
 use std::{error, fmt};
 use std::time::{Duration, Instant};
@@ -141,7 +141,7 @@ where S: Service
                     self.state = State::Ready { until, rem };
                 } else {
                     // The service is disabled until further notice
-                    let sleep = timer::Handle::current().delay(until);
+                    let sleep = Delay::new(until);
                     self.state = State::Limited(sleep);
                 }
 

--- a/tower-rate-limit/tests/rate_limit.rs
+++ b/tower-rate-limit/tests/rate_limit.rs
@@ -5,7 +5,7 @@ extern crate tower_service;
 extern crate tokio_timer;
 extern crate tokio;
 
-use futures::{prelude::*, future};
+use futures::future;
 use tower_rate_limit::*;
 use tower_service::*;
 
@@ -13,49 +13,48 @@ use std::time::{Duration, Instant};
 
 #[test]
 fn reaching_capacity() {
-    let mut rt = tokio::runtime::current_thread::Runtime::new().unwrap();
-    rt.block_on(future::lazy(|| {
-        let (mut service, mut handle) =
-            new_service(Rate::new(1, from_millis(100)));
+    let mut rt = tokio::runtime::current_thread::Runtime::new()
+        .unwrap();
+    let (mut service, mut handle) =
+        new_service(Rate::new(1, from_millis(100)));
 
-        let response = service.call("hello");
+    let response = service.call("hello");
 
-        let request = handle.next_request().unwrap();
-        assert_eq!(*request, "hello");
-        request.respond("world");
+    let request = handle.next_request().unwrap();
+    assert_eq!(*request, "hello");
+    request.respond("world");
 
-        response.then(move |response| Ok((response, service, handle)))
-    }).and_then(|(response, mut service, mut handle)| {
-        assert_eq!(response.unwrap(), "world");
+    let response = rt.block_on(response);
+    assert_eq!(response.unwrap(), "world");
 
-        // Sending another request is rejected
-        let response = service.call("no");
-        assert!(handle.poll_request().unwrap().is_not_ready());
+    // Sending another request is rejected
+    let response = service.call("no");
 
-        response.then(move |response| Ok((response, service, handle)))
-    }).and_then(|(response, mut service, handle)| {
-        assert!(response.is_err());
-        assert!(service.poll_ready().unwrap().is_not_ready());
+    let poll_request = rt.block_on(future::lazy(|| handle.poll_request()));
+    assert!(poll_request.unwrap().is_not_ready());
 
-        tokio_timer::Delay::new(Instant::now() + Duration::from_millis(100))
-            .then(move |_| Ok((service, handle)))
-    }).and_then(|(mut service, mut handle)| {
+    let response = rt.block_on(response);
+    assert!(response.is_err());
 
-        assert!(service.poll_ready().unwrap().is_ready());
+    let poll_request = rt.block_on(future::lazy(|| handle.poll_request()));
+    assert!(poll_request.unwrap().is_not_ready());
 
-        // Send a second request
-        let response = service.call("two");
+    // Unlike `thread::sleep`, this advances the timer.
+    rt.block_on(tokio_timer::Delay::new(Instant::now() + Duration::from_millis(100)))
+        .unwrap();
 
-        let request = handle.next_request().unwrap();
-        assert_eq!(*request, "two");
-        request.respond("done");
+    let poll_ready = rt.block_on(future::lazy(|| service.poll_ready()));
+    assert!(poll_ready.unwrap().is_ready());
 
-        response
-    }).then(|response| {
-        assert_eq!(response.unwrap(), "done");
+    // Send a second request
+    let response = service.call("two");
 
-        Ok::<(), ()>(())
-    })).unwrap();
+    let request = handle.next_request().unwrap();
+    assert_eq!(*request, "two");
+    request.respond("done");
+
+    let response = rt.block_on(response);
+    assert_eq!(response.unwrap(), "done");
 }
 
 type Mock = tower_mock::Mock<&'static str, &'static str, ()>;

--- a/tower-rate-limit/tests/rate_limit.rs
+++ b/tower-rate-limit/tests/rate_limit.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 
 #[test]
 fn reaching_capacity() {
-    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let mut rt = tokio::runtime::current_thread::Runtime::new().unwrap();
     rt.block_on(future::lazy(|| {
         let (mut service, mut handle) =
             new_service(Rate::new(1, from_millis(100)));


### PR DESCRIPTION
While working on a prototype implementation of a generic `Service` trait
(#99), I noticed that `tower-rate-limit` no longer compiles. It depends
on `tokio-timer` v0.1, which was pulling in the _new_ version of
`tokio-timer`, but it was using the old API from before the tokio
reform.

This branch updates that crate to work with the current `tokio` and
`tokio-timer`.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>