### PR TITLE
balance: Internally represent weights as integers

### DIFF
--- a/tower-balance/src/load/weight.rs
+++ b/tower-balance/src/load/weight.rs
@@ -1,5 +1,6 @@
+use log::trace;
 use futures::{try_ready, Async, Poll};
-use std::ops;
+use std::{fmt, ops};
 use tower_discover::{Change, Discover};
 use tower_service::Service;
 
@@ -55,13 +56,16 @@ impl<T> Weighted<T> {
 impl<L> Load for Weighted<L>
 where
     L: Load,
-    L::Metric: ops::Div<Weight>,
-    <L::Metric as ops::Div<Weight>>::Output: PartialOrd,
+    L::Metric: ops::Div<Weight> + fmt::Debug + Copy,
+    <L::Metric as ops::Div<Weight>>::Output: PartialOrd + fmt::Debug,
 {
     type Metric = <L::Metric as ops::Div<Weight>>::Output;
 
     fn load(&self) -> Self::Metric {
-        self.inner.load() / self.weight
+        let load = self.inner.load();
+        let v = load / self.weight;
+        trace!("load={:?}; weight={:?} => {:?}", load, self.weight, v);
+        v
     }
 }
 

--- a/tower-balance/src/load/weight.rs
+++ b/tower-balance/src/load/weight.rs
@@ -12,7 +12,7 @@ use crate::Load;
 pub struct Weight(u32);
 
 /// A Service, that implements Load, that
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct Weighted<T> {
     inner: T,
     weight: Weight,


### PR DESCRIPTION
The balancer's `Weight` type represents a weight value as a float
because, conceptually, we want to think of a unit weight of 1.0...

However, storing a float means that this type cannot be hashed, and
therefore all types that hold a Weight cannot implement Hash. Given that
`Balance` expects that keys impl `Hash` and `Eq`, this is especially
cumbersome.

This branch changes the internal representation of weights to be
unsigned integers with a unit value of `10_000` (corresponding to
1.0000).