### PR TITLE
limit: Add trace log when rate limit is exceeded

### DIFF
--- a/tower-limit/Cargo.toml
+++ b/tower-limit/Cargo.toml
@@ -27,6 +27,7 @@ tower-service = "0.2.0"
 tower-layer = "0.1.0"
 tokio-sync = "0.1.3"
 tokio-timer = "0.2.6"
+tracing = "0.1.2"
 
 [dev-dependencies]
 tower-test = { version = "0.1", path = "../tower-test" }

--- a/tower-limit/src/rate/service.rs
+++ b/tower-limit/src/rate/service.rs
@@ -95,6 +95,7 @@ where
                     self.state = State::Ready { until, rem };
                 } else {
                     // The service is disabled until further notice
+                    tracing::trace!("rate limit exceeded, disabling service");
                     let sleep = Delay::new(until);
                     self.state = State::Limited(sleep);
                 }


### PR DESCRIPTION
Having some visibility into when these limits are hit would be really useful for our application.

There didn't seem to be a strong convention for the style of the message or `tracing::trace!` vs `trace!`, so I just did something similar to tower-buffer. Happy to adjust any of that.