### PR TITLE
balance: Update `rand` dependency

### DIFF
--- a/tower-balance/Cargo.toml
+++ b/tower-balance/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 futures = "0.1"
 log = "0.4.1"
-rand = "0.5"
+rand = "0.6"
 tokio-timer = "0.2.4"
 tower-service = { version = "0.2", path = "../tower-service" }
 tower-direct-service = { version = "0.1", path = "../tower-direct-service" }


### PR DESCRIPTION
This branch updates `tower-balance` to depend on the latest 
released `rand` version.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>