### PR TITLE
spawn-ready: Change layer to operate over MakeSpawnReady

### DIFF
--- a/tower-spawn-ready/src/future.rs
+++ b/tower-spawn-ready/src/future.rs
@@ -1,3 +1,5 @@
+//! Background readiness types
+
 use crate::error::Error;
 use futures::{Async, Future, Poll};
 use tokio_executor::TypedExecutor;
@@ -5,6 +7,7 @@ use tokio_sync::oneshot;
 use tower_service::Service;
 use tower_util::Ready;
 
+/// Drives a service to readiness.
 pub struct BackgroundReady<T, Request>
 where
     T: Service<Request>,

--- a/tower-spawn-ready/src/layer.rs
+++ b/tower-spawn-ready/src/layer.rs
@@ -41,12 +41,11 @@ where
     }
 }
 
-impl<Request, E: Clone> Clone for SpawnReadyLayer<Request, E>
-{
+impl<Request, E: Clone> Clone for SpawnReadyLayer<Request, E> {
     fn clone(&self) -> Self {
         Self {
             executor: self.executor.clone(),
-            _p: PhantomData
+            _p: PhantomData,
         }
     }
 }

--- a/tower-spawn-ready/src/layer.rs
+++ b/tower-spawn-ready/src/layer.rs
@@ -41,6 +41,16 @@ where
     }
 }
 
+impl<Request, E: Clone> Clone for SpawnReadyLayer<Request, E>
+{
+    fn clone(&self) -> Self {
+        Self {
+            executor: self.executor.clone(),
+            _p: PhantomData
+        }
+    }
+}
+
 impl<Request, E> fmt::Debug for SpawnReadyLayer<Request, E>
 where
     // Require E: Debug in case we want to print the executor at a later date

