### PR TITLE
ensure `ResponseFuture` types are in `futures` mod

### DIFF
--- a/tower-limit/src/concurrency/future.rs
+++ b/tower-limit/src/concurrency/future.rs
@@ -1,3 +1,5 @@
+//! Future types
+//!
 use super::Error;
 use futures::{Future, Poll};
 use std::sync::Arc;

--- a/tower-limit/src/concurrency/mod.rs
+++ b/tower-limit/src/concurrency/mod.rs
@@ -1,9 +1,9 @@
 //! Limit the max number of requests being concurrently processed.
 
-mod future;
+pub mod future;
 mod layer;
 mod service;
 
-pub use self::{future::ResponseFuture, layer::ConcurrencyLimitLayer, service::ConcurrencyLimit};
+pub use self::{layer::ConcurrencyLimitLayer, service::ConcurrencyLimit};
 
 type Error = Box<dyn std::error::Error + Send + Sync>;

--- a/tower-limit/src/rate/future.rs
+++ b/tower-limit/src/rate/future.rs
@@ -1,3 +1,5 @@
+//! Future types
+
 use super::error::Error;
 use futures::{Future, Poll};
 

--- a/tower-limit/src/rate/mod.rs
+++ b/tower-limit/src/rate/mod.rs
@@ -1,9 +1,9 @@
 //! Limit the rate at which requests are processed.
 
 mod error;
-mod future;
+pub mod future;
 mod layer;
 mod rate;
 mod service;
 
-pub use self::{future::ResponseFuture, layer::RateLimitLayer, rate::Rate, service::RateLimit};
+pub use self::{layer::RateLimitLayer, rate::Rate, service::RateLimit};

--- a/tower-load-shed/src/future.rs
+++ b/tower-load-shed/src/future.rs
@@ -1,3 +1,5 @@
+//! Future types
+
 use std::fmt;
 
 use futures::{Future, Poll};

--- a/tower-load-shed/src/lib.rs
+++ b/tower-load-shed/src/lib.rs
@@ -14,8 +14,8 @@ pub mod future;
 mod layer;
 
 use crate::error::Error;
-pub use crate::{layer::LoadShedLayer};
 use crate::future::ResponseFuture;
+pub use crate::layer::LoadShedLayer;
 
 /// A `Service` that sheds load when the inner service isn't ready.
 #[derive(Debug)]

--- a/tower-load-shed/src/lib.rs
+++ b/tower-load-shed/src/lib.rs
@@ -10,11 +10,12 @@ use futures::Poll;
 use tower_service::Service;
 
 pub mod error;
-mod future;
+pub mod future;
 mod layer;
 
-use self::error::Error;
-pub use self::{future::ResponseFuture, layer::LoadShedLayer};
+use crate::error::Error;
+pub use crate::{layer::LoadShedLayer};
+use crate::future::ResponseFuture;
 
 /// A `Service` that sheds load when the inner service isn't ready.
 #[derive(Debug)]


### PR DESCRIPTION
Follow the pattern used in the other crates.