### PR TITLE
Add hedge retry middleware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "tower-buffer",
   "tower-discover",
   "tower-filter",
+  "tower-hedge",
   "tower-in-flight-limit",
   "tower-mock",
   "tower-layer",

--- a/tower-hedge/Cargo.toml
+++ b/tower-hedge/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tower-hedge"
+version = "0.1.0"
+authors = ["Alex Leong <adlleong@gmail.com>"]
+publish = false
+
+[dependencies]
+futures = "0.1"
+hdrhistogram = "6.0"
+log = "0.4.1"
+tower-service = "0.2.0"
+tower-retry = { version = "0.1", path = "../tower-retry" }
+tokio-mock-task = { git = "https://github.com/carllerche/tokio-mock-task" }
+tokio-timer = "0.2.6"
+
+[dev-dependencies]
+tower-mock = { version = "0.1", path = "../tower-mock" }
+tokio-executor = "0.1.2"

--- a/tower-hedge/Cargo.toml
+++ b/tower-hedge/Cargo.toml
@@ -9,7 +9,6 @@ futures = "0.1"
 hdrhistogram = "6.0"
 log = "0.4.1"
 tower-service = "0.2.0"
-tower-retry = { version = "0.1", path = "../tower-retry" }
 tokio-mock-task = { git = "https://github.com/carllerche/tokio-mock-task" }
 tokio-timer = "0.2.6"
 