--- a/tower-spawn-ready/src/layer.rs
+++ b/tower-spawn-ready/src/layer.rs
@@ -9,6 +9,7 @@ pub struct SpawnReadyLayer<E = DefaultExecutor> {
 }
 
 impl SpawnReadyLayer<DefaultExecutor> {
+    /// Builds a SpawnReady layer with the default executor.
     pub fn new() -> Self {
         Self {
             executor: DefaultExecutor::current(),
@@ -17,6 +18,7 @@ impl SpawnReadyLayer<DefaultExecutor> {
 }
 
 impl<E: Clone> SpawnReadyLayer<E> {
+    /// Builds a SpawnReady layer with the provided executor.
     pub fn with_executor(executor: E) -> Self {
         Self { executor }
     }

--- a/tower-spawn-ready/src/lib.rs
+++ b/tower-spawn-ready/src/lib.rs
@@ -8,7 +8,9 @@
 pub mod error;
 pub mod future;
 mod layer;
+mod make;
 mod service;
 
 pub use crate::layer::SpawnReadyLayer;
+pub use crate::make::{MakeFuture, MakeSpawnReady};
 pub use crate::service::SpawnReady;

--- a/tower-spawn-ready/src/lib.rs
+++ b/tower-spawn-ready/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc(html_root_url = "https://docs.rs/tower-spawn-ready/0.1.0")]
-#![deny(rust_2018_idioms)]
+#![deny(missing_docs, rust_2018_idioms, warnings)]
 #![allow(elided_lifetimes_in_paths)]
 
 //! When an underlying service is not ready, drive it to readiness on a

--- a/tower-spawn-ready/src/make.rs
+++ b/tower-spawn-ready/src/make.rs
@@ -1,45 +1,32 @@
-use crate::{error, future::BackgroundReadyExecutor, SpawnReady};
+use crate::SpawnReady;
 use futures::{try_ready, Future, Poll};
-use std::marker::PhantomData;
 use tokio_executor::DefaultExecutor;
 use tower_service::Service;
 
-pub struct MakeSpawnReady<S, Target, Request, E = DefaultExecutor> {
+pub struct MakeSpawnReady<S, E = DefaultExecutor> {
     inner: S,
     executor: E,
-    _marker: PhantomData<fn(Target, Request)>,
 }
 
-pub struct MakeFuture<F, Request, E = DefaultExecutor> {
+pub struct MakeFuture<F, E = DefaultExecutor> {
     inner: F,
     executor: E,
-    _marker: PhantomData<fn(Request)>,
 }
 
-impl<S, Target, Request, E> MakeSpawnReady<S, Target, Request, E>
+impl<S, E> MakeSpawnReady<S, E> {
+    pub(crate) fn with_executor(inner: S, executor: E) -> Self {
+        Self { inner, executor }
+    }
+}
+
+impl<S, E, Target> Service<Target> for MakeSpawnReady<S, E>
 where
     S: Service<Target>,
     E: Clone,
 {
-    pub(crate) fn with_executor(inner: S, executor: E) -> Self {
-        Self {
-            inner,
-            executor,
-            _marker: PhantomData,
-        }
-    }
-}
-
-impl<S, Target, T, Request, E> Service<Target> for MakeSpawnReady<S, Target, Request, E>
-where
-    S: Service<Target, Response = T>,
-    T: Service<Request> + Send,
-    T::Error: Into<error::Error>,
-    E: BackgroundReadyExecutor<T, Request> + Clone,
-{
-    type Response = SpawnReady<S::Response, Request, E>;
+    type Response = SpawnReady<S::Response, E>;
     type Error = S::Error;
-    type Future = MakeFuture<S::Future, Request, E>;
+    type Future = MakeFuture<S::Future, E>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         self.inner.poll_ready()
@@ -49,19 +36,16 @@ where
         MakeFuture {
             inner: self.inner.call(target),
             executor: self.executor.clone(),
-            _marker: PhantomData,
         }
     }
 }
 
-impl<S, F, Request, E> Future for MakeFuture<F, Request, E>
+impl<F, E> Future for MakeFuture<F, E>
 where
-    F: Future<Item = S>,
-    S: Service<Request> + Send,
-    S::Error: Into<error::Error>,
-    E: BackgroundReadyExecutor<S, Request> + Clone,
+    F: Future,
+    E: Clone,
 {
-    type Item = SpawnReady<F::Item, Request, E>;
+    type Item = SpawnReady<F::Item, E>;
     type Error = F::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {

--- a/tower-spawn-ready/src/make.rs
+++ b/tower-spawn-ready/src/make.rs
@@ -1,0 +1,72 @@
+use crate::{error, future::BackgroundReadyExecutor, SpawnReady};
+use futures::{try_ready, Future, Poll};
+use std::marker::PhantomData;
+use tokio_executor::DefaultExecutor;
+use tower_service::Service;
+
+pub struct MakeSpawnReady<S, Target, Request, E = DefaultExecutor> {
+    inner: S,
+    executor: E,
+    _marker: PhantomData<fn(Target, Request)>,
+}
+
+pub struct MakeFuture<F, Request, E = DefaultExecutor> {
+    inner: F,
+    executor: E,
+    _marker: PhantomData<fn(Request)>,
+}
+
+impl<S, Target, Request, E> MakeSpawnReady<S, Target, Request, E>
+where
+    S: Service<Target>,
+    E: Clone,
+{
+    pub(crate) fn with_executor(inner: S, executor: E) -> Self {
+        Self {
+            inner,
+            executor,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<S, Target, T, Request, E> Service<Target> for MakeSpawnReady<S, Target, Request, E>
+where
+    S: Service<Target, Response = T>,
+    T: Service<Request> + Send,
+    T::Error: Into<error::Error>,
+    E: BackgroundReadyExecutor<T, Request> + Clone,
+{
+    type Response = SpawnReady<S::Response, Request, E>;
+    type Error = S::Error;
+    type Future = MakeFuture<S::Future, Request, E>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.inner.poll_ready()
+    }
+
+    fn call(&mut self, target: Target) -> Self::Future {
+        MakeFuture {
+            inner: self.inner.call(target),
+            executor: self.executor.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<S, F, Request, E> Future for MakeFuture<F, Request, E>
+where
+    F: Future<Item = S>,
+    S: Service<Request> + Send,
+    S::Error: Into<error::Error>,
+    E: BackgroundReadyExecutor<S, Request> + Clone,
+{
+    type Item = SpawnReady<F::Item, Request, E>;
+    type Error = F::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let inner = try_ready!(self.inner.poll());
+        let svc = SpawnReady::with_executor(inner, self.executor.clone());
+        Ok(svc.into())
+    }
+}

--- a/tower-spawn-ready/src/make.rs
+++ b/tower-spawn-ready/src/make.rs
@@ -3,11 +3,15 @@ use futures::{try_ready, Future, Poll};
 use tokio_executor::DefaultExecutor;
 use tower_service::Service;
 
+/// Builds SpawnReady instances with the result of an inner Service.
+#[derive(Clone, Debug)]
 pub struct MakeSpawnReady<S, E = DefaultExecutor> {
     inner: S,
     executor: E,
 }
 
+/// Builds a SpawnReady with the result of an inner Future.
+#[derive(Debug)]
 pub struct MakeFuture<F, E = DefaultExecutor> {
     inner: F,
     executor: E,

--- a/tower-spawn-ready/tests/spawn_ready.rs
+++ b/tower-spawn-ready/tests/spawn_ready.rs
@@ -90,7 +90,7 @@ where
     }
 }
 
-fn new_service() -> (SpawnReady<Mock, &'static str, Exec>, Handle) {
+fn new_service() -> (SpawnReady<Mock, Exec>, Handle) {
     let (service, handle) = mock::pair();
     let service = SpawnReady::with_executor(service, Exec);
     (service, handle)


### PR DESCRIPTION
The initial implementation of spawn-ready didn't properly compose over MakeService instances. This introduces `MakeSpawnReady` as a factory type for SpawnReady, and changes Layer to produce `MakeSpawnReady` instances.