### PR TITLE
Move misc types

### DIFF
--- a/tower-util/src/lib.rs
+++ b/tower-util/src/lib.rs
@@ -14,6 +14,7 @@ mod either;
 #[cfg(feature = "io")]
 mod make_connection;
 mod make_service;
+mod oneshot;
 mod option;
 mod sealed;
 mod service_fn;
@@ -25,6 +26,7 @@ pub use crate::either::EitherService;
 #[cfg(feature = "io")]
 pub use crate::make_connection::MakeConnection;
 pub use crate::make_service::MakeService;
+pub use crate::oneshot::Oneshot;
 pub use crate::option::OptionService;
 pub use crate::service_fn::ServiceFn;
 

--- a/tower-util/src/lib.rs
+++ b/tower-util/src/lib.rs
@@ -2,6 +2,7 @@
 
 #[cfg(feature = "either")]
 extern crate either as _either;
+#[macro_use]
 extern crate futures;
 #[cfg(feature = "io")]
 extern crate tokio_io;
@@ -16,6 +17,7 @@ mod make_connection;
 mod make_service;
 mod oneshot;
 mod option;
+mod ready;
 mod sealed;
 mod service_fn;
 
@@ -28,6 +30,7 @@ pub use crate::make_connection::MakeConnection;
 pub use crate::make_service::MakeService;
 pub use crate::oneshot::Oneshot;
 pub use crate::option::OptionService;
+pub use crate::ready::Ready;
 pub use crate::service_fn::ServiceFn;
 
 pub mod error {

--- a/tower-util/src/oneshot.rs
+++ b/tower-util/src/oneshot.rs
@@ -20,7 +20,7 @@ impl<S, Req> Oneshot<S, Req>
 where
     S: Service<Req>,
 {
-    pub(super) fn new(svc: S, req: Req) -> Self {
+    pub fn new(svc: S, req: Req) -> Self {
         Oneshot {
             state: State::NotReady(svc, req),
         }

--- a/tower-util/src/ready.rs
+++ b/tower-util/src/ready.rs
@@ -16,7 +16,7 @@ impl<T, Request> Ready<T, Request>
 where
     T: Service<Request>,
 {
-    pub(super) fn new(service: T) -> Self {
+    pub fn new(service: T) -> Self {
         Ready {
             inner: Some(service),
             _p: PhantomData,

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -5,7 +5,6 @@ mod apply;
 mod from_err;
 mod map;
 mod map_err;
-mod ready;
 mod then;
 
 pub use self::and_then::AndThen;
@@ -13,7 +12,6 @@ pub use self::apply::Apply;
 pub use self::from_err::FromErr;
 pub use self::map::Map;
 pub use self::map_err::MapErr;
-pub use self::ready::Ready;
 pub use self::then::Then;
 
 // `tower-util` re-exports
@@ -23,6 +21,7 @@ pub use tower_util::CallAllUnordered;
 pub use tower_util::EitherService;
 pub use tower_util::Oneshot;
 pub use tower_util::OptionService;
+pub use tower_util::Ready;
 pub use tower_util::ServiceFn;
 pub use tower_util::UnsyncBoxService;
 

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -5,7 +5,6 @@ mod apply;
 mod from_err;
 mod map;
 mod map_err;
-mod oneshot;
 mod ready;
 mod then;
 
@@ -14,7 +13,6 @@ pub use self::apply::Apply;
 pub use self::from_err::FromErr;
 pub use self::map::Map;
 pub use self::map_err::MapErr;
-pub use self::oneshot::Oneshot;
 pub use self::ready::Ready;
 pub use self::then::Then;
 
@@ -23,6 +21,7 @@ pub use tower_util::BoxService;
 pub use tower_util::CallAll;
 pub use tower_util::CallAllUnordered;
 pub use tower_util::EitherService;
+pub use tower_util::Oneshot;
 pub use tower_util::OptionService;
 pub use tower_util::ServiceFn;
 pub use tower_util::UnsyncBoxService;


### PR DESCRIPTION
This moves `Ready` and `Oneshot` into `tower-util`.