### PR TITLE
tower: Reexport all layers and add layer::util mod

### DIFF
--- a/tower/src/layer.rs
+++ b/tower/src/layer.rs
@@ -1,9 +1,19 @@
 //! A collection of `Layer` based tower services
 
 pub use tower_layer::Layer;
-// TODO: Should this be re-exported?
-pub use tower_util::layer::Chain;
-pub use tower_util::layer::Identity;
+
+pub use tower_buffer::BufferLayer;
+pub use tower_filter::FilterLayer;
+pub use tower_in_flight_limit::InFlightLimitLayer;
+pub use tower_load_shed::LoadShedLayer;
+pub use tower_rate_limit::RateLimitLayer;
+pub use tower_retry::RetryLayer;
+pub use tower_timeout::TimeoutLayer;
+
+pub mod util {
+    pub use tower_util::layer::Chain;
+    pub use tower_util::layer::Identity;
+}
 
 /// An extension trait for `Layer`'s that provides a variety of convenient
 /// adapters.

--- a/tower/src/layer.rs
+++ b/tower/src/layer.rs
@@ -2,13 +2,13 @@
 
 pub use tower_layer::Layer;
 
-pub use tower_buffer::BufferLayer;
-pub use tower_filter::FilterLayer;
-pub use tower_in_flight_limit::InFlightLimitLayer;
-pub use tower_load_shed::LoadShedLayer;
-pub use tower_rate_limit::RateLimitLayer;
-pub use tower_retry::RetryLayer;
-pub use tower_timeout::TimeoutLayer;
+pub use buffer::BufferLayer;
+pub use filter::FilterLayer;
+pub use in_flight_limit::InFlightLimitLayer;
+pub use load_shed::LoadShedLayer;
+pub use rate_limit::RateLimitLayer;
+pub use retry::RetryLayer;
+pub use timeout::TimeoutLayer;
 
 pub mod util {
     pub use tower_util::layer::Chain;
@@ -22,12 +22,12 @@ pub trait LayerExt<S, Request>: Layer<S, Request> {
     /// `middleware` to services being wrapped.
     ///
     /// This defines a middleware stack.
-    fn chain<T>(self, middleware: T) -> Chain<Self, T>
+    fn chain<T>(self, middleware: T) -> util::Chain<Self, T>
     where
         T: Layer<Self::Service, Request>,
         Self: Sized,
     {
-        Chain::new(self, middleware)
+        util::Chain::new(self, middleware)
     }
 }
 


### PR DESCRIPTION
This makes it easier to import all the layers when using the service builder.  This also moves `Chain` and `Identity` to live under `tower::layer::util::{Chain, Identity}`.

I personally find the export of layers here as well to be really handy and a lot easier to write. It also allows you to bulk import like so `tower::layer::{TimeoutLayer, RetryLayer}`.