### PR TITLE
Rename `Chain` -> `Stack`

### DIFF
--- a/tower-util/src/layer/mod.rs
+++ b/tower-util/src/layer/mod.rs
@@ -1,5 +1,5 @@
-mod chain;
 mod identity;
+mod stack;
 
-pub use self::chain::Chain;
 pub use self::identity::Identity;
+pub use self::stack::Stack;

--- a/tower-util/src/layer/stack.rs
+++ b/tower-util/src/layer/stack.rs
@@ -5,21 +5,21 @@ use tower_service::Service;
 ///
 /// This type is produced by `Layer::chain`.
 #[derive(Debug)]
-pub struct Chain<Inner, Outer> {
+pub struct Stack<Inner, Outer> {
     inner: Inner,
     outer: Outer,
 }
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
 
-impl<Inner, Outer> Chain<Inner, Outer> {
-    /// Create a new `Chain`.
+impl<Inner, Outer> Stack<Inner, Outer> {
+    /// Create a new `Stack`.
     pub fn new(inner: Inner, outer: Outer) -> Self {
-        Chain { inner, outer }
+        Stack { inner, outer }
     }
 }
 
-impl<S, Request, Inner, Outer> Layer<S, Request> for Chain<Inner, Outer>
+impl<S, Request, Inner, Outer> Layer<S, Request> for Stack<Inner, Outer>
 where
     S: Service<Request>,
     Inner: Layer<S, Request>,

--- a/tower/src/builder/mod.rs
+++ b/tower/src/builder/mod.rs
@@ -14,7 +14,7 @@ use timeout::TimeoutLayer;
 
 use tower_layer::Layer;
 use tower_service::Service;
-use tower_util::layer::{Stack, Identity};
+use tower_util::layer::{Identity, Stack};
 use tower_util::MakeService;
 
 use std::time::Duration;

--- a/tower/src/builder/mod.rs
+++ b/tower/src/builder/mod.rs
@@ -14,7 +14,7 @@ use timeout::TimeoutLayer;
 
 use tower_layer::Layer;
 use tower_service::Service;
-use tower_util::layer::{Chain, Identity};
+use tower_util::layer::{Stack, Identity};
 use tower_util::MakeService;
 
 use std::time::Duration;
@@ -226,14 +226,14 @@ impl ServiceBuilder<Identity> {
 
 impl<L> ServiceBuilder<L> {
     /// Layer a new layer `T` onto the `ServiceBuilder`.
-    pub fn layer<T>(self, layer: T) -> ServiceBuilder<Chain<T, L>> {
+    pub fn layer<T>(self, layer: T) -> ServiceBuilder<Stack<T, L>> {
         ServiceBuilder {
-            layer: Chain::new(layer, self.layer),
+            layer: Stack::new(layer, self.layer),
         }
     }
 
     /// Buffer requests when when the next layer is out of capacity.
-    pub fn buffer(self, bound: usize) -> ServiceBuilder<Chain<BufferLayer, L>> {
+    pub fn buffer(self, bound: usize) -> ServiceBuilder<Stack<BufferLayer, L>> {
         self.layer(BufferLayer::new(bound))
     }
 
@@ -245,7 +245,7 @@ impl<L> ServiceBuilder<L> {
     /// `predicate` must implement [`Predicate`]
     ///
     /// [`Predicate`]: ../filter/trait.Predicate.html
-    pub fn filter<U>(self, predicate: U) -> ServiceBuilder<Chain<FilterLayer<U>, L>> {
+    pub fn filter<U>(self, predicate: U) -> ServiceBuilder<Stack<FilterLayer<U>, L>> {
         self.layer(FilterLayer::new(predicate))
     }
 
@@ -254,7 +254,7 @@ impl<L> ServiceBuilder<L> {
     /// A request is in-flight from the time the request is received until the
     /// response future completes. This includes the time spent in the next
     /// layers.
-    pub fn concurrency_limit(self, max: usize) -> ServiceBuilder<Chain<ConcurrencyLimitLayer, L>> {
+    pub fn concurrency_limit(self, max: usize) -> ServiceBuilder<Stack<ConcurrencyLimitLayer, L>> {
         self.layer(ConcurrencyLimitLayer::new(max))
     }
 
@@ -266,12 +266,12 @@ impl<L> ServiceBuilder<L> {
     ///
     /// `load_shed` immediately responds with an error when the next layer is
     /// out of capacity.
-    pub fn load_shed(self) -> ServiceBuilder<Chain<LoadShedLayer, L>> {
+    pub fn load_shed(self) -> ServiceBuilder<Stack<LoadShedLayer, L>> {
         self.layer(LoadShedLayer::new())
     }
 
     /// Limit requests to at most `num` per the given duration
-    pub fn rate_limit(self, num: u64, per: Duration) -> ServiceBuilder<Chain<RateLimitLayer, L>> {
+    pub fn rate_limit(self, num: u64, per: Duration) -> ServiceBuilder<Stack<RateLimitLayer, L>> {
         self.layer(RateLimitLayer::new(num, per))
     }
 
@@ -280,7 +280,7 @@ impl<L> ServiceBuilder<L> {
     /// `policy` must implement [`Policy`].
     ///
     /// [`Policy`]: ../retry/trait.Policy.html
-    pub fn retry<P>(self, policy: P) -> ServiceBuilder<Chain<RetryLayer<P>, L>> {
+    pub fn retry<P>(self, policy: P) -> ServiceBuilder<Stack<RetryLayer<P>, L>> {
         self.layer(RetryLayer::new(policy))
     }
 
@@ -288,7 +288,7 @@ impl<L> ServiceBuilder<L> {
     ///
     /// If the next layer takes more than `timeout` to respond to a request,
     /// processing is terminated and an error is returned.
-    pub fn timeout(self, timeout: Duration) -> ServiceBuilder<Chain<TimeoutLayer, L>> {
+    pub fn timeout(self, timeout: Duration) -> ServiceBuilder<Stack<TimeoutLayer, L>> {
         self.layer(TimeoutLayer::new(timeout))
     }
 

--- a/tower/src/layer.rs
+++ b/tower/src/layer.rs
@@ -3,6 +3,6 @@
 pub use tower_layer::Layer;
 
 pub mod util {
-    pub use tower_util::layer::Stack;
     pub use tower_util::layer::Identity;
+    pub use tower_util::layer::Stack;
 }

--- a/tower/src/layer.rs
+++ b/tower/src/layer.rs
@@ -3,7 +3,7 @@
 pub use tower_layer::Layer;
 
 pub mod util {
-    pub use tower_util::layer::Chain;
+    pub use tower_util::layer::Stack;
     pub use tower_util::layer::Identity;
 }
 
@@ -14,12 +14,12 @@ pub trait LayerExt<S, Request>: Layer<S, Request> {
     /// `middleware` to services being wrapped.
     ///
     /// This defines a middleware stack.
-    fn chain<T>(self, middleware: T) -> util::Chain<Self, T>
+    fn chain<T>(self, middleware: T) -> util::Stack<Self, T>
     where
         T: Layer<Self::Service, Request>,
         Self: Sized,
     {
-        util::Chain::new(self, middleware)
+        util::Stack::new(self, middleware)
     }
 }
 

--- a/tower/src/layer.rs
+++ b/tower/src/layer.rs
@@ -6,21 +6,3 @@ pub mod util {
     pub use tower_util::layer::Stack;
     pub use tower_util::layer::Identity;
 }
-
-/// An extension trait for `Layer`'s that provides a variety of convenient
-/// adapters.
-pub trait LayerExt<S, Request>: Layer<S, Request> {
-    /// Return a new `Layer` instance that applies both `self` and
-    /// `middleware` to services being wrapped.
-    ///
-    /// This defines a middleware stack.
-    fn chain<T>(self, middleware: T) -> util::Stack<Self, T>
-    where
-        T: Layer<Self::Service, Request>,
-        Self: Sized,
-    {
-        util::Stack::new(self, middleware)
-    }
-}
-
-impl<T, S, Request> LayerExt<S, Request> for T where T: Layer<S, Request> {}


### PR DESCRIPTION
Try to reduce metaphores.

Fixes #233