### PR TITLE
builder: Add `into_inner`

### DIFF
--- a/tower/src/builder/mod.rs
+++ b/tower/src/builder/mod.rs
@@ -212,6 +212,11 @@ impl<L> ServiceBuilder<L> {
         self.layer(TimeoutLayer::new(timeout))
     }
 
+    /// Obtains the underlying `Layer` impementation.
+    pub fn into_stack(self) -> L {
+        self.layer
+    }
+
     /// Wrap the service `S` with the layers.
     pub fn service<S>(self, service: S) -> L::Service
     where

--- a/tower/src/builder/mod.rs
+++ b/tower/src/builder/mod.rs
@@ -213,7 +213,7 @@ impl<L> ServiceBuilder<L> {
     }
 
     /// Obtains the underlying `Layer` implementation.
-    pub fn into_stack(self) -> L {
+    pub fn into_inner(self) -> L {
         self.layer
     }
 

--- a/tower/src/builder/mod.rs
+++ b/tower/src/builder/mod.rs
@@ -212,7 +212,7 @@ impl<L> ServiceBuilder<L> {
         self.layer(TimeoutLayer::new(timeout))
     }
 
-    /// Obtains the underlying `Layer` impementation.
+    /// Obtains the underlying `Layer` implementation.
     pub fn into_stack(self) -> L {
         self.layer
     }


### PR DESCRIPTION
When using a `ServiceBuilder`, it's not possible to obtain the
underlying `Layer` implementation.

Adding a `ServiceBuilder::into_inner` allows callers to retrieve this
field instead of only being able to build a `Service`.