### PR TITLE
Consistently apply deny/warn rules

### DIFF
--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -17,6 +17,7 @@ jobs:
     - script: cargo test
       env:
         CI: 'True'
+        RUSTFLAGS: '-D warnings'
       displayName: cargo test -p ${{ crate }}
       workingDirectory: $(Build.SourcesDirectory)/${{ crate }}
       condition: and(succeeded(), ne(variables['isRelease'], 'true'))
@@ -27,5 +28,6 @@ jobs:
     - script: cargo test
       env:
         CI: 'True'
+        RUSTFLAGS: '-D warnings'
       displayName: cargo test -p ${{ crate }}
       workingDirectory: $(Build.SourcesDirectory)/${{ crate }}

--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -1,9 +1,12 @@
 //! Load balancing middlewares.
 
 #![doc(html_root_url = "https://docs.rs/tower-balance/0.3.0-alpha.1")]
-#![warn(missing_docs)]
-#![warn(rust_2018_idioms)]
-#![warn(missing_debug_implementations)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 #![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 

--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -7,7 +7,6 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 
 pub mod error;

--- a/tower-balance/src/lib.rs
+++ b/tower-balance/src/lib.rs
@@ -1,10 +1,11 @@
 //! Load balancing middlewares.
 
 #![doc(html_root_url = "https://docs.rs/tower-balance/0.3.0-alpha.1")]
-#![deny(missing_docs)]
-#![deny(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_debug_implementations)]
+#![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
-#![deny(warnings)]
 
 pub mod error;
 pub mod p2c;

--- a/tower-balance/src/p2c/make.rs
+++ b/tower-balance/src/p2c/make.rs
@@ -19,8 +19,9 @@ pub struct BalanceMake<S, Req> {
     _marker: PhantomData<fn(Req)>,
 }
 
-#[pin_project]
 /// Makes a balancer instance.
+#[pin_project]
+#[derive(Debug)]
 pub struct MakeFuture<F, Req> {
     #[pin]
     inner: F,

--- a/tower-balance/src/p2c/service.rs
+++ b/tower-balance/src/p2c/service.rs
@@ -6,6 +6,7 @@ use pin_project::pin_project;
 use rand::{rngs::SmallRng, FromEntropy};
 use std::marker::PhantomData;
 use std::{
+    fmt,
     future::Future,
     pin::Pin,
     task::{Context, Poll},
@@ -36,7 +37,6 @@ use tracing::{debug, trace};
 /// [p2c]: http://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf
 /// [`Box::pin`]: https://doc.rust-lang.org/std/boxed/struct.Box.html#method.pin
 /// [#319]: https://github.com/tower-rs/tower/issues/319
-#[derive(Debug)]
 pub struct Balance<D: Discover, Req> {
     discover: D,
 
@@ -52,6 +52,23 @@ pub struct Balance<D: Discover, Req> {
     rng: SmallRng,
 
     _req: PhantomData<Req>,
+}
+
+impl<D: Discover, Req> fmt::Debug for Balance<D, Req>
+where
+    D: fmt::Debug,
+    D::Key: fmt::Debug,
+    D::Service: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Balance")
+            .field("discover", &self.discover)
+            .field("ready_services", &self.ready_services)
+            .field("unready_services", &self.unready_services)
+            .field("cancelations", &self.cancelations)
+            .field("next_ready_index", &self.next_ready_index)
+            .finish()
+    }
 }
 
 #[pin_project]

--- a/tower-balance/src/pool/mod.rs
+++ b/tower-balance/src/pool/mod.rs
@@ -20,6 +20,7 @@ use futures_core::ready;
 use pin_project::pin_project;
 use slab::Slab;
 use std::{
+    fmt,
     future::Future,
     pin::Pin,
     task::{Context, Poll},
@@ -42,9 +43,9 @@ enum Level {
     High,
 }
 
-#[pin_project]
 /// A wrapper around `MakeService` that discovers a new service when load is high, and removes a
 /// service when load is low. See [`Pool`].
+#[pin_project]
 pub struct PoolDiscoverer<MS, Target, Request>
 where
     MS: MakeService<Target, Request>,
@@ -59,6 +60,24 @@ where
     #[pin]
     died_rx: tokio_sync::mpsc::UnboundedReceiver<usize>,
     limit: Option<usize>,
+}
+
+impl<MS, Target, Request> fmt::Debug for PoolDiscoverer<MS, Target, Request>
+where
+    MS: MakeService<Target, Request> + fmt::Debug,
+    MS::Future: fmt::Debug,
+    Target: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PoolDiscoverer")
+            .field("maker", &self.maker)
+            .field("making", &self.making)
+            .field("target", &self.target)
+            .field("load", &self.load)
+            .field("services", &self.services)
+            .field("limit", &self.limit)
+            .finish()
+    }
 }
 
 impl<MS, Target, Request> Discover for PoolDiscoverer<MS, Target, Request>
@@ -298,6 +317,24 @@ where
     ewma: f64,
 }
 
