### PR TITLE
Add initial base tower crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,31 @@
+[package]
+name = "tower"
+version = "0.1.0"
+authors = ["Carl Lerche <me@carllerche.com>"]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/tower-rs/tower"
+publish = false
+description = """
+Tower is a library of modular and reusable components for building robust
+clients and servers.
+"""
+categories = ["asynchronous", "network-programming"]
+keywords = ["io", "async", "non-blocking", "futures", "service"]
+
+[dev-dependencies]
+tower-service = { version = "0.2", path = "tower-service" }
+tower-util = { version = "0.1", path = "tower-util" }
+futures = "0.1"
+log = "0.4.1"
+env_logger = { version = "0.5.3", default-features = false }
+tokio-timer = "0.1"
+futures-cpupool = "0.1"
+
 [workspace]
 
 members = [
+  "./",
   "tower-balance",
   "tower-buffer",
   "tower-direct-service",
@@ -17,10 +42,3 @@ members = [
   "tower-util",
   "tower-watch",
 ]
-
-[dev-dependencies]
-futures = "0.1"
-log = "0.4.1"
-env_logger = { version = "0.5.3", default-features = false }
-tokio-timer = "0.1"
-futures-cpupool = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,6 @@
+#![deny(missing_docs, warnings, missing_debug_implementations)]
+
+//! Tower is a library of modular and reusable components for building robust networking
+//! clients and servers.
+//!
+//! This main crate is still a WIP.


### PR DESCRIPTION
This adds the initial base tower crate, as of right now it contains
nothing and is only needed to ensure that cargo workspaces can
properly compile with rust 1.32.