### PR TITLE
Add license field to all crates

### DIFF
--- a/tower-balance/Cargo.toml
+++ b/tower-balance/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tower-balance"
 version = "0.1.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
+license = "MIT"
 publish = false
 edition = "2018"
 

--- a/tower-buffer/Cargo.toml
+++ b/tower-buffer/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tower-buffer"
 version = "0.1.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
+license = "MIT"
 publish = false
 edition = "2018"
 

--- a/tower-discover/Cargo.toml
+++ b/tower-discover/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tower-discover"
 version = "0.1.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
+license = "MIT"
 publish = false
 edition = "2018"
 

--- a/tower-filter/Cargo.toml
+++ b/tower-filter/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tower-filter"
 version = "0.1.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
+license = "MIT"
 publish = false
 edition = "2018"
 

--- a/tower-limit/Cargo.toml
+++ b/tower-limit/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tower-limit"
 version = "0.1.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
+license = "MIT"
 publish = false
 edition = "2018"
 

--- a/tower-load-shed/Cargo.toml
+++ b/tower-load-shed/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tower-load-shed"
 version = "0.1.0"
 authors = ["Sean McArthur <sean@seanmonstar.com>"]
+license = "MIT"
 publish = false
 edition = "2018"
 

--- a/tower-reconnect/Cargo.toml
+++ b/tower-reconnect/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tower-reconnect"
 version = "0.1.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
+license = "MIT"
 publish = false
 edition = "2018"
 

--- a/tower-retry/Cargo.toml
+++ b/tower-retry/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tower-retry"
 version = "0.1.0"
 authors = ["Sean McArthur <sean@seanmonstar.com>"]
+license = "MIT"
 publish = false
 edition = "2018"
 

--- a/tower-test/Cargo.toml
+++ b/tower-test/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tower-test"
 version = "0.1.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
+license = "MIT"
 publish = false
 edition = "2018"
 

--- a/tower-timeout/Cargo.toml
+++ b/tower-timeout/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tower-timeout"
 version = "0.1.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
+license = "MIT"
 publish = false
 edition = "2018"
 


### PR DESCRIPTION
This PR just adds the `license = "MIT"` to all the crates in the workspace, so that tools such as https://github.com/onur/cargo-license can more easily grab that information.