+impl<MS, Target, Request> fmt::Debug for Pool<MS, Target, Request>
+where
+    MS: MakeService<Target, Request> + fmt::Debug,
+    MS::MakeError: Into<error::Error>,
+    MS::Error: Into<error::Error>,
+    Target: Clone + fmt::Debug,
+    MS::Service: fmt::Debug,
+    MS::Future: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Pool")
+            .field("balance", &self.balance)
+            .field("options", &self.options)
+            .field("ewma", &self.ewma)
+            .finish()
+    }
+}
+
 impl<MS, Target, Request> Pool<MS, Target, Request>
 where
     MS: MakeService<Target, Request>,
@@ -396,6 +433,7 @@ where
 }
 
 #[doc(hidden)]
+#[derive(Debug)]
 pub struct DropNotifyService<Svc> {
     svc: Svc,
     id: usize,

--- a/tower-balance/src/pool/mod.rs
+++ b/tower-balance/src/pool/mod.rs
@@ -65,13 +65,12 @@ where
 impl<MS, Target, Request> fmt::Debug for PoolDiscoverer<MS, Target, Request>
 where
     MS: MakeService<Target, Request> + fmt::Debug,
-    MS::Future: fmt::Debug,
     Target: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PoolDiscoverer")
             .field("maker", &self.maker)
-            .field("making", &self.making)
+            .field("making", &self.making.is_some())
             .field("target", &self.target)
             .field("load", &self.load)
             .field("services", &self.services)
@@ -324,7 +323,6 @@ where
     MS::Error: Into<error::Error>,
     Target: Clone + fmt::Debug,
     MS::Service: fmt::Debug,
-    MS::Future: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Pool")

--- a/tower-buffer/src/future.rs
+++ b/tower-buffer/src/future.rs
@@ -14,12 +14,14 @@ use std::{
 
 /// Future eventually completed with the response to the original request.
 #[pin_project]
+#[derive(Debug)]
 pub struct ResponseFuture<T> {
     #[pin]
     state: ResponseState<T>,
 }
 
 #[pin_project]
+#[derive(Debug)]
 enum ResponseState<T> {
     Failed(Option<Error>),
     Rx(#[pin] message::Rx<T>),

--- a/tower-buffer/src/layer.rs
+++ b/tower-buffer/src/layer.rs
@@ -12,6 +12,7 @@ pub struct BufferLayer<Request, E = DefaultExecutor> {
 }
 
 impl<Request> BufferLayer<Request, DefaultExecutor> {
+    #[allow(missing_docs)]
     pub fn new(bound: usize) -> Self {
         BufferLayer {
             bound,
@@ -22,6 +23,7 @@ impl<Request> BufferLayer<Request, DefaultExecutor> {
 }
 
 impl<Request, E: Clone> BufferLayer<Request, E> {
+    /// Create a new buffered service layer spawned on the given executor.
     pub fn with_executor(bound: usize, executor: E) -> Self {
         BufferLayer {
             bound,

--- a/tower-buffer/src/lib.rs
+++ b/tower-buffer/src/lib.rs
@@ -1,5 +1,8 @@
 #![doc(html_root_url = "https://docs.rs/tower-buffer/0.3.0-alpha.1a")]
-#![deny(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_debug_implementations)]
+#![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 
 //! Buffer requests when the inner service is out of capacity.

--- a/tower-buffer/src/lib.rs
+++ b/tower-buffer/src/lib.rs
@@ -5,7 +5,6 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 
 //! Buffer requests when the inner service is out of capacity.

--- a/tower-buffer/src/lib.rs
+++ b/tower-buffer/src/lib.rs
@@ -1,7 +1,10 @@
 #![doc(html_root_url = "https://docs.rs/tower-buffer/0.3.0-alpha.1a")]
-#![warn(missing_docs)]
-#![warn(rust_2018_idioms)]
-#![warn(missing_debug_implementations)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 #![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 

--- a/tower-buffer/src/service.rs
+++ b/tower-buffer/src/service.rs
@@ -14,6 +14,7 @@ use tower_service::Service;
 /// Adds a buffer in front of an inner service.
 ///
 /// See crate level documentation for more details.
+#[derive(Debug)]
 pub struct Buffer<T, Request>
 where
     T: Service<Request>,

--- a/tower-buffer/src/worker.rs
+++ b/tower-buffer/src/worker.rs
@@ -22,6 +22,7 @@ use tower_service::Service;
 /// types in public traits that are not meant for consumers of the library to
 /// implement (only call).
 #[pin_project]
+#[derive(Debug)]
 pub struct Worker<T, Request>
 where
     T: Service<Request>,
@@ -36,6 +37,7 @@ where
 }
 
 /// Get the error out
+#[derive(Debug)]
 pub(crate) struct Handle {
     inner: Arc<Mutex<Option<ServiceError>>>,
 }

--- a/tower-discover/src/lib.rs
+++ b/tower-discover/src/lib.rs
@@ -5,7 +5,6 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 
 //! # Tower service discovery

--- a/tower-discover/src/lib.rs
+++ b/tower-discover/src/lib.rs
@@ -1,7 +1,10 @@
 #![doc(html_root_url = "https://docs.rs/tower-discover/0.3.0-alpha.1")]
-#![warn(missing_docs)]
-#![warn(rust_2018_idioms)]
-#![warn(missing_debug_implementations)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 #![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 

--- a/tower-discover/src/lib.rs
+++ b/tower-discover/src/lib.rs
@@ -1,5 +1,8 @@
 #![doc(html_root_url = "https://docs.rs/tower-discover/0.3.0-alpha.1")]
-#![deny(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_debug_implementations)]
+#![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 
 //! # Tower service discovery
@@ -32,6 +35,7 @@ pub trait Discover {
     /// NewService key
     type Key: Hash + Eq;
 
+    /// The type of `Service` yielded by this `Discover`.
     type Service;
 
     /// Error produced during discovery
@@ -88,7 +92,10 @@ impl<D: ?Sized + Discover + Unpin> Discover for Box<D> {
 }
 
 /// A change in the service set
+#[derive(Debug)]
 pub enum Change<K, V> {
+    /// A new service identified by key `K` was identified.
     Insert(K, V),
+    /// The service identified by key `K` disappeared.
     Remove(K),
 }

--- a/tower-discover/src/list.rs
+++ b/tower-discover/src/list.rs
@@ -12,6 +12,7 @@ use tower_service::Service;
 /// `ServiceList` is created with an initial list of services. The discovery
 /// process will yield this list once and do nothing after.
 #[pin_project]
+#[derive(Debug)]
 pub struct ServiceList<T>
 where
     T: IntoIterator,
@@ -23,6 +24,7 @@ impl<T, U> ServiceList<T>
 where
     T: IntoIterator<Item = U>,
 {
+    #[allow(missing_docs)]
     pub fn new<Request>(services: T) -> ServiceList<T>
     where
         U: Service<Request>,

--- a/tower-discover/src/stream.rs
+++ b/tower-discover/src/stream.rs
@@ -10,12 +10,14 @@ use tower_service::Service;
 
 /// Dynamic service discovery based on a stream of service changes.
 #[pin_project]
+#[derive(Debug)]
 pub struct ServiceStream<S> {
     #[pin]
     inner: S,
 }
 
 impl<S> ServiceStream<S> {
+    #[allow(missing_docs)]
     pub fn new<K, Svc, Request>(services: S) -> Self
     where
         S: TryStream<Ok = Change<K, Svc>>,

--- a/tower-filter/src/layer.rs
+++ b/tower-filter/src/layer.rs
@@ -1,11 +1,14 @@
 use crate::Filter;
 use tower_layer::Layer;
 
+/// Conditionally dispatch requests to the inner service based on a predicate.
+#[derive(Debug)]
 pub struct FilterLayer<U> {
     predicate: U,
 }
 
 impl<U> FilterLayer<U> {
+    #[allow(missing_docs)]
     pub fn new(predicate: U) -> Self {
         FilterLayer { predicate }
     }

--- a/tower-filter/src/lib.rs
+++ b/tower-filter/src/lib.rs
@@ -5,7 +5,6 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 
 //! Conditionally dispatch requests to the inner service based on the result of

--- a/tower-filter/src/lib.rs
+++ b/tower-filter/src/lib.rs
@@ -1,5 +1,8 @@
 #![doc(html_root_url = "https://docs.rs/tower-filter/0.3.0-alpha.1")]
-#![deny(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_debug_implementations)]
+#![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 
 //! Conditionally dispatch requests to the inner service based on the result of
@@ -17,6 +20,7 @@ use futures_core::ready;
 use std::task::{Context, Poll};
 use tower_service::Service;
 
+/// Conditionally dispatch requests to the inner service based on a predicate.
 #[derive(Clone, Debug)]
 pub struct Filter<T, U> {
     inner: T,
@@ -24,6 +28,7 @@ pub struct Filter<T, U> {
 }
 
 impl<T, U> Filter<T, U> {
+    #[allow(missing_docs)]
     pub fn new(inner: T, predicate: U) -> Self {
         Filter { inner, predicate }
     }

--- a/tower-filter/src/lib.rs
+++ b/tower-filter/src/lib.rs
@@ -1,7 +1,10 @@
 #![doc(html_root_url = "https://docs.rs/tower-filter/0.3.0-alpha.1")]
-#![warn(missing_docs)]
-#![warn(rust_2018_idioms)]
-#![warn(missing_debug_implementations)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 #![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 

--- a/tower-filter/src/predicate.rs
+++ b/tower-filter/src/predicate.rs
@@ -3,8 +3,12 @@ use std::future::Future;
 
 /// Checks a request
 pub trait Predicate<Request> {
+    /// The future returned by `check`.
     type Future: Future<Output = Result<(), Error>>;
 
+    /// Check whether the given request should be forwarded.
+    ///
+    /// If the future resolves with `Ok`, the request is forwarded to the inner service.
     fn check(&mut self, request: &Request) -> Self::Future;
 }
 

--- a/tower-hedge/src/lib.rs
+++ b/tower-hedge/src/lib.rs
@@ -7,7 +7,6 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(test, deny(warnings))]
 
 use futures_util::future;
 use log::error;

--- a/tower-hedge/src/lib.rs
+++ b/tower-hedge/src/lib.rs
@@ -1,8 +1,10 @@
 //! Pre-emptively retry requests which have been outstanding for longer
 //! than a given latency percentile.
 
-#![deny(warnings)]
-#![deny(missing_docs)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_debug_implementations)]
+#![cfg_attr(test, deny(warnings))]
 
 use futures_util::future;
 use log::error;
@@ -37,8 +39,9 @@ type Service<S, P> = select::Select<
 #[derive(Debug)]
 pub struct Hedge<S, P>(Service<S, P>);
 
-#[pin_project]
 /// The Future returned by the hedge Service.
+#[pin_project]
+#[derive(Debug)]
 pub struct Future<S, Request>
 where
     S: tower_service::Service<Request>,

--- a/tower-hedge/src/lib.rs
+++ b/tower-hedge/src/lib.rs
@@ -1,9 +1,12 @@
 //! Pre-emptively retry requests which have been outstanding for longer
 //! than a given latency percentile.
 
-#![warn(missing_docs)]
-#![warn(rust_2018_idioms)]
-#![warn(missing_debug_implementations)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 #![cfg_attr(test, deny(warnings))]
 
 use futures_util::future;

--- a/tower-hedge/src/rotating_histogram.rs
+++ b/tower-hedge/src/rotating_histogram.rs
@@ -1,5 +1,3 @@
-extern crate tokio_timer;
-
 use hdrhistogram::Histogram;
 use log::trace;
 use std::time::{Duration, Instant};

--- a/tower-layer/src/lib.rs
+++ b/tower-layer/src/lib.rs
@@ -1,7 +1,10 @@
 #![doc(html_root_url = "https://docs.rs/tower-layer/0.3.0-alpha.1")]
-#![warn(missing_docs)]
-#![warn(rust_2018_idioms)]
-#![warn(missing_debug_implementations)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 #![cfg_attr(test, deny(warnings))]
 
 //! Layer traits and extensions.

--- a/tower-layer/src/lib.rs
+++ b/tower-layer/src/lib.rs
@@ -1,5 +1,8 @@
 #![doc(html_root_url = "https://docs.rs/tower-layer/0.3.0-alpha.1")]
-#![deny(missing_docs, rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_debug_implementations)]
+#![cfg_attr(test, deny(warnings))]
 
 //! Layer traits and extensions.
 //!

--- a/tower-layer/src/lib.rs
+++ b/tower-layer/src/lib.rs
@@ -5,7 +5,6 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(test, deny(warnings))]
 
 //! Layer traits and extensions.
 //!

--- a/tower-limit/src/lib.rs
+++ b/tower-limit/src/lib.rs
@@ -5,7 +5,6 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 
 //! Tower middleware for limiting requests.

--- a/tower-limit/src/lib.rs
+++ b/tower-limit/src/lib.rs
@@ -1,7 +1,10 @@
 #![doc(html_root_url = "https://docs.rs/tower-limit/0.3.0-alpha.1")]
-#![warn(missing_docs)]
-#![warn(rust_2018_idioms)]
-#![warn(missing_debug_implementations)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 #![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 

--- a/tower-limit/src/lib.rs
+++ b/tower-limit/src/lib.rs
@@ -1,6 +1,8 @@
 #![doc(html_root_url = "https://docs.rs/tower-limit/0.3.0-alpha.1")]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
-#![deny(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 #![allow(elided_lifetimes_in_paths)]
 
 //! Tower middleware for limiting requests.

--- a/tower-load-shed/src/lib.rs
+++ b/tower-load-shed/src/lib.rs
@@ -1,6 +1,8 @@
 #![doc(html_root_url = "https://docs.rs/tower-load-shed/0.3.0-alpha.1")]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
-#![deny(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 #![allow(elided_lifetimes_in_paths)]
 
 //! Tower middleware for shedding load when inner services aren't ready.

--- a/tower-load-shed/src/lib.rs
+++ b/tower-load-shed/src/lib.rs
@@ -1,7 +1,10 @@
 #![doc(html_root_url = "https://docs.rs/tower-load-shed/0.3.0-alpha.1")]
-#![warn(missing_docs)]
-#![warn(rust_2018_idioms)]
-#![warn(missing_debug_implementations)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 #![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 

--- a/tower-load-shed/src/lib.rs
+++ b/tower-load-shed/src/lib.rs
@@ -5,7 +5,6 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 
 //! Tower middleware for shedding load when inner services aren't ready.

--- a/tower-load/src/lib.rs
+++ b/tower-load/src/lib.rs
@@ -1,9 +1,10 @@
 //! Abstractions and utilties for measuring a service's load.
 
 #![doc(html_root_url = "https://docs.rs/tower-load/0.3.0-alpha.1")]
-#![deny(missing_docs)]
-#![deny(rust_2018_idioms)]
-#![deny(warnings)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_debug_implementations)]
+#![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 
 mod constant;

--- a/tower-load/src/lib.rs
+++ b/tower-load/src/lib.rs
@@ -1,9 +1,12 @@
 //! Abstractions and utilties for measuring a service's load.
 
 #![doc(html_root_url = "https://docs.rs/tower-load/0.3.0-alpha.1")]
-#![warn(missing_docs)]
-#![warn(rust_2018_idioms)]
-#![warn(missing_debug_implementations)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 #![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 

--- a/tower-load/src/lib.rs
+++ b/tower-load/src/lib.rs
@@ -7,7 +7,6 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 
 mod constant;

--- a/tower-load/src/peak_ewma.rs
+++ b/tower-load/src/peak_ewma.rs
@@ -42,6 +42,7 @@ use tower_service::Service;
 ///
 /// [finagle]:
 /// https://github.com/twitter/finagle/blob/9cc08d15216497bb03a1cafda96b7266cfbbcff1/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/PeakEwma.scala
+#[derive(Debug)]
 pub struct PeakEwma<S, I = NoInstrument> {
     service: S,
     decay_ns: f64,
@@ -51,6 +52,7 @@ pub struct PeakEwma<S, I = NoInstrument> {
 
 /// Wraps a `D`-typed stream of discovery updates with `PeakEwma`.
 #[pin_project]
+#[derive(Debug)]
 pub struct PeakEwmaDiscover<D, I = NoInstrument> {
     #[pin]
     discover: D,
@@ -67,6 +69,7 @@ pub struct PeakEwmaDiscover<D, I = NoInstrument> {
 pub struct Cost(f64);
 
 /// Tracks an in-flight request and updates the RTT-estimate on Drop.
+#[derive(Debug)]
 pub struct Handle {
     sent_at: Instant,
     decay_ns: f64,
@@ -74,6 +77,7 @@ pub struct Handle {
 }
 
 /// Holds the current RTT estimate and the last time this value was updated.
+#[derive(Debug)]
 struct RttEstimate {
     update_at: Instant,
     rtt_ns: f64,

--- a/tower-load/src/pending_requests.rs
+++ b/tower-load/src/pending_requests.rs
@@ -135,7 +135,7 @@ where
 // ==== RefCount ====
 
 impl RefCount {
-    pub fn ref_count(&self) -> usize {
+    pub(crate) fn ref_count(&self) -> usize {
         Arc::strong_count(&self.0)
     }
 }

--- a/tower-make/src/lib.rs
+++ b/tower-make/src/lib.rs
@@ -1,5 +1,8 @@
 #![doc(html_root_url = "https://docs.rs/tower-make/0.3.0-alpha.2")]
-#![deny(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_debug_implementations)]
+#![cfg_attr(test, deny(warnings))]
 
 //! Trait aliases for Services that produce specific types of Responses.
 

--- a/tower-make/src/lib.rs
+++ b/tower-make/src/lib.rs
@@ -1,7 +1,10 @@
 #![doc(html_root_url = "https://docs.rs/tower-make/0.3.0-alpha.2")]
-#![warn(missing_docs)]
-#![warn(rust_2018_idioms)]
-#![warn(missing_debug_implementations)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 #![cfg_attr(test, deny(warnings))]
 
 //! Trait aliases for Services that produce specific types of Responses.

--- a/tower-make/src/lib.rs
+++ b/tower-make/src/lib.rs
@@ -5,7 +5,6 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(test, deny(warnings))]
 
 //! Trait aliases for Services that produce specific types of Responses.
 

--- a/tower-reconnect/src/future.rs
+++ b/tower-reconnect/src/future.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 #[pin_project]
+#[derive(Debug)]
 pub struct ResponseFuture<F> {
     #[pin]
     inner: F,

--- a/tower-reconnect/src/lib.rs
+++ b/tower-reconnect/src/lib.rs
@@ -1,7 +1,6 @@
 #![doc(html_root_url = "https://docs.rs/tower-reconnect/0.3.0-alpha.1")]
 #![warn(missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 #![allow(missing_docs)] // TODO
-#![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 
 pub mod future;

--- a/tower-reconnect/src/lib.rs
+++ b/tower-reconnect/src/lib.rs
@@ -1,7 +1,6 @@
 #![doc(html_root_url = "https://docs.rs/tower-reconnect/0.3.0-alpha.1")]
-//#![warn(missing_docs)]
-#![warn(rust_2018_idioms)]
-#![warn(missing_debug_implementations)]
+#![warn(missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
+#![allow(missing_docs)] // TODO
 #![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 

--- a/tower-reconnect/src/lib.rs
+++ b/tower-reconnect/src/lib.rs
@@ -1,5 +1,8 @@
 #![doc(html_root_url = "https://docs.rs/tower-reconnect/0.3.0-alpha.1")]
-#![deny(rust_2018_idioms)]
+//#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_debug_implementations)]
+#![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 
 pub mod future;

--- a/tower-retry/src/lib.rs
+++ b/tower-retry/src/lib.rs
@@ -1,5 +1,7 @@
 #![doc(html_root_url = "https://docs.rs/tower-retry/0.3.0-alpha.1")]
-#![deny(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 

--- a/tower-retry/src/lib.rs
+++ b/tower-retry/src/lib.rs
@@ -5,7 +5,6 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 
 //! Tower middleware for retrying "failed" requests.

--- a/tower-retry/src/lib.rs
+++ b/tower-retry/src/lib.rs
@@ -1,7 +1,10 @@
 #![doc(html_root_url = "https://docs.rs/tower-retry/0.3.0-alpha.1")]
-#![warn(missing_docs)]
-#![warn(rust_2018_idioms)]
-#![warn(missing_debug_implementations)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 #![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 

--- a/tower-service/src/lib.rs
+++ b/tower-service/src/lib.rs
@@ -1,5 +1,8 @@
-#![deny(missing_docs)]
 #![doc(html_root_url = "https://docs.rs/tower-service/0.3.0-alpha.1")]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_debug_implementations)]
+#![cfg_attr(test, deny(warnings))]
 
 //! Definition of the core `Service` trait to Tower
 //!

--- a/tower-service/src/lib.rs
+++ b/tower-service/src/lib.rs
@@ -5,7 +5,6 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(test, deny(warnings))]
 
 //! Definition of the core `Service` trait to Tower
 //!

--- a/tower-service/src/lib.rs
+++ b/tower-service/src/lib.rs
@@ -1,7 +1,10 @@
 #![doc(html_root_url = "https://docs.rs/tower-service/0.3.0-alpha.1")]
-#![warn(missing_docs)]
-#![warn(rust_2018_idioms)]
-#![warn(missing_debug_implementations)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 #![cfg_attr(test, deny(warnings))]
 
 //! Definition of the core `Service` trait to Tower

--- a/tower-spawn-ready/src/future.rs
+++ b/tower-spawn-ready/src/future.rs
@@ -13,8 +13,9 @@ use tokio_executor::TypedExecutor;
 use tokio_sync::oneshot;
 use tower_service::Service;
 
-#[pin_project]
 /// Drives a service to readiness.
+#[pin_project]
+#[derive(Debug)]
 pub struct BackgroundReady<T, Request> {
     service: Option<T>,
     tx: Option<oneshot::Sender<Result<T, Error>>>,

--- a/tower-spawn-ready/src/lib.rs
+++ b/tower-spawn-ready/src/lib.rs
@@ -5,7 +5,6 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 
 //! When an underlying service is not ready, drive it to readiness on a

--- a/tower-spawn-ready/src/lib.rs
+++ b/tower-spawn-ready/src/lib.rs
@@ -1,7 +1,10 @@
 #![doc(html_root_url = "https://docs.rs/tower-spawn-ready/0.3.0-alpha.1")]
-#![warn(missing_docs)]
-#![warn(rust_2018_idioms)]
-#![warn(missing_debug_implementations)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 #![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 

--- a/tower-spawn-ready/src/lib.rs
+++ b/tower-spawn-ready/src/lib.rs
@@ -1,5 +1,8 @@
 #![doc(html_root_url = "https://docs.rs/tower-spawn-ready/0.3.0-alpha.1")]
-#![deny(missing_docs, rust_2018_idioms, warnings)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_debug_implementations)]
+#![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 
 //! When an underlying service is not ready, drive it to readiness on a

--- a/tower-spawn-ready/src/service.rs
+++ b/tower-spawn-ready/src/service.rs
@@ -16,10 +16,12 @@ use tower_service::Service;
 /// Spawns tasks to drive an inner service to readiness.
 ///
 /// See crate level documentation for more details.
+#[derive(Debug)]
 pub struct SpawnReady<T> {
     inner: Inner<T>,
 }
 
+#[derive(Debug)]
 enum Inner<T> {
     Service(Option<T>),
     Future(oneshot::Receiver<Result<T, Error>>),

--- a/tower-test/src/lib.rs
+++ b/tower-test/src/lib.rs
@@ -1,7 +1,10 @@
 #![doc(html_root_url = "https://docs.rs/tower-test/0.3.0-alpha.1")]
-#![warn(missing_docs)]
-#![warn(rust_2018_idioms)]
-#![warn(missing_debug_implementations)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 #![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 

--- a/tower-test/src/lib.rs
+++ b/tower-test/src/lib.rs
@@ -1,5 +1,8 @@
 #![doc(html_root_url = "https://docs.rs/tower-test/0.3.0-alpha.1")]
-#![deny(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_debug_implementations)]
+#![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 
 //! Mock `Service` that can be used in tests.

--- a/tower-test/src/lib.rs
+++ b/tower-test/src/lib.rs
@@ -5,7 +5,6 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 
 //! Mock `Service` that can be used in tests.

--- a/tower-test/src/mock/error.rs
+++ b/tower-test/src/mock/error.rs
@@ -4,6 +4,7 @@ use std::{error, fmt};
 
 pub(crate) type Error = Box<dyn error::Error + Send + Sync>;
 
+/// Error yielded when a mocked service does not yet accept requests.
 #[derive(Debug)]
 pub struct Closed(());
 

--- a/tower-test/src/mock/mod.rs
+++ b/tower-test/src/mock/mod.rs
@@ -261,11 +261,13 @@ impl<T, U> Drop for Handle<T, U> {
 // ===== impl SendResponse =====
 
 impl<T> SendResponse<T> {
+    /// Resolve the pending request future for the linked request with the given response.
     pub fn send_response(self, response: T) {
         // TODO: Should the result be dropped?
         let _ = self.tx.send(Ok(response));
     }
 
+    /// Resolve the pending request future for the linked request with the given error.
     pub fn send_error<E: Into<Error>>(self, err: E) {
         // TODO: Should the result be dropped?
         let _ = self.tx.send(Err(err.into()));

--- a/tower-timeout/src/error.rs
+++ b/tower-timeout/src/error.rs
@@ -16,7 +16,7 @@ impl Elapsed {
 }
 
 impl fmt::Display for Elapsed {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("request timed out")
     }
 }

--- a/tower-timeout/src/lib.rs
+++ b/tower-timeout/src/lib.rs
@@ -1,7 +1,10 @@
 #![doc(html_root_url = "https://docs.rs/tower-timeout/0.3.0-alpha.1")]
-#![warn(missing_docs)]
-#![warn(rust_2018_idioms)]
-#![warn(missing_debug_implementations)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 #![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 

--- a/tower-timeout/src/lib.rs
+++ b/tower-timeout/src/lib.rs
@@ -1,7 +1,9 @@
 #![doc(html_root_url = "https://docs.rs/tower-timeout/0.3.0-alpha.1")]
-#![deny(missing_debug_implementations, missing_docs, rust_2018_idioms)]
-#![allow(elided_lifetimes_in_paths)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
+#![allow(elided_lifetimes_in_paths)]
 
 //! Tower middleware that applies a timeout to requests.
 //!

--- a/tower-timeout/src/lib.rs
+++ b/tower-timeout/src/lib.rs
@@ -5,7 +5,6 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(test, deny(warnings))]
 
 //! Tower middleware that applies a timeout to requests.
 //!

--- a/tower-timeout/src/lib.rs
+++ b/tower-timeout/src/lib.rs
@@ -6,7 +6,6 @@
     unreachable_pub
 )]
 #![cfg_attr(test, deny(warnings))]
-#![allow(elided_lifetimes_in_paths)]
 
 //! Tower middleware that applies a timeout to requests.
 //!

--- a/tower-util/src/boxed/mod.rs
+++ b/tower-util/src/boxed/mod.rs
@@ -32,4 +32,5 @@
 mod sync;
 mod unsync;
 
+#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::{sync::BoxService, unsync::UnsyncBoxService};

--- a/tower-util/src/boxed/sync.rs
+++ b/tower-util/src/boxed/sync.rs
@@ -30,6 +30,7 @@ struct Boxed<S> {
 }
 
 impl<T, U, E> BoxService<T, U, E> {
+    #[allow(missing_docs)]
     pub fn new<S>(inner: S) -> Self
     where
         S: Service<T, Response = U, Error = E> + Send + 'static,

--- a/tower-util/src/boxed/unsync.rs
+++ b/tower-util/src/boxed/unsync.rs
@@ -24,6 +24,7 @@ struct UnsyncBoxed<S> {
 }
 
 impl<T, U, E> UnsyncBoxService<T, U, E> {
+    #[allow(missing_docs)]
     pub fn new<S>(inner: S) -> Self
     where
         S: Service<T, Response = U, Error = E> + 'static,

--- a/tower-util/src/call_all/mod.rs
+++ b/tower-util/src/call_all/mod.rs
@@ -4,6 +4,7 @@ mod common;
 mod ordered;
 mod unordered;
 
+#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::{ordered::CallAll, unordered::CallAllUnordered};
 
 type Error = Box<dyn std::error::Error + Send + Sync>;

--- a/tower-util/src/either.rs
+++ b/tower-util/src/either.rs
@@ -19,7 +19,9 @@ use tower_service::Service;
 #[pin_project]
 #[derive(Clone, Debug)]
 pub enum Either<A, B> {
+    /// One type of backing `Service`.
     A(#[pin] A),
+    /// The other type of backing `Service`.
     B(#[pin] B),
 }
 

--- a/tower-util/src/lib.rs
+++ b/tower-util/src/lib.rs
@@ -5,7 +5,6 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 
 //! Various utility types and functions that are generally with Tower.

--- a/tower-util/src/lib.rs
+++ b/tower-util/src/lib.rs
@@ -1,7 +1,10 @@
 #![doc(html_root_url = "https://docs.rs/tower-util/0.3.0-alpha.1")]
-#![warn(missing_docs)]
-#![warn(rust_2018_idioms)]
-#![warn(missing_debug_implementations)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 #![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 

--- a/tower-util/src/lib.rs
+++ b/tower-util/src/lib.rs
@@ -1,5 +1,8 @@
 #![doc(html_root_url = "https://docs.rs/tower-util/0.3.0-alpha.1")]
-#![deny(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_debug_implementations)]
+#![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 
 //! Various utility types and functions that are generally with Tower.
@@ -7,12 +10,14 @@
 mod boxed;
 mod call_all;
 mod either;
-pub mod layer;
 mod oneshot;
 mod optional;
 mod ready;
 mod sealed;
 mod service_fn;
+
+/// Different ways to chain service layers.
+pub mod layer;
 
 pub use crate::{
     boxed::{BoxService, UnsyncBoxService},

--- a/tower-util/src/optional/error.rs
+++ b/tower-util/src/optional/error.rs
@@ -1,5 +1,6 @@
 use std::{error, fmt};
 
+/// Error returned if the inner `Service` has not been set.
 #[derive(Debug)]
 pub struct None(());
 

--- a/tower-util/src/optional/future.rs
+++ b/tower-util/src/optional/future.rs
@@ -9,6 +9,7 @@ use std::{
 
 /// Response future returned by `Optional`.
 #[pin_project]
+#[derive(Debug)]
 pub struct ResponseFuture<T> {
     #[pin]
     inner: Option<T>,

--- a/tower-util/src/optional/mod.rs
+++ b/tower-util/src/optional/mod.rs
@@ -3,7 +3,9 @@
 //! See `OptionService` documentation for more details.
 //!
 
+/// Error types for `OptionalService`.
 pub mod error;
+/// Future types for `OptionalService`.
 pub mod future;
 
 use self::{error::Error, future::ResponseFuture};
@@ -13,6 +15,7 @@ use tower_service::Service;
 /// Optionally forwards requests to an inner service.
 ///
 /// If the inner service is `None`, `Error::None` is returned as the response.
+#[derive(Debug)]
 pub struct Optional<T> {
     inner: Option<T>,
 }

--- a/tower-util/src/ready.rs
+++ b/tower-util/src/ready.rs
@@ -22,6 +22,7 @@ impl<'a, T, Request> Ready<'a, T, Request>
 where
     T: Service<Request>,
 {
+    #[allow(missing_docs)]
     pub fn new(service: &'a mut T) -> Self {
         Ready {
             inner: service,

--- a/tower-util/src/sealed.rs
+++ b/tower-util/src/sealed.rs
@@ -1,1 +1,2 @@
+#[allow(unreachable_pub)]
 pub trait Sealed<T> {}

--- a/tower/src/builder/mod.rs
+++ b/tower/src/builder/mod.rs
@@ -188,7 +188,7 @@ impl<L> ServiceBuilder<L> {
 }
 
 impl<L: fmt::Debug> fmt::Debug for ServiceBuilder<L> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("ServiceBuilder").field(&self.layer).finish()
     }
 }

--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -8,7 +8,6 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(test, deny(warnings))]
 
 //! `fn(Request) -> Future<Response>`
 //!

--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -2,9 +2,12 @@
 // Allows refining features in the future without breaking backwards
 // compatibility
 #![cfg(feature = "full")]
-#![warn(missing_docs)]
-#![warn(rust_2018_idioms)]
-#![warn(missing_debug_implementations)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 #![cfg_attr(test, deny(warnings))]
 #![allow(elided_lifetimes_in_paths)]
 

--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -9,7 +9,6 @@
     unreachable_pub
 )]
 #![cfg_attr(test, deny(warnings))]
-#![allow(elided_lifetimes_in_paths)]
 
 //! `fn(Request) -> Future<Response>`
 //!

--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -2,9 +2,11 @@
 // Allows refining features in the future without breaking backwards
 // compatibility
 #![cfg(feature = "full")]
-#![deny(missing_docs, missing_debug_implementations, rust_2018_idioms)]
-#![allow(elided_lifetimes_in_paths)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
+#![allow(elided_lifetimes_in_paths)]
 
 //! `fn(Request) -> Future<Response>`
 //!


### PR DESCRIPTION
This makes all tower subcrates have the following lints as warn (rather than allow): `missing_docs`, `rust_2018_idioms`, and `missing_debug_implementations`. In addition, it consistently applies `deny(warning)` *only* under `#[cfg(test)]` so that deprecations and macro changes in minor version bumps in dependencies will never cause `tower` crates to stop compiling.

Note that `tower-reconnect` has the `missing_docs` lint disabled for now since it contained _no_ documentation previously. Also note that this patch does not add documentation to the various `new` methods, as they are considered self-explanatory. They are instead marked as`#[allow(missing_docs)]`.