### PR TITLE
Require `poll_ready` to be called before `call`

### DIFF
--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -53,7 +53,6 @@ pub struct Balance<D: Discover, C> {
 pub enum Error<T, U> {
     Inner(T),
     Balance(U),
-    NotReady,
 }
 
 pub struct ResponseFuture<F: Future, E>(F, PhantomData<E>);
@@ -357,7 +356,6 @@ where
         match *self {
             Error::Inner(ref why) => fmt::Display::fmt(why, f),
             Error::Balance(ref why) => write!(f, "load balancing failed: {}", why),
-            Error::NotReady => f.pad("not ready"),
         }
     }
 }
@@ -371,7 +369,6 @@ where
         match *self {
             Error::Inner(ref why) => Some(why),
             Error::Balance(ref why) => Some(why),
-            _ => None,
         }
     }
 
@@ -379,7 +376,6 @@ where
         match *self {
             Error::Inner(_) => "inner service error",
             Error::Balance(_) => "load balancing failed",
-            Error::NotReady => "not ready",
         }
     }
 }

--- a/tower-buffer/src/lib.rs
+++ b/tower-buffer/src/lib.rs
@@ -58,8 +58,6 @@ pub enum Error<E> {
     Inner(E),
     /// The underlying `Service` failed. All subsequent requests will fail.
     Closed(Arc<ServiceError<E>>),
-    /// The underlying `Service` is currently at capacity; wait for `poll_ready`.
-    Full,
 }
 
 mod sealed {
@@ -113,7 +111,6 @@ struct State<E> {
 }
 
 enum ResponseState<T, E> {
-    Full,
     Failed(Arc<ServiceError<E>>),
     Rx(oneshot::Receiver<Result<T, Arc<ServiceError<E>>>>),
     Poll(T),
@@ -202,9 +199,7 @@ where
                         state: ResponseState::Failed(self.get_error_on_closed()),
                     }
                 } else {
-                    ResponseFuture {
-                        state: ResponseState::Full,
-                    }
+                    panic!("buffer full; poll_ready must be called first");
                 }
             }
             Ok(_) => ResponseFuture {
@@ -242,9 +237,6 @@ where
             let fut;
 
             match self.state {
-                Full => {
-                    return Err(Error::Full);
-                }
                 Failed(ref e) => {
                     return Err(Error::Closed(e.clone()));
                 }
@@ -433,7 +425,6 @@ where
         match *self {
             Error::Inner(ref why) => fmt::Display::fmt(why, f),
             Error::Closed(ref e) => write!(f, "Service::{} failed: {}", e.method, e.inner),
-            Error::Full => f.pad("Service at capacity"),
         }
     }
 }
@@ -446,7 +437,6 @@ where
         match *self {
             Error::Inner(ref why) => Some(why),
             Error::Closed(ref e) => Some(&e.inner),
-            Error::Full => None,
         }
     }
 
@@ -454,7 +444,6 @@ where
         match *self {
             Error::Inner(ref e) => e.description(),
             Error::Closed(ref e) => e.inner.description(),
-            Error::Full => "Service as capacity",
         }
     }
 }

--- a/tower-buffer/src/lib.rs
+++ b/tower-buffer/src/lib.rs
@@ -199,6 +199,13 @@ where
                         state: ResponseState::Failed(self.get_error_on_closed()),
                     }
                 } else {
+                    // When `mpsc::Sender::poll_ready` returns `Ready`, a slot
+                    // in the channel is reserved for the handle. Other `Sender`
+                    // handles may not send a message using that slot. This
+                    // guarantees capacity for `request`.
+                    //
+                    // Given this, the only way to hit this code path is if
+                    // `poll_ready` has not been called & `Ready` returned.
                     panic!("buffer full; poll_ready must be called first");
                 }
             }

--- a/tower-in-flight-limit/src/lib.rs
+++ b/tower-in-flight-limit/src/lib.rs
@@ -137,15 +137,11 @@ where
         use futures::Async::*;
 
         match self.inner.poll() {
-            Ok(Ready(v)) => {
-                Ok(Ready(v))
-            }
+            Ok(Ready(v)) => Ok(Ready(v)),
             Ok(NotReady) => {
                 return Ok(NotReady);
             }
-            Err(e) => {
-                Err(Error::Upstream(e))
-            }
+            Err(e) => Err(Error::Upstream(e)),
         }
     }
 }

--- a/tower-in-flight-limit/src/lib.rs
+++ b/tower-in-flight-limit/src/lib.rs
@@ -22,13 +22,12 @@ pub struct InFlightLimit<T> {
 /// Error returned when the service has reached its limit.
 #[derive(Debug)]
 pub enum Error<T> {
-    NoCapacity,
     Upstream(T),
 }
 
 #[derive(Debug)]
 pub struct ResponseFuture<T> {
-    inner: Option<T>,
+    inner: T,
     shared: Arc<Shared>,
 }
 
@@ -114,15 +113,12 @@ where
         } else {
             // Try to reserve
             if !self.state.shared.reserve() {
-                return ResponseFuture {
-                    inner: None,
-                    shared: self.state.shared.clone(),
-                };
+                panic!("service not ready; call poll_ready first");
             }
         }
 
         ResponseFuture {
-            inner: Some(self.inner.call(request)),
+            inner: self.inner.call(request),
             shared: self.state.shared.clone(),
         }
     }
