### PR TITLE
inline docs for re-exported crates in facade

### DIFF
--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -5,11 +5,17 @@
 
 //! Various utility types and functions that are generally with Tower.
 
+#[doc(inline)]
 pub use tower_buffer as buffer;
+#[doc(inline)]
 pub use tower_discover as discover;
+#[doc(inline)]
 pub use tower_limit as limit;
+#[doc(inline)]
 pub use tower_load_shed as load_shed;
+#[doc(inline)]
 pub use tower_retry as retry;
+#[doc(inline)]
 pub use tower_timeout as timeout;
 
 pub mod builder;


### PR DESCRIPTION
The existing docs show the re-exports in an ugly way:

![Screenshot_2019-04-23 tower - Rust](https://user-images.githubusercontent.com/51479/56609071-211aaa80-65c1-11e9-93d9-4b5bc263ebb3.png)

This changes them to appear like Modules.