### PR TITLE
Make Ready only take Service by reference

### DIFF
--- a/tower-balance/Cargo.toml
+++ b/tower-balance/Cargo.toml
@@ -40,7 +40,6 @@ tower-layer = { version = "=0.3.0-alpha.1", path = "../tower-layer" }
 tower-load = { version = "=0.3.0-alpha.1", path = "../tower-load" }
 tower-service = "=0.3.0-alpha.1"
 tower-make = { version = "=0.3.0-alpha.1", path = "../tower-make" }
-tower-util = { version = "=0.3.0-alpha.1", path = "../tower-util" }
 slab = "0.4"
 
 [dev-dependencies]

--- a/tower-spawn-ready/Cargo.toml
+++ b/tower-spawn-ready/Cargo.toml
@@ -28,7 +28,6 @@ futures-util-preview = "=0.3.0-alpha.18"
 pin-project = "=0.4.0-alpha.11"
 tower-service = "=0.3.0-alpha.1"
 tower-layer = { version = "=0.3.0-alpha.1", path = "../tower-layer" }
-tower-util = { version = "=0.3.0-alpha.1", path = "../tower-util" }
 tokio-executor = "=0.2.0-alpha.4"
 tokio-sync = "=0.2.0-alpha.4"
 

--- a/tower-util/src/ready.rs
+++ b/tower-util/src/ready.rs
@@ -14,7 +14,7 @@ use tower_service::Service;
 /// `Ready` values are produced by `ServiceExt::ready`.
 #[pin_project]
 pub struct Ready<'a, T, Request> {
-    inner: Option<&'a mut T>,
+    inner: &'a mut T,
     _p: PhantomData<fn() -> Request>,
 }
 
@@ -24,7 +24,7 @@ where
 {
     pub fn new(service: &'a mut T) -> Self {
         Ready {
-            inner: Some(service),
+            inner: service,
             _p: PhantomData,
         }
     }
@@ -38,11 +38,7 @@ where
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
-        ready!(this
-            .inner
-            .as_mut()
-            .expect("called `poll` after future completed")
-            .poll_ready(cx))?;
+        ready!(this.inner.poll_ready(cx))?;
 
         Poll::Ready(Ok(()))
     }

--- a/tower/src/util.rs
+++ b/tower/src/util.rs
@@ -14,7 +14,7 @@ type Error = Box<dyn std::error::Error + Send + Sync>;
 /// adapters
 pub trait ServiceExt<Request>: Service<Request> {
     /// A future yielding the service when it is ready to accept a request.
-    fn ready(self) -> Ready<Self, Request>
+    fn ready(&mut self) -> Ready<'_, Self, Request>
     where
         Self: Sized,
     {

--- a/tower/tests/builder.rs
+++ b/tower/tests/builder.rs
@@ -17,7 +17,7 @@ async fn builder_service() {
     pin_mut!(handle);
 
     let policy = MockPolicy;
-    let client = ServiceBuilder::new()
+    let mut client = ServiceBuilder::new()
         .layer(BufferLayer::new(5))
         .layer(ConcurrencyLimitLayer::new(5))
         .layer(RateLimitLayer::new(5, Duration::from_secs(1)))
@@ -28,7 +28,7 @@ async fn builder_service() {
     // allow a request through
     handle.allow(1);
 
-    let mut client = client.ready().await.unwrap();
+    client.ready().await.unwrap();
     let fut = client.call("hello");
     let (request, rsp) = poll_fn(|cx| handle.as_mut().poll_request(cx))
         .await


### PR DESCRIPTION
Rather than consuming `self` and returning `(Self, _)`. This did mean
that a few crates that depended on `Ready` to own the `Service` and
provide it once it was ready had to change to call `poll_ready`
directly. Which in turn meant adding in some PhantomData<Request> so
that the impl blocks wouldn't be under-constrainted. Take, for example:

```rust
impl<K, S: Service<Req>, Req> Future for UnreadyService<K, S>
```

would fail to compile with

```
error[E0207]: the type parameter `Req` is not constrained by the impl trait, self type, or predicates
```