### PR TITLE
Update tower-balance to std::future::Future

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
   # "tower-hedge",
   # "tower-layer",
   # "tower-limit",
-  # "tower-load",
+  "tower-load",
   # "tower-load-shed",
   # "tower-reconnect",
   # "tower-retry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [
   # "tower",
   # "tower-balance",
   # "tower-buffer",
-  # "tower-discover",
+  "tower-discover",
   # "tower-filter",
   # "tower-hedge",
   # "tower-layer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,12 +2,12 @@
 
 members = [
   # "tower",
-  # "tower-balance",
+  "tower-balance",
   # "tower-buffer",
   "tower-discover",
   # "tower-filter",
   # "tower-hedge",
-  # "tower-layer",
+  "tower-layer",
   # "tower-limit",
   "tower-load",
   # "tower-load-shed",

--- a/tower-balance/Cargo.toml
+++ b/tower-balance/Cargo.toml
@@ -41,7 +41,7 @@ slab = "0.4"
 
 futures-core-preview = "=0.3.0-alpha.18"
 futures-util-preview = "=0.3.0-alpha.18"
-pin-project = "0.4.0-alpha.7"
+pin-project = "0.4.0-alpha.9"
 
 [dev-dependencies]
 tracing-fmt = { git = "https://github.com/tokio-rs/tracing.git" }

--- a/tower-balance/Cargo.toml
+++ b/tower-balance/Cargo.toml
@@ -41,7 +41,7 @@ slab = "0.4"
 
 futures-core-preview = "=0.3.0-alpha.18"
 futures-util-preview = "=0.3.0-alpha.18"
-pin-project = "0.4.0-alpha.6"
+pin-project = "0.4.0-alpha.7"
 
 [dev-dependencies]
 tracing-fmt = { git = "https://github.com/tokio-rs/tracing.git" }

--- a/tower-balance/Cargo.toml
+++ b/tower-balance/Cargo.toml
@@ -27,26 +27,29 @@ log = ["tracing/log"]
 default = ["log"]
 
 [dependencies]
-futures = "0.1.26"
 indexmap = "1.0.2"
 tracing = "0.1"
 rand = "0.6.5"
-tokio-sync = "0.1.3"
-tokio-timer = "0.2.4"
-tower-discover = "0.1.0"
-tower-layer = "0.1.0"
+tokio-sync = "0.2.0-alpha.4"
+tokio-timer = "0.2.0-alpha.4"
+tower-discover = { path = "../tower-discover" }
+tower-layer = { path = "../tower-layer" }
 tower-load = { version = "0.1.0", path = "../tower-load" }
-tower-service = "0.2.0"
-tower-util = "0.1.0"
+tower-service = "0.3.0-alpha.1"
+tower-make = "0.1.0-alpha.1"
 slab = "0.4"
+
+futures-core-preview = "=0.3.0-alpha.18"
+futures-util-preview = "=0.3.0-alpha.18"
+pin-project = "0.4.0-alpha.6"
 
 [dev-dependencies]
 tracing-fmt = { git = "https://github.com/tokio-rs/tracing.git" }
 hdrhistogram = "6.0"
 quickcheck = { version = "0.6", default-features = false }
-tokio = "0.1.7"
-tokio-executor = "0.1.2"
-tower = { version = "*", path = "../tower" }
+tokio = "0.2.0-alpha.4"
+tokio-executor = "0.2.0-alpha.4"
+# tower = { version = "*", path = "../tower" }
 tower-buffer = { version = "*", path = "../tower-buffer" }
 tower-limit = { version = "*", path = "../tower-limit" }
-tower-test = { version = "*", path = "../tower-test" }
+# tower-test = { version = "*", path = "../tower-test" }

--- a/tower-balance/Cargo.toml
+++ b/tower-balance/Cargo.toml
@@ -41,7 +41,7 @@ slab = "0.4"
 
 futures-core-preview = "=0.3.0-alpha.18"
 futures-util-preview = "=0.3.0-alpha.18"
-pin-project = "0.4.0-alpha.9"
+pin-project = "0.4.0-alpha.7"
 
 [dev-dependencies]
 tracing-fmt = { git = "https://github.com/tokio-rs/tracing.git" }

--- a/tower-balance/examples_old/demo.rs
+++ b/tower-balance/examples_old/demo.rs
@@ -10,6 +10,7 @@ use tower::{
     limit::concurrency::ConcurrencyLimit,
     Service, ServiceExt,
 };
+
 use tower_balance as lb;
 use tower_load as load;
 

--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -4,11 +4,7 @@
 #![deny(missing_docs)]
 #![deny(rust_2018_idioms)]
 #![allow(elided_lifetimes_in_paths)]
-// #![deny(warnings)]
-// TODO: remove this, I need to add this due to a bug in pin-project
-// sending out a false positive and I am unable to add this allow directly
-// to the item due to macro magic.
-#![allow(dead_code)]
+#![deny(warnings)]
 
 pub mod error;
 pub mod p2c;

--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -4,7 +4,11 @@
 #![deny(missing_docs)]
 #![deny(rust_2018_idioms)]
 #![allow(elided_lifetimes_in_paths)]
-#![deny(warnings)]
+// #![deny(warnings)]
+// TODO: remove this, I need to add this due to a bug in pin-project
+// sending out a false positive and I am unable to add this allow directly
+// to the item due to macro magic.
+#![allow(dead_code)]
 
 pub mod error;
 pub mod p2c;

--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -8,4 +8,4 @@
 
 pub mod error;
 pub mod p2c;
-pub mod pool;
+// pub mod pool;

--- a/tower-balance/src/p2c/service.rs
+++ b/tower-balance/src/p2c/service.rs
@@ -91,6 +91,8 @@ where
     }
 
     // XXX `pool::Pool` requires direct access to this... Not ideal.
