### PR TITLE
buffer: make Buffer::new infallible

### DIFF
--- a/tower-buffer/src/layer.rs
+++ b/tower-buffer/src/layer.rs
@@ -41,6 +41,10 @@ where
     type Service = Buffer<S, Request>;
 
     fn layer(&self, service: S) -> Result<Self::Service, Self::LayerError> {
-        Buffer::with_executor(service, self.bound, &mut self.executor.clone())
+        Ok(Buffer::with_executor(
+            service,
+            self.bound,
+            &mut self.executor.clone(),
+        ))
     }
 }

--- a/tower-buffer/src/worker.rs
+++ b/tower-buffer/src/worker.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{Closed, Error, ServiceError, SpawnError},
+    error::{Closed, Error, ServiceError},
     message::Message,
 };
 use futures::{try_ready, Async, Future, Poll, Stream};
@@ -58,7 +58,7 @@ where
         service: T,
         rx: mpsc::Receiver<Message<Request, T::Future>>,
         executor: &mut E,
-    ) -> Result<Handle, Error>
+    ) -> Option<Handle>
     where
         E: WorkerExecutor<T, Request>,
     {
@@ -76,8 +76,8 @@ where
         };
 
         match executor.spawn(worker) {
-            Ok(()) => Ok(handle),
-            Err(_) => Err(SpawnError::new().into()),
+            Ok(()) => Some(handle),
+            Err(_) => None,
         }
     }
 


### PR DESCRIPTION
Creating a buffer can internally fail to spawn a worker. Before, that
error was returned immediately from `Buffer::new`. This changes `new` to
always return a `Buffer`, and the spawn error is encountered via
`poll_ready`.