### PR TITLE
Minor docs fix

### DIFF
--- a/tower-retry/src/lib.rs
+++ b/tower-retry/src/lib.rs
@@ -29,7 +29,7 @@ pub struct Retry<P, S> {
 // ===== impl Retry =====
 
 impl<P, S> Retry<P, S> {
-    /// Retry the inner service depending on this [`Policy`][Policy}.
+    /// Retry the inner service depending on this `Policy`.
     pub fn new(policy: P, service: S) -> Self {
         Retry { policy, service }
     }


### PR DESCRIPTION
I think that there was the intent to create a link, but it was malformed anyway. I corrected it to just the name, consistent with other crates in this repository.