### PR TITLE
change poll_next to poll_recv

### DIFF
--- a/tower-buffer/src/worker.rs
+++ b/tower-buffer/src/worker.rs
@@ -115,7 +115,7 @@ where
         }
 
         // Get the next request
-        while let Some(mut msg) = ready!(Pin::new(&mut self.rx).poll_next(cx)) {
+        while let Some(mut msg) = ready!(Pin::new(&mut self.rx).poll_recv(cx)) {
             if msg.tx.poll_closed(cx).is_pending() {
                 tracing::trace!("processing new request");
                 return Poll::Ready(Some((msg, true)));


### PR DESCRIPTION
This fixes #341 and also may fix the [build error](https://docs.rs/crate/tower/0.3.0-alpha.1/builds/184929) on docs.rs.

The error suggests using `poll_recv` instead, so I tried it and the minimum example compiles now.
