### PR TITLE
Fix up broken dependencies and deprecated methods

### DIFF
--- a/tower-balance/Cargo.toml
+++ b/tower-balance/Cargo.toml
@@ -41,7 +41,7 @@ tower-util = "0.1.0"
 slab = "0.4"
 
 [dev-dependencies]
-tracing-fmt = { git = "https://github.com/tokio-rs/tracing.git" }
+tracing-subscriber = { git = "https://github.com/tokio-rs/tracing.git" }
 hdrhistogram = "6.0"
 quickcheck = { version = "0.6", default-features = false }
 tokio = "0.1.7"

--- a/tower-balance/Cargo.toml
+++ b/tower-balance/Cargo.toml
@@ -41,7 +41,7 @@ tower-util = "0.1.0"
 slab = "0.4"
 
 [dev-dependencies]
-tracing-subscriber = { git = "https://github.com/tokio-rs/tracing.git" }
+tracing-subscriber = "0.1.3"
 hdrhistogram = "6.0"
 quickcheck = { version = "0.6", default-features = false }
 tokio = "0.1.7"

--- a/tower-balance/examples/demo.rs
+++ b/tower-balance/examples/demo.rs
@@ -37,7 +37,8 @@ struct Summary {
 }
 
 fn main() {
-    tracing::subscriber::set_global_default(tracing_fmt::FmtSubscriber::default()).unwrap();
+    tracing::subscriber::set_global_default(tracing_subscriber::fmt::Subscriber::default())
+        .unwrap();
 
     println!("REQUESTS={}", REQUESTS);
     println!("CONCURRENCY={}", CONCURRENCY);

--- a/tower-balance/src/p2c/service.rs
+++ b/tower-balance/src/p2c/service.rs
@@ -132,7 +132,7 @@ where
                 .next_ready_index
                 .and_then(|i| Self::repair_index(i, idx, self.ready_services.len()));
             debug_assert!(!self.cancelations.contains_key(key));
-        } else if let Some(cancel) = self.cancelations.remove(key) {
+        } else if let Some(cancel) = self.cancelations.swap_remove(key) {
             let _ = cancel.send(());
         }
     }
@@ -143,7 +143,7 @@ where
                 Ok(Async::NotReady) | Ok(Async::Ready(None)) => return,
                 Ok(Async::Ready(Some((key, svc)))) => {
                     trace!("endpoint ready");
-                    let _cancel = self.cancelations.remove(&key);
+                    let _cancel = self.cancelations.swap_remove(&key);
                     debug_assert!(_cancel.is_some(), "missing cancelation");
                     self.ready_services.insert(key, svc);
                 }

--- a/tower-buffer/Cargo.toml
+++ b/tower-buffer/Cargo.toml
@@ -30,7 +30,7 @@ futures = "0.1.25"
 tower-service = "0.2.0"
 tower-layer = "0.1.0"
 tokio-executor = "0.1.7"
-tokio-sync = "0.1.0"
+tokio-sync = "0.1.3"
 tracing = "0.1.2"
 
 [dev-dependencies]

--- a/tower-spawn-ready/Cargo.toml
+++ b/tower-spawn-ready/Cargo.toml
@@ -28,7 +28,7 @@ tower-service = "0.2.0"
 tower-layer = "0.1.0"
 tower-util = "0.1.0"
 tokio-executor = "0.1.7"
-tokio-sync = "0.1.0"
+tokio-sync = "0.1.3"
 
 [dev-dependencies]
 tower = { version = "0.1.0", path = "../tower" }


### PR DESCRIPTION
I ran into a few issues getting everything to compile on master. The fixes were:

1. Follow the reorganization of `tracing-fmt` into `tracing_subscriber`
2. Update all crates to the same version of `'tokio-sync`
3. Stop calling deprecated method on `IndexMap` (should be a change in name only).