### PR TITLE
WIP: Add Routing middleware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "tower-test",
   "tower-timeout",
   "tower-util",
+  "tower-route"
 ]
 
 [patch.'https://github.com/tower-rs/tower']

--- a/tower-route/Cargo.toml
+++ b/tower-route/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tower-route"
+version = "0.1.0"
+authors = ["Abdel-Rahman A. <abogical@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+futures = "0.1.26"
+tower-service = "0.2.0"
+tower-layer = { path = "../tower-layer" }
+void = "1.0.2"

--- a/tower-route/src/lib.rs
+++ b/tower-route/src/lib.rs
@@ -1,0 +1,37 @@
+extern crate futures;
+extern crate tower_service;
+extern crate void;
+
+use futures::{future::Either, Async, Poll};
+use tower_service::Service;
+
+pub trait Accepts<Request> {
+    fn accepts(&self, request: &Request) -> bool;
+}
+
+pub struct Route<A, B> {
+    service: A,
+    other: B,
+}
+
+impl<Request, A, B> Service<Request> for Route<A, B>
+where
+    A: Service<Request> + Accepts<Request>,
+    B: Service<Request, Response = A::Response, Error = A::Error>,
+{
+    type Response = A::Response;
+    type Error = A::Error;
+    type Future = Either<A::Future, B::Future>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        Ok(Async::Ready(()))
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        if self.service.accepts(&request) {
+            Either::A(self.service.call(request))
+        } else {
+            Either::B(self.other.call(request))
+        }
+    }
+}


### PR DESCRIPTION
Idea by @carllerche.
I'm still failing at implementing the `Layer` trait for the last couple of days. I can't have a structure that can recursively layer itself, as `Service` expects a mutable reference and `Layer` expects a non-mutable reference. This doesn't seem to have a clean solution, so I'm not sure if this middleware would make things any easier.