+    // TODO: remove this allow once pool is updated
+    #[allow(dead_code)]
     pub(crate) fn discover_mut(&mut self) -> &mut D {
         &mut self.discover
     }

--- a/tower-balance/src/p2c/test.rs
+++ b/tower-balance/src/p2c/test.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "broken")]
+
 use futures::{Async, Future};
 use tower_discover::ServiceList;
 use tower_load as load;

--- a/tower-discover/Cargo.toml
+++ b/tower-discover/Cargo.toml
@@ -22,5 +22,4 @@ categories = ["asynchronous", "network-programming"]
 edition = "2018"
 
 [dependencies]
-futures = "0.1.26"
-tower-service = "0.2.0"
+tower-service = "0.3.0-alpha.1"

--- a/tower-discover/src/lib.rs
+++ b/tower-discover/src/lib.rs
@@ -11,12 +11,14 @@
 
 mod error;
 mod list;
-mod stream;
+// mod stream;
 
-pub use crate::{list::ServiceList, stream::ServiceStream};
+// pub use crate::{list::ServiceList, stream::ServiceStream};
+pub use crate::list::ServiceList;
 
-use futures::Poll;
 use std::hash::Hash;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 /// Provide a uniform set of services able to satisfy a request.
 ///
@@ -34,7 +36,10 @@ pub trait Discover {
     type Error;
 
     /// Yields the next discovery change set.
-    fn poll(&mut self) -> Poll<Change<Self::Key, Self::Service>, Self::Error>;
+    fn poll(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Change<Self::Key, Self::Service>, Self::Error>>;
 }
 
 /// A change in the service set

--- a/tower-discover/src/lib.rs
+++ b/tower-discover/src/lib.rs
@@ -17,7 +17,6 @@ mod list;
 pub use crate::list::ServiceList;
 
 use std::hash::Hash;
-use std::pin::Pin;
 use std::task::{Context, Poll};
 
 /// Provide a uniform set of services able to satisfy a request.
@@ -37,7 +36,7 @@ pub trait Discover {
 
     /// Yields the next discovery change set.
     fn poll(
-        self: Pin<&mut Self>,
+        &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<Result<Change<Self::Key, Self::Service>, Self::Error>>;
 }

--- a/tower-discover/src/list.rs
+++ b/tower-discover/src/list.rs
@@ -1,6 +1,5 @@
 use crate::{error::Never, Change, Discover};
 use std::iter::{Enumerate, IntoIterator};
-use std::pin::Pin;
 use std::task::{Context, Poll};
 use tower_service::Service;
 
@@ -40,7 +39,7 @@ where
     type Error = Never;
 
     fn poll(
-        mut self: Pin<&mut Self>,
+        &mut self,
         _cx: &mut Context<'_>,
     ) -> Poll<Result<Change<Self::Key, Self::Service>, Self::Error>> {
         match self.inner.next() {

--- a/tower-layer/Cargo.toml
+++ b/tower-layer/Cargo.toml
@@ -22,8 +22,7 @@ categories = ["asynchronous", "network-programming"]
 edition = "2018"
 
 [dependencies]
-futures = "0.1.26"
 tower-service = "0.2.0"
 
-[dev-dependencies]
-void = "1.0.2"
+# [dev-dependencies]
+# void = "1.0.2"

--- a/tower-layer/src/lib.rs
+++ b/tower-layer/src/lib.rs
@@ -20,7 +20,7 @@
 ///
 /// Take request logging as an example:
 ///
-/// ```rust
+/// ```rust,ignore
 /// # extern crate futures;
 /// # extern crate tower_service;
 /// # extern crate void;

--- a/tower-load/Cargo.toml
+++ b/tower-load/Cargo.toml
@@ -27,6 +27,7 @@ tracing = "0.1"
 tokio-timer = "0.3.0-alpha.4"
 tower-service = "0.3.0-alpha.1"
 tower-discover = { path = "../tower-discover" }
+pin-project = "0.4.0-alpha.6"
 
 # [dev-dependencies]
 # tokio-executor = "0.1.2"

--- a/tower-load/Cargo.toml
+++ b/tower-load/Cargo.toml
@@ -23,11 +23,10 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.1.26"
-log = "0.4.1"
-tokio-timer = "0.2.4"
-tower-service = "0.2.0"
-tower-discover = "0.1.0"
+tracing = "0.1"
+tokio-timer = "0.3.0-alpha.4"
+tower-service = "0.3.0-alpha.1"
+tower-discover = { path = "../tower-discover" }
 
-[dev-dependencies]
-tokio-executor = "0.1.2"
+# [dev-dependencies]
+# tokio-executor = "0.1.2"

--- a/tower-load/Cargo.toml
+++ b/tower-load/Cargo.toml
@@ -30,5 +30,7 @@ tower-discover = { path = "../tower-discover" }
 futures-core-preview = "=0.3.0-alpha.18"
 pin-project = "0.4.0-alpha.7"
 
-# [dev-dependencies]
+[dev-dependencies]
+tokio-test = "=0.2.0-alpha.4"
+futures-util-preview = "=0.3.0-alpha.18"
 # tokio-executor = "0.1.2"

--- a/tower-load/Cargo.toml
+++ b/tower-load/Cargo.toml
@@ -27,7 +27,7 @@ tracing = "0.1"
 tokio-timer = "0.3.0-alpha.4"
 tower-service = "0.3.0-alpha.1"
 tower-discover = { path = "../tower-discover" }
-pin-project = "0.4.0-alpha.7"
+pin-project = "0.4.0-alpha.9"
 
 # [dev-dependencies]
 # tokio-executor = "0.1.2"

--- a/tower-load/Cargo.toml
+++ b/tower-load/Cargo.toml
@@ -27,6 +27,7 @@ tracing = "0.1"
 tokio-timer = "0.3.0-alpha.4"
 tower-service = "0.3.0-alpha.1"
 tower-discover = { path = "../tower-discover" }
+futures-core-preview = "=0.3.0-alpha.18"
 pin-project = "0.4.0-alpha.7"
 
 # [dev-dependencies]

--- a/tower-load/Cargo.toml
+++ b/tower-load/Cargo.toml
@@ -27,7 +27,7 @@ tracing = "0.1"
 tokio-timer = "0.3.0-alpha.4"
 tower-service = "0.3.0-alpha.1"
 tower-discover = { path = "../tower-discover" }
-pin-project = "0.4.0-alpha.9"
+pin-project = "0.4.0-alpha.7"
 
 # [dev-dependencies]
 # tokio-executor = "0.1.2"

--- a/tower-load/Cargo.toml
+++ b/tower-load/Cargo.toml
@@ -27,7 +27,7 @@ tracing = "0.1"
 tokio-timer = "0.3.0-alpha.4"
 tower-service = "0.3.0-alpha.1"
 tower-discover = { path = "../tower-discover" }
-pin-project = "0.4.0-alpha.6"
+pin-project = "0.4.0-alpha.7"
 
 # [dev-dependencies]
 # tokio-executor = "0.1.2"

--- a/tower-load/src/constant.rs
+++ b/tower-load/src/constant.rs
@@ -1,6 +1,5 @@
 //! A constant `Load` implementation. Primarily useful for testing.
 
-use std::pin::Pin;
 use std::task::{Context, Poll};
 use tower_discover::{Change, Discover};
 use tower_service::Service;
@@ -56,12 +55,12 @@ impl<D: Discover, M: Copy> Discover for Constant<D, M> {
 
     /// Yields the next discovery change set.
     fn poll(
-        mut self: Pin<&mut Self>,
+        &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<Result<Change<D::Key, Self::Service>, D::Error>> {
         use self::Change::*;
 
-        let change = match unsafe { Pin::new_unchecked(&mut self.inner) }.poll(cx) {
+        let change = match self.inner.poll(cx) {
             Poll::Ready(Ok(Insert(k, svc))) => Insert(k, Constant::new(svc, self.load)),
             Poll::Ready(Ok(Remove(k))) => Remove(k),
             Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),

--- a/tower-load/src/instrument.rs
+++ b/tower-load/src/instrument.rs
@@ -1,3 +1,4 @@
+use futures_core::ready;
 use pin_project::pin_project;
 use std::future::Future;
 use std::pin::Pin;
@@ -66,11 +67,8 @@ where
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let me = self.project();
 
-        let rsp = match me.future.poll(cx) {
-            Poll::Ready(Ok(rsp)) => rsp,
-            Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-            Poll::Pending => return Poll::Pending,
-        };
+        let rsp = ready!(me.future.poll(cx))?;
+
         let h = me.handle.take().expect("handle");
         Ok(me.instrument.instrument(h, rsp)).into()
     }

--- a/tower-load/src/peak_ewma.rs
+++ b/tower-load/src/peak_ewma.rs
@@ -2,8 +2,6 @@
 
 use super::{Instrument, InstrumentFuture, NoInstrument};
 use crate::Load;
-// use std::future::Future;
-use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::{
     sync::{Arc, Mutex},
@@ -111,10 +109,10 @@ where
     type Error = D::Error;
 
     fn poll(
-        mut self: Pin<&mut Self>,
+        &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<Result<Change<D::Key, Self::Service>, D::Error>> {
-        let change = match unsafe { Pin::new_unchecked(&mut self.discover) }.poll(cx) {
+        let change = match self.discover.poll(cx) {
             Poll::Ready(Ok(Change::Remove(k))) => Change::Remove(k),
             Poll::Ready(Ok(Change::Insert(k, svc))) => {
                 let peak_ewma = PeakEwma::new(

--- a/tower-load/src/pending_requests.rs
+++ b/tower-load/src/pending_requests.rs
@@ -2,7 +2,6 @@
 
 use super::{Instrument, InstrumentFuture, NoInstrument};
 use crate::Load;
-use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use tower_discover::{Change, Discover};
@@ -111,12 +110,12 @@ where
 
     /// Yields the next discovery change set.
     fn poll(
-        mut self: Pin<&mut Self>,
+        &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<Result<Change<D::Key, Self::Service>, D::Error>> {
         use self::Change::*;
 
-        let change = match unsafe { Pin::new_unchecked(&mut self.discover) }.poll(cx) {
+        let change = match self.discover.poll(cx) {
             Poll::Ready(Ok(Insert(k, svc))) => {
                 Insert(k, PendingRequests::new(svc, self.instrument.clone()))
             }

--- a/tower-load/src/pending_requests.rs
+++ b/tower-load/src/pending_requests.rs
@@ -2,6 +2,7 @@
 
 use super::{Instrument, InstrumentFuture, NoInstrument};
 use crate::Load;
+use futures_core::ready;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use tower_discover::{Change, Discover};
@@ -113,15 +114,11 @@ where
         &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<Result<Change<D::Key, Self::Service>, D::Error>> {
-        use self::Change::*;
-
-        let change = match self.discover.poll(cx) {
-            Poll::Ready(Ok(Insert(k, svc))) => {
-                Insert(k, PendingRequests::new(svc, self.instrument.clone()))
+        let change = match ready!(self.discover.poll(cx))? {
+            Change::Insert(k, svc) => {
+                Change::Insert(k, PendingRequests::new(svc, self.instrument.clone()))
             }
-            Poll::Ready(Ok(Remove(k))) => Remove(k),
-            Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-            Poll::Pending => return Poll::Pending,
+            Change::Remove(k) => Change::Remove(k),
         };
 
         Poll::Ready(Ok(change))


### PR DESCRIPTION
This is an update of tower balance and its siblings. No tests were updated waiting on tower-test but the functionality here should be the same. This also only updates the p2c section. We can update pool in a following PR.