### PR TITLE
Update tower-reconnect to std::future

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
   "tower-limit",
   "tower-load",
   "tower-load-shed",
-  # "tower-reconnect",
+  "tower-reconnect",
   "tower-retry",
   "tower-service",
   # "tower-spawn-ready",

--- a/tower-make/CHANGELOG.md
+++ b/tower-make/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.0-alpha.1
+
+- Bump version to match all the other crates with `std::future`
+
 # 0.1.0-alpha.2 (August 30, 2019)
 
 - Update `tokio-io` to `alpha.4`

--- a/tower-make/Cargo.toml
+++ b/tower-make/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "tower-make"
-version = "0.1.0-alpha.2"
+version = "0.3.0-alpha.1"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tower-rs/tower"
 homepage = "https://github.com/tower-rs/tower"
-documentation = "https://docs.rs/tower-make/0.1.0-alpha.2"
+documentation = "https://docs.rs/tower-make/0.3.0-alpha.1"
 description = """
 Trait aliases for Services that produce specific types of Responses.
 """

--- a/tower-make/src/lib.rs
+++ b/tower-make/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tower-make/0.1.0-alpha.2")]
+#![doc(html_root_url = "https://docs.rs/tower-make/0.3.0-alpha.1")]
 #![deny(rust_2018_idioms)]
 
 //! Trait aliases for Services that produce specific types of Responses.

--- a/tower-reconnect/CHANGELOG.md
+++ b/tower-reconnect/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.0-alpha.1
+
+- Move to `std::future`
+
 # 0.1.0 (unreleased)
 
 - Initial release

--- a/tower-reconnect/Cargo.toml
+++ b/tower-reconnect/Cargo.toml
@@ -8,13 +8,13 @@ name = "tower-reconnect"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.0"
+version = "0.3.0-alpha.1"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tower-rs/tower"
 homepage = "https://github.com/tower-rs/tower"
-documentation = "https://docs.rs/tower-reconnect/0.1.0"
+documentation = "https://docs.rs/tower-reconnect/0.3.0-alpha.1"
 description = """
 Automatically recreate a new `Service` instance when an error is encountered.
 """
@@ -24,6 +24,6 @@ publish = false
 
 [dependencies]
 log = "0.4.1"
-futures = "0.1.26"
-tower-service = "0.2.0"
-tower-util = "0.1.0"
+tower-service = "0.3.0-alpha.1"
+tower-make = { version = "0.3.0-alpha.1", path = "../tower-make" }
+pin-project = "0.4.0-alpha.10"


### PR DESCRIPTION
This bumps tower-reconnect to 0.3.0-alpha.1.
It also makes the tower-make version consistent with the 0.3.0 move.