### PR TITLE
WIP RFC Introduce tower-breaker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
   "tower",
   "tower-balance",
+  "tower-breaker",
   "tower-buffer",
   "tower-discover",
   "tower-filter",

--- a/tower-breaker/Cargo.toml
+++ b/tower-breaker/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "tower-breaker"
+# When releasing to crates.io:
+# - Remove path dependencies
+# - Update html_root_url.
+# - Update doc url
+#   - Cargo.toml
+#   - README.md
+# - Update CHANGELOG.md.
+# - Create "v0.1.x" git tag.
+version = "0.1.0"
+authors = ["Tower Maintainers <team@tower-rs.com>"]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/tower-rs/tower"
+homepage = "https://github.com/tower-rs/tower"
+documentation = "https://docs.rs/tower-breaker/0.1.0"
+description = """
+Load-based circuit-breaking middlewares
+"""
+categories = ["asynchronous", "network-programming"]
+edition = "2018"
+publish = false
+
+[dependencies]
+futures = "0.1.26"
+tokio-timer = "0.2.4"
+tower-load = { version = "0.1.0", path = "../tower-load" }
+tower-service = "0.2.0"
+tower-util = "0.1.0"

--- a/tower-breaker/src/error.rs
+++ b/tower-breaker/src/error.rs
@@ -1,0 +1,3 @@
+//! Error types
+
+pub(crate) type Error = Box<dyn std::error::Error + Send + Sync>;

--- a/tower-breaker/src/lib.rs
+++ b/tower-breaker/src/lib.rs
@@ -7,7 +7,7 @@ use tower_load::Load;
 use tower_service as svc;
 
 /// Determmines readiness based on an `M`-typed load metric.
-pub trait Breaker<M: PartialOrd> {
+pub trait Breaker<M> {
     /// Checks to see whether the breaker is open, given a load metric.
     ///
     /// If the breaker is closed, NotReady is returned and the task ust be
@@ -62,7 +62,7 @@ pub mod delay {
     use std::time::Instant;
     use tokio_timer::Delay;
 
-    pub trait BreakUntil<M: PartialOrd> {
+    pub trait BreakUntil<M> {
         fn break_until(&mut self, load: M) -> Option<Instant>;
     }
 
@@ -71,7 +71,7 @@ pub mod delay {
         delay: Option<Delay>,
     }
 
-    impl<M: PartialOrd, B: BreakUntil<M>> super::Breaker<M> for Breaker<B> {
+    impl<M, B: BreakUntil<M>> super::Breaker<M> for Breaker<B> {
         fn poll_breaker(&mut self, load: M) -> Poll<(), error::Error> {
             // Even if there's already a delay, update the inner breaker with
             // the new load and reset any pre-existing delay.

--- a/tower-breaker/src/lib.rs
+++ b/tower-breaker/src/lib.rs
@@ -1,0 +1,98 @@
+//! A middleware that blocks readiness based on an inner service's load.
+
+pub mod error;
+
+use futures::{future, try_ready, Future, Poll};
+use tower_load::Load;
+use tower_service as svc;
+
+/// Determmines readiness based on an `M`-typed load metric.
+pub trait Breaker<M: PartialOrd> {
+    /// Checks to see whether the breaker is open, given a load metric.
+    ///
+    /// If the breaker is closed, NotReady is returned and the task ust be
+    /// notified when the breaker should be polled again with an updated load
+    /// metric.
+    fn poll_breaker(&mut self, load: M) -> Poll<(), error::Error>;
+}
+
+/// Wraps a load-bearing service with a load-dependent circuit-breaker.
+pub struct Service<B, S> {
+    breaker: B,
+    inner: S,
+}
+
+// === impl CircuitBreaker ===
+
+impl<B, S> Service<B, S> {
+    /// Wraps an `S` typed service with `B`-typed breaker.
+    pub fn new(breaker: B, inner: S) -> Self {
+        Self { breaker, inner }
+    }
+}
+
+impl<B, S, Req> svc::Service<Req> for Service<B, S>
+where
+    B: Breaker<S::Metric>,
+    S: Load + svc::Service<Req>,
+    S::Error: Into<error::Error>,
+{
+    type Response = S::Response;
+    type Error = error::Error;
+    type Future = future::MapErr<S::Future, fn(S::Error) -> error::Error>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        try_ready!(self.inner.poll_ready().map_err(Into::into));
+        let load = self.inner.load();
+
+        // Update the breaker with the current load and only advertise readiness
+        // when the breaker is open.
+        self.breaker.poll_breaker(load)
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        self.inner.call(req).map_err(Into::into)
+    }
+}
+
+#[allow(missing_docs)]
+pub mod delay {
+    use crate::error;
+    use futures::{try_ready, Async, Future, Poll};
+    use std::time::Instant;
+    use tokio_timer::Delay;
+
+    pub trait BreakUntil<M: PartialOrd> {
+        fn break_until(&mut self, load: M) -> Option<Instant>;
+    }
+
+    pub struct Breaker<B> {
+        break_until: B,
+        delay: Option<Delay>,
+    }
+
+    impl<M: PartialOrd, B: BreakUntil<M>> super::Breaker<M> for Breaker<B> {
+        fn poll_breaker(&mut self, load: M) -> Poll<(), error::Error> {
+            // Even if there's already a delay, update the inner breaker with
+            // the new load and reset any pre-existing delay.
+            //
+            // The `delay` is stored so that the breaker task is notified after
+            // the delay expires.
+            self.delay = self.break_until.break_until(load).map(Delay::new);
+
+            if let Some(delay) = self.delay.as_mut() {
+                try_ready!(delay.poll());
+                self.delay = None;
+            }
+
+            Ok(Async::Ready(()))
+        }
+    }
+
+    #[allow(unused_imports)]
+    pub mod peak_ewma {
+        use tower_load::peak_ewma;
+
+        pub struct Breaker {}
+    }
+}

--- a/tower-breaker/src/lib.rs
+++ b/tower-breaker/src/lib.rs
@@ -43,11 +43,10 @@ where
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         try_ready!(self.inner.poll_ready().map_err(Into::into));
-        let load = self.inner.load();
 
         // Update the breaker with the current load and only advertise readiness
         // when the breaker is open.
-        self.breaker.poll_breaker(load)
+        self.breaker.poll_breaker(self.inner.load())
     }
 
     fn call(&mut self, req: Req) -> Self::Future {


### PR DESCRIPTION
tower-breaker introduces a circuit-breaking middleware that instruments
load-based backpressure.

This is a work-in-progress and should be fleshed out more fully before
merging.