@@ -140,35 +136,23 @@ where
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         use futures::Async::*;
 
-        let res = match self.inner {
-            Some(ref mut f) => match f.poll() {
-                Ok(Ready(v)) => {
-                    self.shared.release();
-                    Ok(Ready(v))
-                }
-                Ok(NotReady) => {
-                    return Ok(NotReady);
-                }
-                Err(e) => {
-                    self.shared.release();
-                    Err(Error::Upstream(e))
-                }
-            },
-            None => Err(Error::NoCapacity),
-        };
-
-        // Drop the inner future
-        self.inner = None;
-
-        res
+        match self.inner.poll() {
+            Ok(Ready(v)) => {
+                Ok(Ready(v))
+            }
+            Ok(NotReady) => {
+                return Ok(NotReady);
+            }
+            Err(e) => {
+                Err(Error::Upstream(e))
+            }
+        }
     }
 }
 
 impl<T> Drop for ResponseFuture<T> {
     fn drop(&mut self) {
-        if self.inner.is_some() {
-            self.shared.release();
-        }
+        self.shared.release();
     }
 }
 
@@ -238,7 +222,6 @@ where
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::Upstream(ref why) => fmt::Display::fmt(why, f),
-            Error::NoCapacity => write!(f, "in-flight limit exceeded"),
         }
     }
 }
@@ -248,17 +231,14 @@ where
     T: error::Error,
 {
     fn cause(&self) -> Option<&error::Error> {
-        if let Error::Upstream(ref why) = *self {
-            Some(why)
-        } else {
-            None
+        match *self {
+            Error::Upstream(ref why) => Some(why),
         }
     }
 
     fn description(&self) -> &str {
         match *self {
             Error::Upstream(_) => "upstream service error",
-            Error::NoCapacity => "in-flight limit exceeded",
         }
     }
 }

--- a/tower-in-flight-limit/tests/in_flight_limit.rs
+++ b/tower-in-flight-limit/tests/in_flight_limit.rs
@@ -68,6 +68,7 @@ fn basic_service_limit_functionality_with_poll_ready() {
 }
 
 #[test]
+#[should_panic]
 fn basic_service_limit_functionality_without_poll_ready() {
     let mut task = MockTask::new();
 
@@ -112,6 +113,7 @@ fn basic_service_limit_functionality_without_poll_ready() {
 }
 
 #[test]
+#[should_panic]
 fn request_without_capacity() {
     let mut task = MockTask::new();
 

--- a/tower-mock/tests/mock.rs
+++ b/tower-mock/tests/mock.rs
@@ -35,6 +35,7 @@ fn single_request_ready() {
 }
 
 #[test]
+#[should_panic]
 fn backpressure() {
     let (mut mock, mut handle) = new_mock();
 
@@ -46,15 +47,7 @@ fn backpressure() {
     });
 
     // Try to send a request
-    let response = mock.call("hello?".into());
-
-    // Did not send
-    with_task(|| {
-        assert!(handle.poll_request().unwrap().is_not_ready());
-    });
-
-    // Response is an error
-    assert!(response.wait().is_err());
+    mock.call("hello?".into());
 }
 
 type Mock = tower_mock::Mock<String, String, ()>;

--- a/tower-rate-limit/tests/rate_limit.rs
+++ b/tower-rate-limit/tests/rate_limit.rs
@@ -28,7 +28,8 @@ fn reaching_capacity() {
     rt.block_on(future::lazy(|| {
         assert!(service.poll_ready().unwrap().is_not_ready());
         Ok::<_, ()>(())
-    })).unwrap();
+    }))
+    .unwrap();
 
     let poll_request = rt.block_on(future::lazy(|| handle.poll_request()));
     assert!(poll_request.unwrap().is_not_ready());

--- a/tower-rate-limit/tests/rate_limit.rs
+++ b/tower-rate-limit/tests/rate_limit.rs
@@ -25,14 +25,10 @@ fn reaching_capacity() {
     let response = rt.block_on(response);
     assert_eq!(response.unwrap(), "world");
 
-    // Sending another request is rejected
-    let response = service.call("no");
-
-    let poll_request = rt.block_on(future::lazy(|| handle.poll_request()));
-    assert!(poll_request.unwrap().is_not_ready());
-
-    let response = rt.block_on(response);
-    assert!(response.is_err());
+    rt.block_on(future::lazy(|| {
+        assert!(service.poll_ready().unwrap().is_not_ready());
+        Ok::<_, ()>(())
+    })).unwrap();
 
     let poll_request = rt.block_on(future::lazy(|| handle.poll_request()));
     assert!(poll_request.unwrap().is_not_ready());


### PR DESCRIPTION
This updates the `Service` contract requiring `poll_ready` to be called
before `call`. This allows `Service::call` to panic in the event the
user of the service omits `poll_ready` or does not wait until `Ready` is
observed.