### PR TITLE
Add MakeConnection trait alias

### DIFF
--- a/tower-util/Cargo.toml
+++ b/tower-util/Cargo.toml
@@ -8,3 +8,4 @@ publish = false
 futures = "0.1"
 tower-service = { version = "0.2", path = "../tower-service" }
 tower-direct-service = { version = "0.1", path = "../tower-direct-service" }
+tokio-io = "0.1"

--- a/tower-util/src/lib.rs
+++ b/tower-util/src/lib.rs
@@ -2,12 +2,14 @@
 
 #[macro_use]
 extern crate futures;
+extern crate tokio_io;
 extern crate tower_direct_service;
 extern crate tower_service;
 
 pub mod boxed;
 pub mod either;
 pub mod ext;
+mod make_connection;
 mod make_service;
 pub mod option;
 mod service_fn;
@@ -15,6 +17,7 @@ mod service_fn;
 pub use boxed::BoxService;
 pub use either::EitherService;
 pub use ext::ServiceExt;
+pub use make_connection::MakeConnection;
 pub use make_service::MakeService;
 pub use option::OptionService;
 pub use service_fn::ServiceFn;

--- a/tower-util/src/make_connection.rs
+++ b/tower-util/src/make_connection.rs
@@ -1,0 +1,42 @@
+use futures::Future;
+use tokio_io::{AsyncRead, AsyncWrite};
+use tower_service::Service;
+
+/// The MakeConnection trait is used to create transports
+///
+/// The goal of this service is to allow composable methods for creating
+/// `AsyncRead + AsyncWrite` transports. This could mean creating a TLS
+/// based connection or using some other method to authenticate the connection.
+pub trait MakeConnection<Request> {
+    /// The transport provided by this service
+    type Response: AsyncRead + AsyncWrite;
+
+    /// Errors produced by the connecting service
+    type Error;
+
+    /// The future that eventually produces the transport
+    type Future: Future<Item = Self::Response, Error = Self::Error>;
+
+    /// Connect and return a transport asynchronously
+    fn make_connection(&mut self, target: Request) -> Self::Future;
+}
+
+impl<S, Request> self::sealed::Sealed<Request> for S where S: Service<Request> {}
+
+impl<C, Request> MakeConnection<Request> for C
+where
+    C: Service<Request>,
+    C::Response: AsyncRead + AsyncWrite,
+{
+    type Response = C::Response;
+    type Error = C::Error;
+    type Future = C::Future;
+
+    fn make_connection(&mut self, target: Request) -> Self::Future {
+        Service::call(self, target)
+    }
+}
+
+mod sealed {
+    pub trait Sealed<A> {}
+}


### PR DESCRIPTION
This adds a bare-bones connection creation service trait alias. The goal behind this is to allow libraries like `tower-h2`, `tower-hyper` and `tokio-tower`. To establish the underlying transport in a composable way. This also replaces https://github.com/carllerche/tokio-connect.

Example usage of this type of service alias:

https://github.com/tower-rs/tower-hyper/blob/master/src/client/connect.rs#L88

and 

https://github.com/tower-rs/tower-h2/pull/48

cc @carllerche @jonhoo 