### PR TITLE
Greatly improve Debug output of ServiceBuilder

### DIFF
--- a/tower-buffer/src/layer.rs
+++ b/tower-buffer/src/layer.rs
@@ -1,5 +1,5 @@
 use crate::{error::Error, service::Buffer, worker::WorkerExecutor};
-use std::marker::PhantomData;
+use std::{fmt, marker::PhantomData};
 use tokio_executor::DefaultExecutor;
 use tower_layer::Layer;
 use tower_service::Service;
@@ -41,5 +41,17 @@ where
 
     fn layer(&self, service: S) -> Self::Service {
         Buffer::with_executor(service, self.bound, &mut self.executor.clone())
+    }
+}
+
+impl<Request, E> fmt::Debug for BufferLayer<Request, E>
+where
+    // Require E: Debug in case we want to print the executor at a later date
+    E: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("BufferLayer")
+            .field("bound", &self.bound)
+            .finish()
     }
 }

--- a/tower-load-shed/src/layer.rs
+++ b/tower-load-shed/src/layer.rs
@@ -1,9 +1,10 @@
+use std::fmt;
 use tower_layer::Layer;
 
 use crate::LoadShed;
 
 /// A `tower-layer` to wrap services in `LoadShed` middleware.
-#[derive(Debug)]
+#[derive(Clone)]
 pub struct LoadShedLayer {
     _p: (),
 }
@@ -20,5 +21,11 @@ impl<S> Layer<S> for LoadShedLayer {
 
     fn layer(&self, service: S) -> Self::Service {
         LoadShed::new(service)
+    }
+}
+
+impl fmt::Debug for LoadShedLayer {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("LoadShedLayer").finish()
     }
 }

--- a/tower-util/src/layer/identity.rs
+++ b/tower-util/src/layer/identity.rs
@@ -1,10 +1,11 @@
+use std::fmt;
 use tower_layer::Layer;
 
 /// A no-op middleware.
 ///
 /// When wrapping a `Service`, the `Identity` layer returns the provided
 /// service without modifying it.
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Clone)]
 pub struct Identity {
     _p: (),
 }
@@ -22,5 +23,11 @@ impl<S> Layer<S> for Identity {
 
     fn layer(&self, inner: S) -> Self::Service {
         inner
+    }
+}
+
+impl fmt::Debug for Identity {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Identity").finish()
     }
 }

--- a/tower/src/builder/mod.rs
+++ b/tower/src/builder/mod.rs
@@ -11,7 +11,7 @@ use crate::{
 use tower_layer::Layer;
 use tower_util::layer::{Identity, Stack};
 
-use std::time::Duration;
+use std::{fmt, time::Duration};
 
 /// Declaratively construct Service values.
 ///
@@ -142,7 +142,7 @@ use std::time::Duration;
 ///     .rate_limit(5, Duration::from_secs(1))
 ///     .service(MyService);
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct ServiceBuilder<L> {
     layer: L,
 }
@@ -218,5 +218,11 @@ impl<L> ServiceBuilder<L> {
         L: Layer<S>,
     {
         self.layer.layer(service)
+    }
+}
+
+impl<L: fmt::Debug> fmt::Debug for ServiceBuilder<L> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("ServiceBuilder").field(&self.layer).finish()
     }
 }

--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -3,6 +3,7 @@
 // compatibility
 #![cfg(feature = "full")]
 #![deny(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![allow(elided_lifetimes_in_paths)]
 #![cfg_attr(test, deny(warnings))]
 
 //! `fn(Request) -> Future<Response>`


### PR DESCRIPTION
Before:

```
new = ServiceBuilder {
    layer: Identity {
        _p: (),
    },
}
builder = ServiceBuilder {
    layer: Stack {
        inner: BufferLayer {
            bound: 5,
        },
        outer: Stack {
            inner: TimeoutLayer {
                timeout: 3s,
            },
            outer: Stack {
                inner: ConcurrencyLimitLayer {
                    max: 5,
                },
                outer: Stack {
                    inner: LoadShedLayer {
                        _p: (),
                    },
                    outer: Identity {
                        _p: (),
                    },
                },
            },
        },
    },
}
```

After:

```
new = ServiceBuilder(Identity)
new # = ServiceBuilder(
    Identity,
)

builder = ServiceBuilder(Identity, LoadShedLayer, ConcurrencyLimitLayer { max: 5 }, TimeoutLayer { timeout: 3s }, BufferLayer {
 bound: 5 })
builder # = ServiceBuilder(
    Identity,
    LoadShedLayer,
    ConcurrencyLimitLayer {
        max: 5,
    },
    TimeoutLayer {
        timeout: 3s,
    },
    BufferLayer {
        bound: 5,
    },
)
```