### PR TITLE
Add Extra for MakeConnection

### DIFF
--- a/tower-util/src/make_connection.rs
+++ b/tower-util/src/make_connection.rs
@@ -29,7 +29,7 @@ impl<S, Request> self::sealed::Sealed<Request> for S where S: Service<Request> {
 impl<C, Request, Response, Extra> MakeConnection<Request> for C
 where
     C: Service<Request, Response = (Response, Extra)>,
-    Response: AsyncRead + AsyncWrite
+    Response: AsyncRead + AsyncWrite,
 {
     type Response = Response;
     type Extra = Extra;


### PR DESCRIPTION
This PR adds an `Extra` associated type to `MakeConnection`. This allows `Connector` to pass some extra information, like ALPN.

see https://github.com/tower-rs/tower-hyper/issues/9