### PR TITLE
Switch tower-buffer to use tokio-sync

### DIFF
--- a/tower-buffer/Cargo.toml
+++ b/tower-buffer/Cargo.toml
@@ -10,6 +10,7 @@ tower-service = { version = "0.2", path = "../tower-service" }
 tower-direct-service = { version = "0.1", path = "../tower-direct-service" }
 tokio-executor = "0.1"
 lazycell = "1.2"
+tokio-sync = "0.1"
 
 [dev-dependencies]
 tower-mock = { version = "0.1", path = "../tower-mock" }


### PR DESCRIPTION
Given the [performance improvements](https://github.com/tokio-rs/tokio/pull/839) in [`tokio-sync`](https://docs.rs/tokio-sync/), it seems like a good idea to switch over `tower-buffer` to use those channels instead of the implementations found in `futures::sync`, especially since none of those types are externally visible. This PR does that.