### PR TITLE
fix tower-service helloworld docs example

### DIFF
--- a/tower-service/src/lib.rs
+++ b/tower-service/src/lib.rs
@@ -40,10 +40,10 @@ use std::task::{Context, Poll};
 /// impl Service<http::Request> for HelloWorld {
 ///     type Response = http::Response;
 ///     type Error = http::Error;
-///     type Future = Box<Future<Output = Result<Self::Response, Self::Error>>>;
+///     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
 ///
-///     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<(), Self::Error> {
-///         Ok(Async::Ready(()))
+///     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+///         Poll::Ready(Ok(()))
 ///     }
 ///
 ///     fn call(&mut self, req: http::Request) -> Self::Future {
@@ -52,7 +52,7 @@ use std::task::{Context, Poll};
 ///             .with_body(b"hello world\n");
 ///
 ///         // Return the response as an immediate future
-///         Box::new(futures::finished(resp))
+///         Box::pin(futures::future::ok(resp))
 ///     }
 /// }
 /// ```


### PR DESCRIPTION
I tried running the main example on in the `Service` docs with the 0.3.x branch and got a compiler error. This PR updates the example to use the new 0.3 futures primitives. 

I was able to test the example locally by stubbing the http structs.