### PR TITLE
Expose Service errors through tower-buffer

### DIFF
--- a/tower-balance/examples/demo.rs
+++ b/tower-balance/examples/demo.rs
@@ -96,8 +96,9 @@ where
     D: Discover + Send + 'static,
     D::Key: Send,
     D::Service: Service<Req, Response = Rsp> + Send,
-    D::Error: Send,
+    D::Error: Send + Sync,
     <D::Service as Service<Req>>::Future: Send,
+    <D::Service as Service<Req>>::Error: Send + Sync,
     C: lb::Choose<D::Key, D::Service> + Send + 'static,
 {
     println!("{}", name);
@@ -243,8 +244,9 @@ where
     D::Service: Service<Req>,
     D::Key: Send,
     D::Service: Send,
-    D::Error: Send,
+    D::Error: Send + Sync,
     <D::Service as Service<Req>>::Future: Send,
+    <D::Service as Service<Req>>::Error: Send + Sync,
     C: lb::Choose<D::Key, D::Service> + Send + 'static,
 {
     pub fn new(lb: lb::Balance<D, C>, total: usize, concurrency: usize) -> Self {

--- a/tower-buffer/Cargo.toml
+++ b/tower-buffer/Cargo.toml
@@ -9,6 +9,7 @@ futures = "0.1"
 tower-service = { version = "0.2", path = "../tower-service" }
 tower-direct-service = { version = "0.1", path = "../tower-direct-service" }
 tokio-executor = "0.1"
+lazycell = "1.2"
 
 [dev-dependencies]
 tower-mock = { version = "0.1", path = "../tower-mock" }

--- a/tower-buffer/src/lib.rs
+++ b/tower-buffer/src/lib.rs
@@ -45,10 +45,20 @@ pub struct ResponseFuture<T, E> {
 /// An error produced by a `Service` wrapped by a `Buffer`
 #[derive(Debug)]
 pub struct ServiceError<E> {
+    method: &'static str,
+    inner: E,
+}
+
+impl<E> ServiceError<E> {
     /// The method that was called on `Service` when it failed.
-    pub method: &'static str,
-    /// The error produced by the `Service`.
-    pub inner: E,
+    pub fn method(&self) -> &'static str {
+        self.method
+    }
+
+    /// The error produced by the `Service` when `method` was called.
+    pub fn error(&self) -> &E {
+        &self.inner
+    }
 }
 
 /// Errors produced by `Buffer`.

--- a/tower-buffer/src/lib.rs
+++ b/tower-buffer/src/lib.rs
@@ -50,11 +50,6 @@ pub struct ServiceError<E> {
 }
 
 impl<E> ServiceError<E> {
-    /// The method that was called on `Service` when it failed.
-    pub fn method(&self) -> &'static str {
-        self.method
-    }
-
     /// The error produced by the `Service` when `method` was called.
     pub fn error(&self) -> &E {
         &self.inner

--- a/tower-buffer/tests/buffer.rs
+++ b/tower-buffer/tests/buffer.rs
@@ -96,8 +96,8 @@ fn when_inner_fails() {
     with_task(|| {
         let e = res1.poll().unwrap_err();
         if let Error::Closed(e) = e {
-            assert_eq!(e.method, "poll_ready");
-            assert_eq!(e.inner, tower_mock::Error::Other("foobar"));
+            assert_eq!(e.method(), "poll_ready");
+            assert_eq!(e.error(), &tower_mock::Error::Other("foobar"));
         } else {
             panic!("unexpected error type: {:?}", e);
         }

--- a/tower-buffer/tests/buffer.rs
+++ b/tower-buffer/tests/buffer.rs
@@ -96,7 +96,7 @@ fn when_inner_fails() {
     with_task(|| {
         let e = res1.poll().unwrap_err();
         if let Error::Closed(e) = e {
-            assert_eq!(e.method(), "poll_ready");
+            assert!(format!("{:?}", e).contains("poll_ready"));
             assert_eq!(e.error(), &tower_mock::Error::Other("foobar"));
         } else {
             panic!("unexpected error type: {:?}", e);

--- a/tower-buffer/tests/buffer.rs
+++ b/tower-buffer/tests/buffer.rs
@@ -81,8 +81,31 @@ fn when_inner_is_not_ready() {
     assert_eq!(res1.wait().expect("res1.wait"), "world");
 }
 
-type Mock = tower_mock::Mock<&'static str, &'static str, ()>;
-type Handle = tower_mock::Handle<&'static str, &'static str, ()>;
+#[test]
+fn when_inner_fails() {
+    let (mut service, mut handle) = new_service();
+
+    // Make the service NotReady
+    handle.allow(0);
+    handle.error("foobar");
+
+    let mut res1 = service.call("hello");
+
+    // Allow the Buffer's executor to do work
+    ::std::thread::sleep(::std::time::Duration::from_millis(100));
+    with_task(|| {
+        let e = res1.poll().unwrap_err();
+        if let Error::Closed(e) = e {
+            assert_eq!(e.method, "poll_ready");
+            assert_eq!(e.inner, tower_mock::Error::Other("foobar"));
+        } else {
+            panic!("unexpected error type: {:?}", e);
+        }
+    });
+}
+
+type Mock = tower_mock::Mock<&'static str, &'static str, &'static str>;
+type Handle = tower_mock::Handle<&'static str, &'static str, &'static str>;
 
 struct Exec;
 


### PR DESCRIPTION
In the past, any errors thrown by a `Service` wrapped in a `tower_buffer::Buffer` were silently swallowed, and the handles were simply informed that the connection to the `Service` was closed.

This patch captures errors from a wrapped `Service`, and communicates that error to all pending and future requests. It does so by wrapping up the error in an `Arc`, which is sent to all pending `oneshot` request channels, and is stored in a shared location so that future requests will see the error when their send to the `Worker` fail.

Note that this patch also removes the `open` field from `State`, as it is no longer necessary following #120, since bounded channels have a `try_ready` method we can rely on instead.

Note that this change is not entirely backwards compatible -- the error type for a `Service` that is wrapped in `Buffer` must now be `Send + Sync` so that it can safely be communicated back to callers. Furthermore, `tower_buffer::Error::Closed` now contains the error that the failed `Service` produced, which may trip up old code.