### PR TITLE
timeout: Add `Elapsed::new` and prepare 0.1.1 release

### DIFF
--- a/tower-timeout/CHANGELOG.md
+++ b/tower-timeout/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.1 (July 30th, 2019)
+
+- Add `Elapsed::new`
+
 # 0.1.0 (April 26, 2019)
 
 - Initial release

--- a/tower-timeout/Cargo.toml
+++ b/tower-timeout/Cargo.toml
@@ -8,13 +8,13 @@ name = "tower-timeout"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tower-rs/tower"
 homepage = "https://github.com/tower-rs/tower"
-documentation = "https://docs.rs/tower-timeout/0.1.0"
+documentation = "https://docs.rs/tower-timeout/0.1.1"
 description = """
 Apply a timeout to requests, ensuring completion within a fixed time duration.
 """

--- a/tower-timeout/src/error.rs
+++ b/tower-timeout/src/error.rs
@@ -8,6 +8,13 @@ pub(crate) type Error = Box<dyn error::Error + Send + Sync>;
 #[derive(Debug)]
 pub struct Elapsed(pub(super) ());
 
+impl Elapsed {
+    /// Construct a new elapsed error
+    pub fn new() -> Self {
+        Elapsed(())
+    }
+}
+
 impl fmt::Display for Elapsed {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.pad("request timed out")

--- a/tower-timeout/src/lib.rs
+++ b/tower-timeout/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tower-timeout/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/tower-timeout/0.1.1")]
 #![deny(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 #![allow(elided_lifetimes_in_paths)]
 #![cfg_attr(test, deny(warnings))]


### PR DESCRIPTION
The motivation for this change is to support the ability to test that my `tower-retry` policy will properly retry on `Elapsed` errors.