### PR TITLE
buffer: switch to TypedExecutor

### DIFF
--- a/tower-buffer/Cargo.toml
+++ b/tower-buffer/Cargo.toml
@@ -5,11 +5,11 @@ authors = ["Carl Lerche <me@carllerche.com>"]
 publish = false
 
 [dependencies]
-futures = "0.1"
+futures = "0.1.25"
 tower-service = "0.2.0"
 tower-layer = { version = "0.1", path = "../tower-layer" }
-tokio-executor = "0.1"
-tokio-sync = "0.1"
+tokio-executor = "0.1.7"
+tokio-sync = "0.1.0"
 
 [dev-dependencies]
 tower-mock = { version = "0.1", path = "../tower-mock" }

--- a/tower-buffer/src/worker.rs
+++ b/tower-buffer/src/worker.rs
@@ -1,8 +1,8 @@
 use error::{Closed, Error, ServiceError, SpawnError};
-use futures::future::Executor;
 use futures::{Async, Future, Poll, Stream};
 use message::Message;
 use std::sync::{Arc, Mutex};
+use tokio_executor::TypedExecutor;
 use tokio_sync::mpsc;
 use tower_service::Service;
 
@@ -33,14 +33,14 @@ pub(crate) struct Handle {
 
 /// This trait allows you to use either Tokio's threaded runtime's executor or the `current_thread`
 /// runtime's executor depending on if `T` is `Send` or `!Send`.
-pub trait WorkerExecutor<T, Request>: Executor<Worker<T, Request>>
+pub trait WorkerExecutor<T, Request>: TypedExecutor<Worker<T, Request>>
 where
     T: Service<Request>,
     T::Error: Into<Error>,
 {
 }
 
-impl<T, Request, E: Executor<Worker<T, Request>>> WorkerExecutor<T, Request> for E
+impl<T, Request, E: TypedExecutor<Worker<T, Request>>> WorkerExecutor<T, Request> for E
 where
     T: Service<Request>,
     T::Error: Into<Error>,
@@ -55,7 +55,7 @@ where
     pub(crate) fn spawn<E>(
         service: T,
         rx: mpsc::Receiver<Message<Request, T::Future>>,
-        executor: &E,
+        executor: &mut E,
     ) -> Result<Handle, Error>
     where
         E: WorkerExecutor<T, Request>,
@@ -73,7 +73,7 @@ where
             handle: handle.clone(),
         };
 
-        match executor.execute(worker) {
+        match executor.spawn(worker) {
             Ok(()) => Ok(handle),
             Err(_) => Err(SpawnError::new().into()),
         }

--- a/tower-buffer/tests/buffer.rs
+++ b/tower-buffer/tests/buffer.rs
@@ -5,7 +5,7 @@ extern crate tower_mock;
 extern crate tower_service;
 
 use futures::prelude::*;
-use tokio_executor::{TypedExecutor, SpawnError};
+use tokio_executor::{SpawnError, TypedExecutor};
 use tower_buffer::*;
 use tower_service::*;
 


### PR DESCRIPTION
Switch tower-buffer to use `TypedExecutor`.

For better or for worse (which is TBD), `TypedExecutor` takes `&mut self`. This makes things a bit trickier in the layer impl, because `layer` takes `&self`.

To work around this, `Layer` now requires the executor to also be `Clone`.

Perhaps having `TypedExecutor` take `&mut self` is not the right choice. However, its been pushed to crates.io and `tokio_executor::Executor`, which has been around for a while also takes `&mut self`.