--- a/tower-hedge/src/lib.rs
+++ b/tower-hedge/src/lib.rs
@@ -1,0 +1,246 @@
+#[macro_use]
+extern crate futures;
+extern crate hdrhistogram;
+#[macro_use]
+extern crate log;
+extern crate tokio_timer;
+extern crate tower_service;
+
+use futures::{Async, Future, Poll};
+use hdrhistogram::Histogram;
+use tokio_timer::{clock, Delay};
+use tower_service::Service;
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+mod rotating;
+
+use rotating::Rotating;
+
+/// A "retry policy" to classify if a request should be pre-emptively retried.
+pub trait Policy<Request>: Sized {
+    /// Check the policy if a certain request should be pre-emptively retried.
+    ///
+    /// This method is passed a reference to the original request.
+    fn can_retry(&self, req: &Request) -> bool;
+    /// Tries to clone a request before being passed to the inner service.
+    ///
+    /// If the request cannot be cloned, return `None`.
+    fn clone_request(&self, req: &Request) -> Option<Request>;
+}
+
+/// A middleware that pre-emptively retries requests which have been outstanding
+/// for longer than a given latency percentile.  If either of the original
+/// future or the retry future completes, that value is used.
+#[derive(Clone)]
+pub struct Hedge<P, S> {
+    policy: P,
+    service: S,
+    latency_percentile: f32,
+    /// Only retry if there are at least this many data points in the histogram.
+    min_data_points: u64,
+    /// A rotating histogram is used to track response latency.
+    pub latency_histogram: Arc<Mutex<Rotating<Histogram<u64>>>>,
+}
+
+/// The Future returned by the Hedge service.
+pub struct ResponseFuture<P, S, Request>
+where
+    P: Policy<Request>,
+    S: Service<Request>,
+{
+    /// If the request was clonable, a clone is stored.
+    request: Option<Request>,
+    /// The time of the original call to the inner service.  Used to calculate
+    /// response latency.
+    start: Instant,
+    hedge: Hedge<P, S>,
+    orig_fut: S::Future,
+    hedge_fut: Option<S::Future>,
+    /// A future representing when to start the hedge request.
+    delay: Option<Delay>,
+}
+
+// ===== impl Hedge =====
+
+impl<P, S> Hedge<P, S> {
+    pub fn new<Request>(
+        policy: P,
+        service: S,
+        latency_percentile: f32,
+        rotation_period: Duration,
+        min_data_points: u64,
+    ) -> Self
+    where
+        P: Policy<Request> + Clone,
+        S: Service<Request>,
+    {
+        let new: fn() -> Histogram<u64> = || {
+            Histogram::<u64>::new_with_bounds(1, 10_000, 3).expect("Invalid histogram params")
+        };
+        let latency_histogram = Arc::new(Mutex::new(Rotating::new(rotation_period, new)));
+        Hedge {
+            policy,
+            service,
+            latency_percentile,
+            min_data_points,
+            latency_histogram,
+        }
+    }
+
+    /// Record the latency of a completed request in the latency histogram.
+    fn record(&self, start: Instant) {
+        let duration = clock::now() - start;
+        let mut locked = self.latency_histogram.lock().unwrap();
+        locked.write().record(Self::as_millis(duration)).unwrap_or_else(|e| {
+            error!("Failed to write to hedge histogram: {:?}", e);
+        });
+    }
+
+    // TODO: Remove when Duration::as_millis() becomes stable.
+    fn as_millis(d: Duration) -> u64 {
+        d.as_secs() * 1_000 + d.subsec_millis() as u64
+    }
+}
+
+impl<P, S, Request> Service<Request> for Hedge<P, S>
+where
+    P: Policy<Request> + Clone,
+    S: Service<Request> + Clone,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ResponseFuture<P, S, Request>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.service.poll_ready()
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let cloned = self.policy.clone_request(&request);
+        let orig_fut = self.service.call(request);
+
+        let start = clock::now();
+        // Find the nth percentile latency from the read side of the histogram.
+        // Requests which take longer than this will be pre-emptively retried.
+        let mut histo = self.latency_histogram.lock().unwrap();
+        // TODO: Consider adding a minimum delay for hedge requests (perhaps as
+        // a factor of the p50 latency).
+
+        // We will only issue a hedge request if there are sufficiently many
+        // data points in the histogram to give us confidence about the
+        // distribution.
+        let read = histo.read();
+        let delay = if read.len() < self.min_data_points {
+            trace!("Not enough data points to determine hedge timeout.  Have {}, need {}", 
+                read.len(),
+                self.min_data_points
+            );
+            None
+        } else {
+            let hedge_timeout = read.value_at_quantile(self.latency_percentile.into());
+            trace!("Issuing request with hedge timeout of {}ms", hedge_timeout);
+            Some(Delay::new(start + Duration::from_millis(hedge_timeout)))
+        };
+
+        ResponseFuture {
+            request: cloned,
+            start,
+            hedge: self.clone(),
+            orig_fut,
+            hedge_fut: None,
+            delay,
+        }
+    }
+}
+
+// ===== impl ResponseFuture =====
+
+impl<P, S, Request> Future for ResponseFuture<P, S, Request>
+where
+    P: Policy<Request> + Clone,
+    S: Service<Request> + Clone,
+{
+    type Item = S::Response;
+    type Error = S::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        loop {
+            // If the original future is complete, return its result.
+            match self.orig_fut.poll() {
+                Ok(Async::Ready(rsp)) => {
+                    self.hedge.record(self.start);
+                    return Ok(Async::Ready(rsp));
+                }
+                Ok(Async::NotReady) => {}
+                Err(e) => {
+                    self.hedge.record(self.start);;
+                    return Err(e);
+                }
+            }
+
+            if let Some(ref mut hedge_fut) = self.hedge_fut {
+                // If the hedge future exists, return its result.
+                let p = hedge_fut.poll();
+                if let Ok(ref a) = p {
+                    if a.is_ready() {
+                        trace!("Hedge request complete after {:?}", clock::now() - self.start);
+                        self.hedge.record(self.start);
+                    }
+                }
+                return p;
+            }
+            // Original future is pending, but hedge hasn't started.  Check
+            // the delay.
+            let delay = match self.delay.as_mut() {
+                Some(d) => d,
+                // No delay, can't retry.
+                None => return Ok(Async::NotReady),
+            };
+            match delay.poll() {
+                Ok(Async::Ready(_)) => {
+                    try_ready!(self.hedge.poll_ready());
+                    if let Some(req) = self.request.take() {
+                        if self.hedge.policy.can_retry(&req) {
+                            // Start the hedge request.
+                            trace!("Issuing hedge request after {:?}", clock::now() - self.start);
+                            self.request = self.hedge.policy.clone_request(&req);
+                            self.hedge_fut = Some(self.hedge.service.call(req));
+                        } else {
+                            // Policy says we can't retry.
+                            // Put the taken request back.
+                            trace!("Hedge timeout reached, but unable to retry due to policy");
+                            self.request = Some(req);
+                            return Ok(Async::NotReady);
+                        }
+                    } else {
+                        // No cloned request, can't retry.
+                        trace!("Hedge timeout reached, but unable to retry because request is not clonable");
+                        return Ok(Async::NotReady);
+                    }
+                }
+                Ok(Async::NotReady) => return Ok(Async::NotReady), // Not time to retry yet.
+                Err(e) => {
+                    // Timer error, don't retry.
+                    error!("Timer error: {:?}", e);
+                    return Ok(Async::NotReady);
+                },
+            }
+        }
+    }
+}
+
+// ===== impl Histogram =====
+
+impl rotating::Clear for Histogram<u64> {
+    fn clear(&mut self) {
+        Histogram::clear(self);
+    }
+}
+
+impl rotating::Size for Histogram<u64> {
+    fn size(&self) -> u64 {
+        self.len()
+    }
+}

