### PR TITLE
Prepare `tower-buffer` 0.3.0-alpha.1a release

### DIFF
--- a/tower-balance/Cargo.toml
+++ b/tower-balance/Cargo.toml
@@ -48,7 +48,7 @@ quickcheck = { version = "0.6", default-features = false }
 tokio = "=0.2.0-alpha.4"
 tokio-executor = "=0.2.0-alpha.4"
 tokio-test = "=0.2.0-alpha.4"
-tower-buffer = { version = "=0.3.0-alpha.1", path = "../tower-buffer" }
+tower-buffer = { version = "=0.3.0-alpha.1a", path = "../tower-buffer" }
 tower-limit = { version = "=0.3.0-alpha.1", path = "../tower-limit" }
 tower-test = { version = "=0.3.0-alpha.1", path = "../tower-test" }
-tower = { version = "=0.3.0-alpha.1", path = "../tower" }
+tower = { version = "=0.3.0-alpha.1a", path = "../tower" }

--- a/tower-buffer/CHANGELOG.md
+++ b/tower-buffer/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.0-alpha.1a (September 13, 2019)
+
+- Fix `poll_next` not exisitng.
+
 # 0.3.0-alpha.1 (September 11, 2019)
 
 - Move to `std::future`

--- a/tower-buffer/Cargo.toml
+++ b/tower-buffer/Cargo.toml
@@ -8,7 +8,7 @@ name = "tower-buffer"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.1a"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"

--- a/tower-buffer/src/lib.rs
+++ b/tower-buffer/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tower-buffer/0.3.0-alpha.1")]
+#![doc(html_root_url = "https://docs.rs/tower-buffer/0.3.0-alpha.1a")]
 #![deny(rust_2018_idioms)]
 #![allow(elided_lifetimes_in_paths)]
 

--- a/tower-util/Cargo.toml
+++ b/tower-util/Cargo.toml
@@ -33,5 +33,5 @@ futures-core-preview = "=0.3.0-alpha.18"
 futures-util-preview = "=0.3.0-alpha.18"
 tokio-test = "=0.2.0-alpha.4"
 tokio = "=0.2.0-alpha.4"
-tower = { version = "=0.3.0-alpha.1", path = "../tower" }
+tower = { version = "=0.3.0-alpha.1a", path = "../tower" }
 tower-test = { version = "=0.3.0-alpha.1", path = "../tower-test" }

--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.0-alpha.1a (September 13, 2019)
+
+- Update `tower-buffer` to `0.3.0-alpha.1a`
+
 # 0.3.0-alpha.1 (September 11, 2019)
 
 - Move to `std::future`

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -8,7 +8,7 @@ name = "tower"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.1a"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"
@@ -28,7 +28,7 @@ default = ["full"]
 full = []
 
 [dependencies]
-tower-buffer = { version = "=0.3.0-alpha.1", path = "../tower-buffer" }
+tower-buffer = { version = "=0.3.0-alpha.1a", path = "../tower-buffer" }
 tower-discover = { version = "=0.3.0-alpha.1", path = "../tower-discover" }
 tower-layer = { version = "=0.3.0-alpha.1", path = "../tower-layer" }
 tower-limit = { version = "=0.3.0-alpha.1", path = "../tower-limit" }

--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tower/0.3.0-alpha.1")]
+#![doc(html_root_url = "https://docs.rs/tower/0.3.0-alpha.1a")]
 // Allows refining features in the future without breaking backwards
 // compatibility
 #![cfg(feature = "full")]


### PR DESCRIPTION
Fixes #341 since for some reason `0.3.0-alpha.1` for buffer got released with a broken version.

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>