### PR TITLE
 Notify Pool when Services are dropped

### DIFF
--- a/tower-balance/Cargo.toml
+++ b/tower-balance/Cargo.toml
@@ -34,6 +34,7 @@ tower-layer = "0.1.0"
 tower-load = { version = "0.1.0", path = "../tower-load" }
 tower-service = "0.2.0"
 tower-util = "0.1.0"
+slab = "0.4"
 
 [dev-dependencies]
 log = "0.4.1"

--- a/tower-balance/src/pool/mod.rs
+++ b/tower-balance/src/pool/mod.rs
@@ -15,6 +15,7 @@
 #![deny(missing_docs)]
 
 use super::p2c::Balance;
+use crate::error;
 use futures::{try_ready, Async, Future, Poll};
 use tower_discover::{Change, Discover};
 use tower_load::Load;
@@ -47,9 +48,8 @@ where
 impl<MS, Target, Request> Discover for PoolDiscoverer<MS, Target, Request>
 where
     MS: MakeService<Target, Request>,
-    // NOTE: these bounds should go away once MakeService adopts Box<dyn Error>
-    MS::MakeError: ::std::error::Error + Send + Sync + 'static,
-    MS::Error: ::std::error::Error + Send + Sync + 'static,
+    MS::MakeError: Into<error::Error>,
+    MS::Error: Into<error::Error>,
     Target: Clone,
 {
     type Key = usize;
@@ -209,8 +209,8 @@ impl Builder {
         MS: MakeService<Target, Request>,
         MS::Service: Load,
         <MS::Service as Load>::Metric: std::fmt::Debug,
-        MS::MakeError: ::std::error::Error + Send + Sync + 'static,
-        MS::Error: ::std::error::Error + Send + Sync + 'static,
+        MS::MakeError: Into<error::Error>,
+        MS::Error: Into<error::Error>,
         Target: Clone,
     {
         let d = PoolDiscoverer {
@@ -234,8 +234,8 @@ impl Builder {
 pub struct Pool<MS, Target, Request>
 where
     MS: MakeService<Target, Request>,
-    MS::MakeError: ::std::error::Error + Send + Sync + 'static,
-    MS::Error: ::std::error::Error + Send + Sync + 'static,
+    MS::MakeError: Into<error::Error>,
+    MS::Error: Into<error::Error>,
     Target: Clone,
 {
     balance: Balance<PoolDiscoverer<MS, Target, Request>, Request>,
@@ -248,8 +248,8 @@ where
     MS: MakeService<Target, Request>,
     MS::Service: Load,
     <MS::Service as Load>::Metric: std::fmt::Debug,
-    MS::MakeError: ::std::error::Error + Send + Sync + 'static,
-    MS::Error: ::std::error::Error + Send + Sync + 'static,
+    MS::MakeError: Into<error::Error>,
+    MS::Error: Into<error::Error>,
     Target: Clone,
 {
     /// Construct a new dynamically sized `Pool`.
@@ -268,8 +268,8 @@ where
     MS: MakeService<Target, Req>,
     MS::Service: Load,
     <MS::Service as Load>::Metric: std::fmt::Debug,
-    MS::MakeError: ::std::error::Error + Send + Sync + 'static,
-    MS::Error: ::std::error::Error + Send + Sync + 'static,
+    MS::MakeError: Into<error::Error>,
+    MS::Error: Into<error::Error>,
     Target: Clone,
 {
     type Response = <Balance<PoolDiscoverer<MS, Target, Req>, Req> as Service<Req>>::Response;

--- a/tower-balance/src/pool/mod.rs
+++ b/tower-balance/src/pool/mod.rs
@@ -23,6 +23,9 @@ use tower_load::Load;
 use tower_service::Service;
 use tower_util::MakeService;
 
+#[cfg(test)]
+mod test;
+
 enum Level {
     /// Load is low -- remove a service instance.
     Low,

--- a/tower-balance/src/pool/test.rs
+++ b/tower-balance/src/pool/test.rs
@@ -1,0 +1,285 @@
+use futures::{Async, Future};
+use tower_load as load;
+use tower_service::Service;
+use tower_test::mock;
+
+use super::*;
+
+macro_rules! assert_fut_ready {
+    ($fut:expr, $val:expr) => {{
+        assert_fut_ready!($fut, $val, "must be ready");
+    }};
+    ($fut:expr, $val:expr, $msg:expr) => {{
+        assert_eq!(
+            $fut.poll().expect("must not fail"),
+            Async::Ready($val),
+            $msg
+        );
+    }};
+}
+
+macro_rules! assert_ready {
+    ($svc:expr) => {{
+        assert_ready!($svc, "must be ready");
+    }};
+    ($svc:expr, $msg:expr) => {{
+        assert!($svc.poll_ready().expect("must not fail").is_ready(), $msg);
+    }};
+}
+
+macro_rules! assert_fut_not_ready {
+    ($fut:expr) => {{
+        assert_fut_not_ready!($fut, "must not be ready");
+    }};
+    ($fut:expr, $msg:expr) => {{
+        assert!(!$fut.poll().expect("must not fail").is_ready(), $msg);
+    }};
+}
+
+macro_rules! assert_not_ready {
+    ($svc:expr) => {{
+        assert_not_ready!($svc, "must not be ready");
+    }};
+    ($svc:expr, $msg:expr) => {{
+        assert!(!$svc.poll_ready().expect("must not fail").is_ready(), $msg);
+    }};
+}
+
+#[test]
+fn basic() {
+    // start the pool
+    let (mock, mut handle) =
+        mock::pair::<(), load::Constant<mock::Mock<(), &'static str>, usize>>();
+    let mut pool = Builder::new().build(mock, ());
+    with_task(|| {
+        assert_not_ready!(pool);
+    });
+
+    // give the pool a backing service
+    let (svc1_m, mut svc1) = mock::pair();
+    handle
+        .next_request()
+        .unwrap()
+        .1
+        .send_response(load::Constant::new(svc1_m, 0));
+    with_task(|| {
+        assert_ready!(pool);
+    });
+
+    // send a request to the one backing service
+    let mut fut = pool.call(());
+    with_task(|| {
+        assert_fut_not_ready!(fut);
+    });
+    svc1.next_request().unwrap().1.send_response("foobar");
+    with_task(|| {
+        assert_fut_ready!(fut, "foobar");
+    });
+}
+
+#[test]
+fn high_load() {
+    // start the pool
+    let (mock, mut handle) =
+        mock::pair::<(), load::Constant<mock::Mock<(), &'static str>, usize>>();
+    let mut pool = Builder::new()
+        .urgency(1.0) // so _any_ NotReady will add a service
+        .underutilized_below(0.0) // so no Ready will remove a service
+        .max_services(Some(2))
+        .build(mock, ());
+    with_task(|| {
+        assert_not_ready!(pool);
+    });
+
+    // give the pool a backing service
+    let (svc1_m, mut svc1) = mock::pair();
+    svc1.allow(1);
+    handle
+        .next_request()
+        .unwrap()
+        .1
+        .send_response(load::Constant::new(svc1_m, 0));
+    with_task(|| {
+        assert_ready!(pool);
+    });
+
+    // make the one backing service not ready
+    let mut fut1 = pool.call(());
+
+    // if we poll_ready again, pool should notice that load is increasing
+    // since urgency == 1.0, it should immediately enter high load
+    with_task(|| {
+        assert_not_ready!(pool);
+    });
+    // it should ask the maker for another service, so we give it one
+    let (svc2_m, mut svc2) = mock::pair();
+    svc2.allow(1);
+    handle
+        .next_request()
+        .unwrap()
+        .1
+        .send_response(load::Constant::new(svc2_m, 0));
+
+    // the pool should now be ready again for one more request
+    with_task(|| {
+        assert_ready!(pool);
+    });
+    let mut fut2 = pool.call(());
+    with_task(|| {
+        assert_not_ready!(pool);
+    });
+
+    // the pool should _not_ try to add another service
+    // sicen we have max_services(2)
+    with_task(|| {
+        assert!(!handle.poll_request().unwrap().is_ready());
+    });
+
+    // let see that each service got one request
+    svc1.next_request().unwrap().1.send_response("foo");
+    svc2.next_request().unwrap().1.send_response("bar");
+    with_task(|| {
+        assert_fut_ready!(fut1, "foo");
+    });
+    with_task(|| {
+        assert_fut_ready!(fut2, "bar");
+    });
+}
+
+#[test]
+fn low_load() {
+    // start the pool
+    let (mock, mut handle) =
+        mock::pair::<(), load::Constant<mock::Mock<(), &'static str>, usize>>();
+    let mut pool = Builder::new()
+        .urgency(1.0) // so any event will change the service count
+        .build(mock, ());
+    with_task(|| {
+        assert_not_ready!(pool);
+    });
+
+    // give the pool a backing service
+    let (svc1_m, mut svc1) = mock::pair();
+    svc1.allow(1);
+    handle
+        .next_request()
+        .unwrap()
+        .1
+        .send_response(load::Constant::new(svc1_m, 0));
+    with_task(|| {
+        assert_ready!(pool);
+    });
+
+    // cycling a request should now work
+    let mut fut = pool.call(());
+    svc1.next_request().unwrap().1.send_response("foo");
+    with_task(|| {
+        assert_fut_ready!(fut, "foo");
+    });
+    // and pool should now not be ready (since svc1 isn't ready)
+    // it should immediately try to add another service
+    // which we give it
+    with_task(|| {
+        assert_not_ready!(pool);
+    });
+    let (svc2_m, mut svc2) = mock::pair();
+    svc2.allow(1);
+    handle
+        .next_request()
+        .unwrap()
+        .1
+        .send_response(load::Constant::new(svc2_m, 0));
+    // pool is now ready
+    // which (because of urgency == 1.0) should immediately cause it to drop a service
+    // it'll drop svc1, so it'll still be ready
+    with_task(|| {
+        assert_ready!(pool);
+    });
+    // and even with another ready, it won't drop svc2 since its now the only service
+    with_task(|| {
+        assert_ready!(pool);
+    });
+
+    // cycling a request should now work on svc2
+    let mut fut = pool.call(());
+    svc2.next_request().unwrap().1.send_response("foo");
+    with_task(|| {
+        assert_fut_ready!(fut, "foo");
+    });
+
+    // and again (still svc2)
+    svc2.allow(1);
+    with_task(|| {
+        assert_ready!(pool);
+    });
+    let mut fut = pool.call(());
+    svc2.next_request().unwrap().1.send_response("foo");
+    with_task(|| {
+        assert_fut_ready!(fut, "foo");
+    });
+}
+
+#[test]
+fn failing_service() {
+    // start the pool
+    let (mock, mut handle) =
+        mock::pair::<(), load::Constant<mock::Mock<(), &'static str>, usize>>();
+    let mut pool = Builder::new()
+        .urgency(1.0) // so _any_ NotReady will add a service
+        .underutilized_below(0.0) // so no Ready will remove a service
+        .build(mock, ());
+    with_task(|| {
+        assert_not_ready!(pool);
+    });
+
+    // give the pool a backing service
+    let (svc1_m, mut svc1) = mock::pair();
+    svc1.allow(1);
+    handle
+        .next_request()
+        .unwrap()
+        .1
+        .send_response(load::Constant::new(svc1_m, 0));
+    with_task(|| {
+        assert_ready!(pool);
+    });
+
+    // one request-response cycle
+    let mut fut = pool.call(());
+    svc1.next_request().unwrap().1.send_response("foo");
+    with_task(|| {
+        assert_fut_ready!(fut, "foo");
+    });
+
+    // now make svc1 fail, so it has to be removed
+    svc1.send_error("ouch");
+    // polling now should recognize the failed service,
+    // try to create a new one, and then realize the maker isn't ready
+    with_task(|| {
+        assert_not_ready!(pool);
+    });
+    // then we release another service
+    let (svc2_m, mut svc2) = mock::pair();
+    svc2.allow(1);
+    handle
+        .next_request()
+        .unwrap()
+        .1
+        .send_response(load::Constant::new(svc2_m, 0));
+
+    // the pool should now be ready again
+    with_task(|| {
+        assert_ready!(pool);
+    });
+    // and a cycle should work (and go through svc2)
+    let mut fut = pool.call(());
+    svc2.next_request().unwrap().1.send_response("bar");
+    with_task(|| {
+        assert_fut_ready!(fut, "bar");
+    });
+}
+
+fn with_task<F: FnOnce() -> U, U>(f: F) -> U {
+    use futures::future::lazy;
+    lazy(|| Ok::<_, ()>(f())).wait().unwrap()
+}


### PR DESCRIPTION
Prior to this change, when `Balance` dropped a failing service, `Pool` would not be notified of this fact. This meant that it never updated `.services`, and so it might not add a new backing `Service` (e.g., due to `max_services`) even though no working backing exist.

With this change, dropped services notify the `Pool` so that it knows to re-check its limits.

This PR also (finally) adds tests for `Pool`, and fixes some missing wakeup paths that were discovered as a result of those tests. In addition, it moves `Pool` to the new `Box<dyn Error>` error pattern.