### PR TITLE
buffer: Add BufferLazy to lazily spawn the worker

### DIFF
--- a/tower-buffer/src/layer.rs
+++ b/tower-buffer/src/layer.rs
@@ -1,4 +1,4 @@
-use crate::{error::Error, service::Buffer, worker::WorkerExecutor};
+use crate::{error::Error, lazy::BufferLazy, service::Buffer, worker::WorkerExecutor};
 use tokio_executor::DefaultExecutor;
 use tower_layer::Layer;
 use tower_service::Service;
@@ -42,5 +42,58 @@ where
 
     fn layer(&self, service: S) -> Result<Self::Service, Self::LayerError> {
         Buffer::with_executor(service, self.bound, &mut self.executor.clone())
+    }
+}
+
+/// BufferLazy requests with a bounded buffer
+///
+/// This will use the `DefaultExecutor` or the provided executor
+/// to lazily spawn the background worker on the first call to
+/// `poll_ready`.
+pub struct BufferLazyLayer<E = DefaultExecutor> {
+    bound: usize,
+    executor: E,
+}
+
+impl BufferLazyLayer<DefaultExecutor> {
+    pub fn new(bound: usize) -> Self {
+        BufferLazyLayer {
+            bound,
+            executor: DefaultExecutor::current(),
+        }
+    }
+}
+
+impl<E> BufferLazyLayer<E> {
+    pub fn with_executor<S, Request>(bound: usize, executor: E) -> Self
+    where
+        S: Service<Request>,
+        S::Error: Into<Error>,
+        E: WorkerExecutor<S, Request> + Clone,
+    {
+        BufferLazyLayer { bound, executor }
+    }
+}
+
+impl<E, S, Request> Layer<S, Request> for BufferLazyLayer<E>
+where
+    S: Service<Request> + Send + 'static,
+    S::Future: Send,
+    S::Response: Send,
+    S::Error: Into<Error> + Send + Sync,
+    Request: Send + 'static,
+    E: WorkerExecutor<S, Request> + Clone,
+{
+    type Response = S::Response;
+    type Error = Error;
+    type LayerError = Error;
+    type Service = BufferLazy<S, Request, E>;
+
+    fn layer(&self, service: S) -> Result<Self::Service, Self::LayerError> {
+        Ok(BufferLazy::with_executor(
+            service,
+            self.bound,
+            self.executor.clone(),
+        ))
     }
 }

--- a/tower-buffer/src/lazy.rs
+++ b/tower-buffer/src/lazy.rs
@@ -1,0 +1,100 @@
+use crate::{error::Error, future::ResponseFuture, service::Buffer, worker::WorkerExecutor};
+use futures::{Async, Poll};
+use std::sync::{Arc, Mutex};
+use tokio_executor::DefaultExecutor;
+use tower_service::Service;
+
+#[derive(Clone)]
+pub struct BufferLazy<T, Request, E>
+where
+    T: Service<Request>,
+{
+    inner: Arc<Mutex<Option<Buffer<T, Request>>>>,
+    state: State<T, Request>,
+    executor: E,
+}
+
+#[derive(Clone)]
+enum State<T, Request>
+where
+    T: Service<Request>,
+{
+    Waiting(Option<T>, usize),
+    Spawned(Buffer<T, Request>),
+}
+
+impl<T, Request> BufferLazy<T, Request, DefaultExecutor>
+where
+    T: Service<Request>,
+{
+    pub fn new(svc: T, bound: usize) -> Self {
+        BufferLazy {
+            inner: Arc::new(Mutex::new(None)),
+            state: State::Waiting(Some(svc), bound),
+            executor: DefaultExecutor::current(),
+        }
+    }
+}
+
+impl<T, Request, E> BufferLazy<T, Request, E>
+where
+    T: Service<Request>,
+    T::Error: Into<Error>,
+    E: WorkerExecutor<T, Request> + Clone,
+{
+    pub fn with_executor(svc: T, bound: usize, executor: E) -> Self {
+        BufferLazy {
+            inner: Arc::new(Mutex::new(None)),
+            state: State::Waiting(Some(svc), bound),
+            executor,
+        }
+    }
+}
+
+impl<T, Request, E> Service<Request> for BufferLazy<T, Request, E>
+where
+    T: Service<Request> + Send + 'static,
+    T::Future: Send,
+    T::Response: Send,
+    T::Error: Into<Error> + Send + Sync,
+    Request: Send + 'static,
+    E: WorkerExecutor<T, Request> + Clone,
+{
+    type Response = T::Response;
+    type Error = Error;
+    type Future = ResponseFuture<T::Future>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        match self.state {
+            State::Waiting(ref mut svc, bound) => {
+                let mut inner = self.inner.lock().unwrap();
+                let state = if inner.is_some() {
+                    State::Spawned(inner.clone().unwrap())
+                } else {
+                    let svc = svc.take().unwrap();
+                    let buffer =
+                        // TODO: this should return the error on poll_ready
+                        Buffer::with_executor(svc, bound, &mut self.executor.clone()).unwrap();
+                    *inner = Some(buffer.clone());
+                    State::Spawned(buffer)
+                };
+                drop(inner);
+
+                self.state = state;
+                return Ok(Async::Ready(()));
+            }
+
+            State::Spawned(ref mut buf) => return buf.poll_ready(),
+        }
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        match &mut self.state {
+            State::Waiting(_, _) => {
+                panic!("Did not call poll_ready!");
+            }
+
+            State::Spawned(buf) => buf.call(request),
+        }
+    }
+}

--- a/tower-buffer/src/lazy.rs
+++ b/tower-buffer/src/lazy.rs
@@ -74,7 +74,7 @@ where
                     let svc = svc.take().unwrap();
                     let buffer =
                         // TODO: this should return the error on poll_ready
-                        Buffer::with_executor(svc, bound, &mut self.executor.clone()).unwrap();
+                        Buffer::with_executor(svc, bound, &mut self.executor.clone())?;
                     *inner = Some(buffer.clone());
                     State::Spawned(buffer)
                 };

--- a/tower-buffer/src/lib.rs
+++ b/tower-buffer/src/lib.rs
@@ -16,7 +16,7 @@ mod message;
 mod service;
 mod worker;
 
-pub use crate::layer::BufferLayer;
+pub use crate::layer::{BufferLayer, BufferLazyLayer};
 pub use crate::lazy::BufferLazy;
 pub use crate::service::Buffer;
 pub use crate::worker::WorkerExecutor;

--- a/tower-buffer/src/lib.rs
+++ b/tower-buffer/src/lib.rs
@@ -11,10 +11,12 @@
 pub mod error;
 pub mod future;
 mod layer;
+mod lazy;
 mod message;
 mod service;
 mod worker;
 
 pub use crate::layer::BufferLayer;
+pub use crate::lazy::BufferLazy;
 pub use crate::service::Buffer;
 pub use crate::worker::WorkerExecutor;


### PR DESCRIPTION
This provides a "lazy" buffer that will only spawn the background worker on the first call to `poll_ready`. The advantage of this is that it allows one to create the service stack outside of a futures context and then call that service stack from within a futures context will provide all the benefits of a `Service + Clone`.

Closes #242 