--- a/tower-hedge/src/rotating.rs
+++ b/tower-hedge/src/rotating.rs
@@ -39,8 +39,8 @@ impl<T: Clear + Size> Rotating<T> {
     fn maybe_rotate(&mut self) {
         let delta = clock::now() - self.last_rotation;
         // TODO: replace with delta.duration_div when it becomes stable.
-        let rotations = (Self::duration_as_nanos(&delta) /
-                             Self::duration_as_nanos(&self.period)) as u32;
+        let rotations =
+            (Self::duration_as_nanos(&delta) / Self::duration_as_nanos(&self.period)) as u32;
         if rotations >= 2 {
             trace!("Time since last rotation is {:?}.  clearing!", delta);
             self.clear();

--- a/tower-hedge/src/rotating.rs
+++ b/tower-hedge/src/rotating.rs
@@ -1,0 +1,77 @@
+extern crate tokio_timer;
+
+use std::time::{Duration, Instant};
+
+use tokio_timer::clock;
+
+/// This represents a "rotating" value which stores two T values, one which
+/// should be read and one which should be written to.  Every period, the
+/// read T is discarded and replaced by the write T.  The idea here is that
+/// the read T should always contain a full period (the previous period) of
+/// write operations.
+pub struct Rotating<T> {
+    read: T,
+    write: T,
+    last_rotation: Instant,
+    period: Duration,
+}
+
+impl<T: Clear + Size> Rotating<T> {
+
+    pub fn new(period: Duration, new: fn() -> T) -> Rotating<T> {
+        Rotating {
+            read: new(),
+            write: new(),
+            last_rotation: clock::now(),
+            period,
+        }
+    }
+
+    pub fn read(&mut self) -> &mut T {
+        self.maybe_rotate();
+        &mut self.read
+    }
+
+    pub fn write(&mut self) -> &mut T {
+        self.maybe_rotate();
+        &mut self.write
+    }
+
+    fn maybe_rotate(&mut self) {
+        let delta = clock::now() - self.last_rotation;
+        // TODO: replace with delta.duration_div when it becomes stable.
+        let rotations = (Self::duration_as_nanos(&delta) / Self::duration_as_nanos(&self.period)) as u32;
+        if rotations >= 2 {
+            trace!("Time since last rotation is {:?}.  clearing!", delta);
+            self.clear();
+        } else if rotations == 1 {
+            trace!("Time since last rotation is {:?}. rotating!", delta);
+            self.rotate();
+        }
+        self.last_rotation += self.period * rotations;
+    }
+
+    fn rotate(&mut self) {
+        std::mem::swap(&mut self.read, &mut self.write);
+        trace!("Rotated {:?} points into read", self.read.size());
+        self.write.clear();
+    }
+
+    fn clear(&mut self) {
+        self.read.clear();
+        self.write.clear();
+    }
+
+    fn duration_as_nanos(d: &Duration) -> u64 {
+        d.as_secs() * 1_000_000_000 + (d.subsec_nanos() as u64)
+    }
+
+}
+
+pub trait Clear {
+    fn clear(&mut self);
+}
+
+pub trait Size {
+    fn size(&self) -> u64;
+}

--- a/tower-hedge/src/rotating.rs
+++ b/tower-hedge/src/rotating.rs
@@ -17,7 +17,6 @@ pub struct Rotating<T> {
 }
 
 impl<T: Clear + Size> Rotating<T> {
-
     pub fn new(period: Duration, new: fn() -> T) -> Rotating<T> {
         Rotating {
             read: new(),
@@ -40,7 +39,8 @@ impl<T: Clear + Size> Rotating<T> {
     fn maybe_rotate(&mut self) {
         let delta = clock::now() - self.last_rotation;
         // TODO: replace with delta.duration_div when it becomes stable.
-        let rotations = (Self::duration_as_nanos(&delta) / Self::duration_as_nanos(&self.period)) as u32;
+        let rotations = (Self::duration_as_nanos(&delta) /
+                             Self::duration_as_nanos(&self.period)) as u32;
         if rotations >= 2 {
             trace!("Time since last rotation is {:?}.  clearing!", delta);
             self.clear();
@@ -65,7 +65,6 @@ impl<T: Clear + Size> Rotating<T> {
     fn duration_as_nanos(d: &Duration) -> u64 {
         d.as_secs() * 1_000_000_000 + (d.subsec_nanos() as u64)
     }
-
 }
 
 pub trait Clear {

--- a/tower-hedge/tests/hedge.rs
+++ b/tower-hedge/tests/hedge.rs
@@ -1,0 +1,182 @@
+extern crate futures;
+extern crate tokio_executor;
+extern crate tokio_mock_task;
+extern crate tokio_timer;
+extern crate tower_hedge as hedge;
+extern crate tower_mock;
+extern crate tower_service;
+
+#[macro_use]
+mod support;
+use support::*;
+
+use futures::Future;
+use hedge::Policy;
+use tower_service::Service;
+
+use std::time::Duration;
+
+#[test]
+fn hedge_orig_completes_first() {
+    let (mut service, mut handle) = new_service(TestPolicy);
+
+    mocked(|timer, _| {
+        let mut fut = service.call("orig");
+        // Check that orig request has been issued.
+        let req = handle.next_request().expect("orig");
+        // Check fut is not ready.
+        assert!(fut.poll().unwrap().is_not_ready());
+
+        // Check hedge has not been issued.
+        assert!(handle.poll_request().unwrap().is_not_ready());
+        advance(timer, ms(10));
+        // Check fut is not ready.
+        assert!(fut.poll().unwrap().is_not_ready());
+        // Check that the hedge has been issued.
+        let _hedge_req = handle.next_request().expect("hedge");
+
+        req.respond("orig-done");
+        // Check that fut gets orig response.
+        assert_eq!(fut.wait().unwrap(), "orig-done");
+    });
+}
+
+#[test]
+fn hedge_hedge_completes_first() {
+    let (mut service, mut handle) = new_service(TestPolicy);
+
+    mocked(|timer, _| {
+        let mut fut = service.call("orig");
+        // Check that orig request has been issued.
+        let _req = handle.next_request().expect("orig");
+        // Check fut is not ready.
+        assert!(fut.poll().unwrap().is_not_ready());
+
+        // Check hedge has not been issued.
+        assert!(handle.poll_request().unwrap().is_not_ready());
+        advance(timer, ms(10));
+        // Check fut is not ready.
+        assert!(fut.poll().unwrap().is_not_ready());
+
+        // Check that the hedge has been issued.
+        let hedge_req = handle.next_request().expect("hedge");
+        hedge_req.respond("hedge-done");
+        // Check that fut gets hedge response.
+        assert_eq!(fut.wait().unwrap(), "hedge-done");
+    });
+}
+
+#[test]
+fn completes_before_hedge() {
+    let (mut service, mut handle) = new_service(TestPolicy);
+
+    mocked(|_, _| {
+        let mut fut = service.call("orig");
+        // Check that orig request has been issued.
+        let req = handle.next_request().expect("orig");
+        // Check fut is not ready.
+        assert!(fut.poll().unwrap().is_not_ready());
+
+        req.respond("orig-done");
+        // Check hedge has not been issued.
+        assert!(handle.poll_request().unwrap().is_not_ready());
+        // Check that fut gets orig response.
+        assert_eq!(fut.wait().unwrap(), "orig-done");
+    });
+}
+
+#[test]
+fn request_not_retyable() {
+    let (mut service, mut handle) = new_service(TestPolicy);
+
+    mocked(|timer, _| {
+        let mut fut = service.call(NOT_RETRYABLE);
+        // Check that orig request has been issued.
+        let req = handle.next_request().expect("orig");
+        // Check fut is not ready.
+        assert!(fut.poll().unwrap().is_not_ready());
+
+        // Check hedge has not been issued.
+        assert!(handle.poll_request().unwrap().is_not_ready());
+        advance(timer, ms(10));
+        // Check fut is not ready.
+        assert!(fut.poll().unwrap().is_not_ready());
+        // Check hedge has not been issued.
+        assert!(handle.poll_request().unwrap().is_not_ready());
+
+        req.respond("orig-done");
+        // Check that fut gets orig response.
+        assert_eq!(fut.wait().unwrap(), "orig-done");
+    });
+}
+
+#[test]
+fn request_not_clonable() {
+    let (mut service, mut handle) = new_service(TestPolicy);
+
+    mocked(|timer, _| {
+        let mut fut = service.call(NOT_CLONABLE);
+        // Check that orig request has been issued.
+        let req = handle.next_request().expect("orig");
+        // Check fut is not ready.
+        assert!(fut.poll().unwrap().is_not_ready());
+
+        // Check hedge has not been issued.
+        assert!(handle.poll_request().unwrap().is_not_ready());
+        advance(timer, ms(10));
+        // Check fut is not ready.
+        assert!(fut.poll().unwrap().is_not_ready());
+        // Check hedge has not been issued.
+        assert!(handle.poll_request().unwrap().is_not_ready());
+
+        req.respond("orig-done");
+        // Check that fut gets orig response.
+        assert_eq!(fut.wait().unwrap(), "orig-done");
+    });
+}
+
+type Req = &'static str;
+type Res = &'static str;
+type Mock = tower_mock::Mock<Req, Res>;
+type Handle = tower_mock::Handle<Req, Res>;
+
+static NOT_RETRYABLE: &'static str = "NOT_RETRYABLE";
+static NOT_CLONABLE: &'static str = "NOT_CLONABLE";
+
+#[derive(Clone)]
+struct TestPolicy;
+
+impl Policy<Req> for TestPolicy {
+    fn can_retry(&self, req: &Req) -> bool {
+        *req != NOT_RETRYABLE
+    }
+
+    fn clone_request(&self, req: &Req) -> Option<Req> {
+        if *req == NOT_CLONABLE {
+            None
+        } else {
+            Some(req)
+        }
+    }
+}
+
+fn new_service<P: Policy<Req> + Clone>(policy: P) -> (hedge::Hedge<P, Mock>, Handle) {
+    let (service, handle) = Mock::new();
+    let mut service = hedge::Hedge::new(policy, service, 0.9, Duration::from_secs(60), 10);
+    populate_histogram(&mut service);
+    (service, handle)
+}
+
+fn populate_histogram<P: Policy<Req> + Clone>(service: &mut hedge::Hedge<P, Mock>) {
+    // Writing directly to the read histogram isn't typical usage but we do it
+    // here to populate the read histogram directly so that we don't have to
+    // wait for a rotation.
+    let mut histo = service.latency_histogram.lock().unwrap();
+
+    for _ in 0..8 {
+        histo.read().record(1).unwrap();
+    }
+    for _ in 8..10 {
+        histo.read().record(10).unwrap();
+    }
+}

--- a/tower-hedge/tests/support/mod.rs
+++ b/tower-hedge/tests/support/mod.rs
@@ -1,0 +1,264 @@
+// Shamelessly copied verbatim from
+// https://github.com/tokio-rs/tokio/blob/master/tokio-timer/tests/support/mod.rs
+
+#![allow(unused_macros, unused_imports, dead_code, deprecated)]
+
+use tokio_executor::park::{Park, Unpark};
+use tokio_timer::clock::Now;
+use tokio_timer::timer::Timer;
+
+use futures::future::{lazy, Future};
+
+use std::marker::PhantomData;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+macro_rules! assert_ready {
+    ($f:expr) => {{
+        use ::futures::Async::*;
+
+        match $f.poll().unwrap() {
+            Ready(v) => v,
+            NotReady => panic!("NotReady"),
+        }
+    }};
+    ($f:expr, $($msg:expr),+) => {{
+        use ::futures::Async::*;
+
+        match $f.poll().unwrap() {
+            Ready(v) => v,
+            NotReady => {
+                let msg = format!($($msg),+);
+                panic!("NotReady; {}", msg)
+            }
+        }
+    }}
+}
+
+macro_rules! assert_ready_eq {
+    ($f:expr, $expect:expr) => {
+        assert_eq!($f.poll().unwrap(), ::futures::Async::Ready($expect));
+    };
+}
+
+macro_rules! assert_not_ready {
+    ($f:expr) => {{
+        let res = $f.poll().unwrap();
+        assert!(!res.is_ready(), "actual={:?}", res)
+    }};
+    ($f:expr, $($msg:expr),+) => {{
+        let res = $f.poll().unwrap();
+        if res.is_ready() {
+            let msg = format!($($msg),+);
+            panic!("actual={:?}; {}", res, msg);
+        }
+    }};
+}
+
+macro_rules! assert_elapsed {
+    ($f:expr) => {
+        assert!($f.poll().unwrap_err().is_elapsed());
+    };
+}
+
+#[derive(Debug)]
+pub struct MockTime {
+    inner: Inner,
+    _p: PhantomData<Rc<()>>,
+}
+
+#[derive(Debug)]
+pub struct MockNow {
+    inner: Inner,
+}
+
+#[derive(Debug)]
+pub struct MockPark {
+    inner: Inner,
+    _p: PhantomData<Rc<()>>,
+}
+
+#[derive(Debug)]
+pub struct MockUnpark {
+    inner: Inner,
+}
+
+type Inner = Arc<Mutex<State>>;
+
+#[derive(Debug)]
+struct State {
+    base: Instant,
+    advance: Duration,
+    unparked: bool,
+    park_for: Option<Duration>,
+}
+
+pub fn ms(num: u64) -> Duration {
+    Duration::from_millis(num)
+}
+
+pub trait IntoTimeout {
+    fn into_timeout(self) -> Option<Duration>;
+}
+
+impl IntoTimeout for Option<Duration> {
+    fn into_timeout(self) -> Self {
+        self
+    }
+}
+
+impl IntoTimeout for Duration {
+    fn into_timeout(self) -> Option<Duration> {
+        Some(self)
+    }
+}
+
+/// Turn the timer state once
+pub fn turn<T: IntoTimeout>(timer: &mut Timer<MockPark>, duration: T) {
+    timer.turn(duration.into_timeout()).unwrap();
+}
+
+/// Advance the timer the specified amount
+pub fn advance(timer: &mut Timer<MockPark>, duration: Duration) {
+    let inner = timer.get_park().inner.clone();
+    let deadline = inner.lock().unwrap().now() + duration;
+
+    while inner.lock().unwrap().now() < deadline {
+        let dur = deadline - inner.lock().unwrap().now();
+        turn(timer, dur);
+    }
+}
+
+pub fn mocked<F, R>(f: F) -> R
+where
+    F: FnOnce(&mut Timer<MockPark>, &mut MockTime) -> R,
+{
+    mocked_with_now(Instant::now(), f)
+}
+
+pub fn mocked_with_now<F, R>(now: Instant, f: F) -> R
+where
+    F: FnOnce(&mut Timer<MockPark>, &mut MockTime) -> R,
+{
+    let mut time = MockTime::new(now);
+    let park = time.mock_park();
+    let now = ::tokio_timer::clock::Clock::new_with_now(time.mock_now());
+
+    let mut enter = ::tokio_executor::enter().unwrap();
+
+    ::tokio_timer::clock::with_default(&now, &mut enter, |enter| {
+        let mut timer = Timer::new(park);
+        let handle = timer.handle();
+
+        ::tokio_timer::with_default(&handle, enter, |_| {
+            lazy(|| Ok::<_, ()>(f(&mut timer, &mut time)))
+                .wait()
+                .unwrap()
+        })
+    })
+}
+
+impl MockTime {
+    pub fn new(now: Instant) -> MockTime {
+        let state = State {
+            base: now,
+            advance: Duration::default(),
+            unparked: false,
+            park_for: None,
+        };
+
+        MockTime {
+            inner: Arc::new(Mutex::new(state)),
+            _p: PhantomData,
+        }
+    }
+
+    pub fn mock_now(&self) -> MockNow {
+        let inner = self.inner.clone();
+        MockNow { inner }
+    }
+
+    pub fn mock_park(&self) -> MockPark {
+        let inner = self.inner.clone();
+        MockPark {
+            inner,
+            _p: PhantomData,
+        }
+    }
+
+    pub fn now(&self) -> Instant {
+        self.inner.lock().unwrap().now()
+    }
+
+    /// Returns the total amount of time the time has been advanced.
+    pub fn advanced(&self) -> Duration {
+        self.inner.lock().unwrap().advance
+    }
+
+    pub fn advance(&self, duration: Duration) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.advance(duration);
+    }
+
+    /// The next call to park_timeout will be for this duration, regardless of
+    /// the timeout passed to `park_timeout`.
+    pub fn park_for(&self, duration: Duration) {
+        self.inner.lock().unwrap().park_for = Some(duration);
+    }
+}
+
+impl Park for MockPark {
+    type Unpark = MockUnpark;
+    type Error = ();
+
+    fn unpark(&self) -> Self::Unpark {
+        let inner = self.inner.clone();
+        MockUnpark { inner }
+    }
+
+    fn park(&mut self) -> Result<(), Self::Error> {
+        let mut inner = self.inner.lock().map_err(|_| ())?;
+
+        let duration = inner.park_for.take().expect("call park_for first");
+
+        inner.advance(duration);
+        Ok(())
+    }
+
+    fn park_timeout(&mut self, duration: Duration) -> Result<(), Self::Error> {
+        let mut inner = self.inner.lock().unwrap();
+
+        if let Some(duration) = inner.park_for.take() {
+            inner.advance(duration);
+        } else {
+            inner.advance(duration);
+        }
+
+        Ok(())
+    }
+}
+
+impl Unpark for MockUnpark {
+    fn unpark(&self) {
+        if let Ok(mut inner) = self.inner.lock() {
+            inner.unparked = true;
+        }
+    }
+}
+
+impl Now for MockNow {
+    fn now(&self) -> Instant {
+        self.inner.lock().unwrap().now()
+    }
+}
+
+impl State {
+    fn now(&self) -> Instant {
+        self.base + self.advance
+    }
+
+    fn advance(&mut self, duration: Duration) {
+        self.advance += duration;
+    }
+}


### PR DESCRIPTION
Add tower-hedge, a middleware that pre-emptively retries requests which have been outstanding for longer than a given latency percentile.  If either of the original future or the retry future completes, that value is used.  For more information about hedge requests, see: [The Tail at Scale](https://cseweb.ucsd.edu/~gmporter/classes/fa17/cse124/post/schedule/p74-dean.pdf)

Signed-off-by: Alex Leong <alex@buoyant.io>