### PR TITLE
Update tower-timeout to use new tokio-timer

### DIFF
--- a/tower-timeout/Cargo.toml
+++ b/tower-timeout/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 [dependencies]
 futures = "0.1"
 tower-service = { version = "0.1", path = "../tower-service" }
-tokio-timer = "0.1"
+tokio-timer = "0.2.6"


### PR DESCRIPTION
Like #100, this branch updates the `tower-timeout` module to use the new
`tokio-timer` API.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>