### PR TITLE
Obviate need for as_mut to assert_request_eq

### DIFF
--- a/tower-buffer/tests/buffer.rs
+++ b/tower-buffer/tests/buffer.rs
@@ -32,7 +32,7 @@ fn clears_canceled_requests() {
         let res1 = service.call("hello");
         pin_mut!(res1);
 
-        let send_response1 = assert_request_eq!(handle.as_mut(), "hello");
+        let send_response1 = assert_request_eq!(handle, "hello");
 
         // don't respond yet, new requests will get buffered
 

--- a/tower-limit/tests/concurrency.rs
+++ b/tower-limit/tests/concurrency.rs
@@ -24,10 +24,10 @@ fn basic_service_limit_functionality_with_poll_ready() {
     assert!(!task.is_woken());
 
     // The request gets passed through
-    assert_request_eq!(handle.as_mut(), "hello 1").send_response("world 1");
+    assert_request_eq!(handle, "hello 1").send_response("world 1");
 
     // The next request gets passed through
-    assert_request_eq!(handle.as_mut(), "hello 2").send_response("world 2");
+    assert_request_eq!(handle, "hello 2").send_response("world 2");
 
     // There are no more requests
     task.enter(|cx| {
@@ -51,7 +51,7 @@ fn basic_service_limit_functionality_with_poll_ready() {
     assert_eq!(block_on(r2).unwrap(), "world 2");
 
     // The request gets passed through
-    assert_request_eq!(handle.as_mut(), "hello 3").send_response("world 3");
+    assert_request_eq!(handle, "hello 3").send_response("world 3");
 
     assert_eq!(block_on(r3).unwrap(), "world 3");
 }
@@ -72,12 +72,12 @@ fn basic_service_limit_functionality_without_poll_ready() {
     assert_pending!(task.enter(|cx| service.poll_ready(cx)));
 
     // The request gets passed through
-    assert_request_eq!(handle.as_mut(), "hello 1").send_response("world 1");
+    assert_request_eq!(handle, "hello 1").send_response("world 1");
 
     assert!(!task.is_woken());
 
     // The next request gets passed through
-    assert_request_eq!(handle.as_mut(), "hello 2").send_response("world 2");
+    assert_request_eq!(handle, "hello 2").send_response("world 2");
 
     assert!(!task.is_woken());
 

--- a/tower-limit/tests/rate.rs
+++ b/tower-limit/tests/rate.rs
@@ -19,7 +19,7 @@ fn reaching_capacity() {
         let response = service.call("hello");
         pin_mut!(response);
 
-        assert_request_eq!(handle.as_mut(), "hello").send_response("world");
+        assert_request_eq!(handle, "hello").send_response("world");
         assert_ready_ok!(task.enter(|cx| response.poll(cx)), "world");
 
         assert_pending!(task.enter(|cx| service.poll_ready(cx)));
@@ -33,7 +33,7 @@ fn reaching_capacity() {
         let response = service.call("two");
         pin_mut!(response);
 
-        assert_request_eq!(handle.as_mut(), "two").send_response("done");
+        assert_request_eq!(handle, "two").send_response("done");
         assert_ready_ok!(task.enter(|cx| response.poll(cx)), "done");
     });
 }

--- a/tower-retry/tests/retry.rs
+++ b/tower-retry/tests/retry.rs
@@ -16,11 +16,11 @@ fn retry_errors() {
         let fut = service.call("hello");
         pin_mut!(fut);
 
-        assert_request_eq!(handle.as_mut(), "hello").send_error("retry me");
+        assert_request_eq!(handle, "hello").send_error("retry me");
 
         assert_pending!(fut.as_mut().poll(cx));
 
-        assert_request_eq!(handle.as_mut(), "hello").send_response("world");
+        assert_request_eq!(handle, "hello").send_response("world");
 
         assert_ready_ok!(fut.poll(cx), "world");
     });
@@ -37,13 +37,13 @@ fn retry_limit() {
         let fut = service.call("hello");
         pin_mut!(fut);
 
-        assert_request_eq!(handle.as_mut(), "hello").send_error("retry 1");
+        assert_request_eq!(handle, "hello").send_error("retry 1");
         assert_pending!(fut.as_mut().poll(cx));
 
-        assert_request_eq!(handle.as_mut(), "hello").send_error("retry 2");
+        assert_request_eq!(handle, "hello").send_error("retry 2");
         assert_pending!(fut.as_mut().poll(cx));
 
-        assert_request_eq!(handle.as_mut(), "hello").send_error("retry 3");
+        assert_request_eq!(handle, "hello").send_error("retry 3");
         assert_eq!(assert_ready_err!(fut.poll(cx)).to_string(), "retry 3");
     });
 }
@@ -58,10 +58,10 @@ fn retry_error_inspection() {
         let fut = service.call("hello");
         pin_mut!(fut);
 
-        assert_request_eq!(handle.as_mut(), "hello").send_error("retry 1");
+        assert_request_eq!(handle, "hello").send_error("retry 1");
         assert_pending!(fut.as_mut().poll(cx));
 
-        assert_request_eq!(handle.as_mut(), "hello").send_error("reject");
+        assert_request_eq!(handle, "hello").send_error("reject");
         assert_eq!(assert_ready_err!(fut.poll(cx)).to_string(), "reject");
     });
 }

--- a/tower-test/src/macros.rs
+++ b/tower-test/src/macros.rs
@@ -38,7 +38,7 @@ macro_rules! assert_request_eq {
         assert_request_eq!($mock_handle, $expect,)
     };
     ($mock_handle:expr, $expect:expr, $($arg:tt)*) => {{
-        let (actual, send_response) = match $mock_handle.next_request() {
+        let (actual, send_response) = match $mock_handle.as_mut().next_request() {
             Some(r) => r,
             None => panic!("expected a request but none was received."),
         };


### PR DESCRIPTION
Calling a method on `Pin<&mut Self>` moves the pin, which means you can't call more methods later. The solution to this is to use `Pin::as_mut`. But it's annoying to have to do that to _every_ call to the `assert_request_eq!` helper macro from `tower-test`, so I made it do it for me.