### PR TITLE
Move MakeService to DirectService for the inner service

### DIFF
--- a/tower-util/Cargo.toml
+++ b/tower-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-util"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
 publish = false
 

--- a/tower-util/src/make_service.rs
+++ b/tower-util/src/make_service.rs
@@ -1,5 +1,6 @@
 use futures::{Future, Poll};
 use tower_service::Service;
+use tower_direct_service::DirectService;
 
 /// Creates new `Service` values.
 ///
@@ -18,7 +19,7 @@ pub trait MakeService<Target, Request>: self::sealed::Sealed<Target, Request> {
     type Error;
 
     /// The `Service` value created by this factory
-    type Service: Service<Request, Response = Self::Response, Error = Self::Error>;
+    type Service: DirectService<Request, Response = Self::Response, Error = Self::Error>;
 
     /// Errors produced while building a service.
     type MakeError;
@@ -43,12 +44,12 @@ pub trait MakeService<Target, Request>: self::sealed::Sealed<Target, Request> {
 
 impl<M, S, Target, Request> self::sealed::Sealed<Target, Request> for M
     where M: Service<Target, Response=S>,
-          S: Service<Request>,
+          S: DirectService<Request>,
 {}
 
 impl<M, S, Target, Request> MakeService<Target, Request> for M
     where M: Service<Target, Response=S>,
-          S: Service<Request>,
+          S: DirectService<Request>,
 {
     type Response = S::Response;
     type Error = S::Error;


### PR DESCRIPTION
This is one of many first steps in an attempt to move tower to `DirectService`, for right now only the service produced from the MakeService is a `DirectService`. This is needed to support `MakeService for https://github.com/LucioFranco/tower-hyper and future leaf service implementations.

Questions:

Should I also move the maker service to `DirectService`?