### PR TITLE
balance: Configure weights from keys, not services

### DIFF
--- a/tower-balance/examples/demo.rs
+++ b/tower-balance/examples/demo.rs
@@ -178,10 +178,12 @@ fn gen_disco() -> impl Discover<
                         .saturating_add(latency.as_secs().saturating_mul(1_000));
                     let latency = Duration::from_millis(rand::thread_rng().gen_range(0, maxms));
 
-                    timer::Delay::new(start + latency).map_err(Into::into).map(move |_| {
-                        let latency = start.elapsed();
-                        Rsp { latency, instance }
-                    })
+                    timer::Delay::new(start + latency)
+                        .map_err(Into::into)
+                        .map(move |_| {
+                            let latency = start.elapsed();
+                            Rsp { latency, instance }
+                        })
                 });
 
                 (key, ConcurrencyLimit::new(svc, ENDPOINT_CAPACITY))


### PR DESCRIPTION
The initial weighted balancing implementation required that the
underlying service implement `HasWeight`.

Practically, this doesn't work that well, since this may force
middlewares to implement this trait as well.

To fix this, we change the type bounds so that _keys_, not services,
must implement `HasWeight`.

This has a drawback, though, in that Weight, which contains a float,
cannot implement `Hash` or `Eq`, which is required by the balancer. This
tradeoff seems manageable, though (and is already addressed in linkerd,
for instance).