### PR TITLE
layer: Prepare 0.3.0 Release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
   # "tower-discover",
   # "tower-filter",
   # "tower-hedge",
-  # "tower-layer",
+  "tower-layer",
   # "tower-limit",
   # "tower-load",
   # "tower-load-shed",

--- a/tower-layer/CHANGELOG.md
+++ b/tower-layer/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.0 (November 29, 2019)
+
+- Move layer builder from `tower-util` to tower-layer.
+
 # 0.3.0-alpha.2 (September 30, 2019)
 
 - Move to `futures-*-preview 0.3.0-alpha.19`

--- a/tower-layer/Cargo.toml
+++ b/tower-layer/Cargo.toml
@@ -8,7 +8,7 @@ name = "tower-layer"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"
@@ -24,4 +24,4 @@ edition = "2018"
 [dependencies]
 
 [dev-dependencies]
-tower-service = { version = "=0.3.0-alpha.2", path = "../tower-service" }
+tower-service = { version = "0.3.0", path = "../tower-service" }

--- a/tower-layer/src/identity.rs
+++ b/tower-layer/src/identity.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use tower_layer::Layer;
+use super::Layer;
 
 /// A no-op middleware.
 ///
@@ -27,7 +27,7 @@ impl<S> Layer<S> for Identity {
 }
 
 impl fmt::Debug for Identity {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Identity").finish()
     }
 }

--- a/tower-layer/src/identity.rs
+++ b/tower-layer/src/identity.rs
@@ -1,5 +1,5 @@
-use std::fmt;
 use super::Layer;
+use std::fmt;
 
 /// A no-op middleware.
 ///

--- a/tower-layer/src/lib.rs
+++ b/tower-layer/src/lib.rs
@@ -15,6 +15,7 @@
 
 mod identity;
 mod stack;
+
 pub use self::{identity::Identity, stack::Stack};
 
 /// Decorates a `Service`, transforming either the request or the response.

--- a/tower-layer/src/lib.rs
+++ b/tower-layer/src/lib.rs
@@ -13,6 +13,10 @@
 //!
 //! A middleware implements the [`Layer`] and [`Service`] trait.
 
+mod identity;
+mod stack;
+pub use self::{identity::Identity, stack::Stack};
+
 /// Decorates a `Service`, transforming either the request or the response.
 ///
 /// Often, many of the pieces needed for writing network applications can be

--- a/tower-layer/src/stack.rs
+++ b/tower-layer/src/stack.rs
@@ -1,5 +1,5 @@
-use std::fmt;
 use super::Layer;
+use std::fmt;
 
 /// Two middlewares chained together.
 #[derive(Clone)]

--- a/tower-layer/src/stack.rs
+++ b/tower-layer/src/stack.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use tower_layer::Layer;
+use super::Layer;
 
 /// Two middlewares chained together.
 #[derive(Clone)]
@@ -34,7 +34,7 @@ where
     Inner: fmt::Debug,
     Outer: fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // The generated output of nested `Stack`s is very noisy and makes
         // it harder to understand what is in a `ServiceBuilder`.
         //

--- a/tower-util/src/layer/mod.rs
+++ b/tower-util/src/layer/mod.rs
@@ -1,4 +1,0 @@
-mod identity;
-mod stack;
-
-pub use self::{identity::Identity, stack::Stack};

--- a/tower-util/src/lib.rs
+++ b/tower-util/src/lib.rs
@@ -18,9 +18,6 @@ mod ready;
 mod sealed;
 mod service_fn;
 
-/// Different ways to chain service layers.
-pub mod layer;
-
 pub use crate::{
     boxed::{BoxService, UnsyncBoxService},
     call_all::{CallAll, CallAllUnordered},


### PR DESCRIPTION
This PR prepares `tower-layer` for a `0.3.0` release. Additionally, this PR moves the layering code from `tower-util` to `tower-layer` in the style of the `tracing-subscriber`.