### PR TITLE
tower: Fix client example

### DIFF
--- a/tower/examples/client.rs
+++ b/tower/examples/client.rs
@@ -55,5 +55,9 @@ fn request() -> impl Future<Item = Response<hyper::Body>, Error = ()> {
     client
         .ready()
         .map_err(|e| panic!("Service is not ready: {:?}", e))
-        .and_then(|mut c| c.call(request).map_err(|e| panic!("{:?}", e)))
+        .and_then(|mut c| {
+            c.call(request)
+                .map(|res| res.map(|b| b.into_inner()))
+                .map_err(|e| panic!("{:?}", e))
+        })
 }


### PR DESCRIPTION
So the return type has changed to `LiftBody` which honestly we should just rename to `tower::body::Body`. LiftBody impls HttpBody and wraps a Payload type.