### PR TITLE
[WIP] Convert Tower's middleware to return Boxed Errors

### DIFF
--- a/tower-buffer/tests/buffer.rs
+++ b/tower-buffer/tests/buffer.rs
@@ -95,9 +95,9 @@ fn when_inner_fails() {
     ::std::thread::sleep(::std::time::Duration::from_millis(100));
     with_task(|| {
         let e = res1.poll().unwrap_err();
-        if let Error::Closed(e) = e {
+        if let Some(e) = e.downcast_ref::<ClosedError<tower_mock::Error>>() {
             assert!(format!("{:?}", e).contains("poll_ready"));
-            assert_eq!(e.error(), &tower_mock::Error::Other("foobar"));
+            // assert_eq!(e.error(), &tower_mock::Error.downcast_ref::);
         } else {
             panic!("unexpected error type: {:?}", e);
         }
@@ -129,6 +129,6 @@ fn new_service() -> (Buffer<Mock, &'static str>, Handle) {
 }
 
 fn with_task<F: FnOnce() -> U, U>(f: F) -> U {
-    use futures::future::{Future, lazy};
+    use futures::future::{lazy, Future};
     lazy(|| Ok::<_, ()>(f())).wait().unwrap()
 }

--- a/tower-buffer/tests/buffer.rs
+++ b/tower-buffer/tests/buffer.rs
@@ -97,7 +97,7 @@ fn when_inner_fails() {
         let e = res1.poll().unwrap_err();
         if let Some(e) = e.downcast_ref::<ClosedError<tower_mock::Error>>() {
             assert!(format!("{:?}", e).contains("poll_ready"));
-            // assert_eq!(e.error(), &tower_mock::Error.downcast_ref::);
+            assert_eq!(format!("{}", e.error().error()), "foobar".to_owned());
         } else {
             panic!("unexpected error type: {:?}", e);
         }

--- a/tower-mock/src/lib.rs
+++ b/tower-mock/src/lib.rs
@@ -48,10 +48,10 @@ pub struct ResponseFuture<T, E> {
     rx: oneshot::Receiver<Result<T, E>>,
 }
 
-type Error = Box<StdError + Send + Sync>;
+pub type Error = Box<StdError + Send + Sync>;
 
 #[derive(Debug, PartialEq)]
-struct ClosedError;
+pub struct ClosedError;
 
 impl StdError for ClosedError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
@@ -66,7 +66,7 @@ impl fmt::Display for ClosedError {
 }
 
 #[derive(Debug, PartialEq)]
-struct NoCapacityError;
+pub struct NoCapacityError;
 
 impl StdError for NoCapacityError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {

--- a/tower-mock/tests/mock.rs
+++ b/tower-mock/tests/mock.rs
@@ -2,9 +2,11 @@ extern crate futures;
 extern crate tower_mock;
 extern crate tower_service;
 
+use futures::Future;
+use std::error::Error as StdError;
 use tower_service::Service;
 
-use futures::Future;
+type Error = Box<StdError + Send + Sync>;
 
 #[test]
 fn single_request_ready() {
@@ -57,8 +59,8 @@ fn backpressure() {
     assert!(response.wait().is_err());
 }
 
-type Mock = tower_mock::Mock<String, String, ()>;
-type Handle = tower_mock::Handle<String, String, ()>;
+type Mock = tower_mock::Mock<String, String, Error>;
+type Handle = tower_mock::Handle<String, String, Error>;
 
 fn new_mock() -> (Mock, Handle) {
     Mock::new()
@@ -66,6 +68,6 @@ fn new_mock() -> (Mock, Handle) {
 
 // Helper to run some code within context of a task
 fn with_task<F: FnOnce() -> U, U>(f: F) -> U {
-    use futures::future::{Future, lazy};
+    use futures::future::{lazy, Future};
     lazy(|| Ok::<_, ()>(f())).wait().unwrap()
 }

--- a/tower-timeout/src/lib.rs
+++ b/tower-timeout/src/lib.rs
@@ -13,9 +13,9 @@ extern crate tokio_timer;
 
 use futures::{Future, Poll, Async};
 use tower_service::Service;
-use tokio_timer::{clock, Delay, Error as TimerError};
+use tokio_timer::{clock, Delay};
 
-use std::{error, fmt};
+use std::{error::Error, fmt};
 use std::time::Duration;
 
 /// Applies a timeout to requests.
@@ -25,21 +25,19 @@ pub struct Timeout<T> {
     timeout: Duration,
 }
 
-/// Errors produced by `Timeout`.
 #[derive(Debug)]
-pub struct Error<T>(Kind<T>);
+struct ElapsedTimer;
 
-/// Timeout error variants
-#[derive(Debug)]
-enum Kind<T> {
-    /// Inner value returned an error
-    Inner(T),
+impl Error for ElapsedTimer {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(self)
+    }
+}
 
-    /// The timeout elapsed.
-    Elapsed,
-
-    /// Timer returned an error.
-    Timer(TimerError),
+impl fmt::Display for ElapsedTimer {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Timer elapsed")
+    }
 }
 
 /// `Timeout` response future
@@ -64,15 +62,16 @@ impl<T> Timeout<T> {
 impl<S, Request> Service<Request> for Timeout<S>
 where
     S: Service<Request>,
+    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     type Response = S::Response;
-    type Error = Error<S::Error>;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
     type Future = ResponseFuture<S::Future>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         self.inner.poll_ready()
             .map_err(|e| {
-                Error(Kind::Inner(e))
+                e.into()
             })
     }
 
@@ -87,124 +86,26 @@ where
 // ===== impl ResponseFuture =====
 
 impl<T> Future for ResponseFuture<T>
-where T: Future,
+where 
+    T: Future,
+    T::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     type Item = T::Item;
-    type Error = Error<T::Error>;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         // First, try polling the future
         match self.response.poll() {
             Ok(Async::Ready(v)) => return Ok(Async::Ready(v)),
             Ok(Async::NotReady) => {}
-            Err(e) => return Err(Error(Kind::Inner(e))),
+            Err(e) => return Err(e.into()),
         }
 
         // Now check the sleep
         match self.sleep.poll() {
             Ok(Async::NotReady) => Ok(Async::NotReady),
-            Ok(Async::Ready(_)) => Err(Error(Kind::Elapsed)),
-            Err(e) => Err(Error(Kind::Timer(e))),
-        }
-    }
-}
-
-// ===== impl Error =====
-
-impl<T> fmt::Display for Error<T>
-where
-    T: fmt::Display,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.0 {
-            Kind::Inner(ref why) => fmt::Display::fmt(why, f),
-            Kind::Elapsed => f.pad("request timed out"),
-            Kind::Timer(ref why) => fmt::Display::fmt(why, f),
-        }
-    }
-}
-
-impl<T> error::Error for Error<T>
-where
-    T: error::Error + 'static,
-{
-    fn description(&self) -> &str {
-        match self.0 {
-            Kind::Inner(ref e) => e.description(),
-            Kind::Elapsed => "request timed out",
-            Kind::Timer(ref e) => e.description(),
-        }
-    }
-
-    fn source(&self) -> Option<&(error::Error + 'static)> {
-        let kind = &self.0;
-        if let Kind::Inner(ref why) = kind {
-            Some(why)
-        } else {
-            None
-        }
-    }
-}
-
-// ===== impl Error =====
-
-impl<T> Error<T> {
-    /// Create a new `Error` representing the inner value completing with `Err`.
-    pub fn inner(err: T) -> Error<T> {
-        Error(Kind::Inner(err))
-    }
-
-    /// Returns `true` if the error was caused by the inner value completing
-    /// with `Err`.
-    pub fn is_inner(&self) -> bool {
-        match self.0 {
-            Kind::Inner(_) => true,
-            _ => false,
-        }
-    }
-
-    /// Consumes `self`, returning the inner future error.
-    pub fn into_inner(self) -> Option<T> {
-        match self.0 {
-            Kind::Inner(err) => Some(err),
-            _ => None,
-        }
-    }
-
-    /// Create a new `Error` representing the inner value not completing before
-    /// the deadline is reached.
-    pub fn elapsed() -> Error<T> {
-        Error(Kind::Elapsed)
-    }
-
-    /// Returns `true` if the error was caused by the inner value not completing
-    /// before the deadline is reached.
-    pub fn is_elapsed(&self) -> bool {
-        match self.0 {
-            Kind::Elapsed => true,
-            _ => false,
-        }
-    }
-
-    /// Creates a new `Error` representing an error encountered by the timer
-    /// implementation
-    pub fn timer(err: TimerError) -> Error<T> {
-        Error(Kind::Timer(err))
-    }
-
-    /// Returns `true` if the error was caused by the timer.
-    pub fn is_timer(&self) -> bool {
-        match self.0 {
-            Kind::Timer(_) => true,
-            _ => false,
-        }
-    }
-
-    /// Consumes `self`, returning the error raised by the timer implementation.
-    pub fn into_timer(self) -> Option<TimerError> {
-        match self.0 {
-            Kind::Timer(err) => Some(err),
-            _ => None,
+            Ok(Async::Ready(_)) => Err(ElapsedTimer.into()),
+            Err(e) => Err(e.into()),
         }
     }
 }


### PR DESCRIPTION
This PR _begins_ implementation of #131, but does not finish it. So far, this PR converted:

- `tower-inflight-limit`
- `tower-rate-limit`
- `tower-timeout`

I ran into issues on the following: 

- Some middleware defines errors that have _two_ generic parameters or more than two variants. In those cases, I still think the error should be collapsed into a _single_ boxed error, but I think thee's value in preserving some form of an error type that can be downcasted. In those cases, I think the correct approach is to defined multiple _public_ error structs that an end-library user can downcast to.
- Tower Mock makes interesting uses of oneshot channels. I'm not sure what the correct approach is there (note—the WIP tower-mock commit _does not_ compile).