### PR TITLE
Implement DirectService for ServiceFn

### DIFF
--- a/tower-util/Cargo.toml
+++ b/tower-util/Cargo.toml
@@ -7,3 +7,4 @@ publish = false
 [dependencies]
 futures = "0.1"
 tower-service = { version = "0.1", path = "../tower-service" }
+tower-direct-service = { version = "0.1", path = "../tower-direct-service" }

--- a/tower-util/src/lib.rs
+++ b/tower-util/src/lib.rs
@@ -2,6 +2,7 @@
 
 #[macro_use]
 extern crate futures;
+extern crate tower_direct_service;
 extern crate tower_service;
 
 pub mod boxed;

--- a/tower-util/src/service_fn.rs
+++ b/tower-util/src/service_fn.rs
@@ -1,4 +1,5 @@
 use futures::{IntoFuture, Poll};
+use tower_direct_service::DirectService;
 use tower_service::Service;
 
 /// A `Service` implemented by a closure.
@@ -24,6 +25,31 @@ where T: Fn(Request) -> F,
     type Future = F::Future;
 
     fn poll_ready(&mut self) -> Poll<(), F::Error> {
+        Ok(().into())
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        (self.f)(req).into_future()
+    }
+}
+
+impl<T, F, Request> DirectService<Request> for ServiceFn<T>
+where T: Fn(Request) -> F,
+      F: IntoFuture,
+{
+    type Response = F::Item;
+    type Error = F::Error;
+    type Future = F::Future;
+
+    fn poll_ready(&mut self) -> Poll<(), F::Error> {
+        Ok(().into())
+    }
+
+    fn poll_service(&mut self) -> Poll<(), F::Error> {
+        Ok(().into())
+    }
+
+    fn poll_close(&mut self) -> Poll<(), F::Error> {
         Ok(().into())
     }
 


### PR DESCRIPTION
This enables `ServiceFn` to be used where a `DirectService` is expected or required.