### PR TITLE
Update timeout, tower-test and reconnect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
   "tower-service",
   # "tower-spawn-ready",
   # "tower-test",
-  # "tower-timeout",
+  "tower-timeout",
   "tower-make",
   # "tower-util",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
   # "tower-retry",
   "tower-service",
   # "tower-spawn-ready",
-  # "tower-test",
+  "tower-test",
   "tower-timeout",
   "tower-make",
   # "tower-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
   # "tower-load",
   # "tower-load-shed",
   # "tower-ready-cache",
-  # "tower-reconnect",
+  "tower-reconnect",
   # "tower-retry",
   "tower-service",
   # "tower-spawn-ready",

--- a/tower-reconnect/CHANGELOG.md
+++ b/tower-reconnect/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.0 (December 1, 2019)
+
+- Update to `tower-service 0.3`
+
 # 0.3.0-alpha.2 (September 30, 2019)
 
 - Move to `futures-*-preview 0.3.0-alpha.19`

--- a/tower-reconnect/Cargo.toml
+++ b/tower-reconnect/Cargo.toml
@@ -8,7 +8,7 @@ name = "tower-reconnect"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"
@@ -23,6 +23,6 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.1"
-tower-service = { version = "=0.3.0-alpha.2", path = "../tower-service" }
-tower-make = { version = "=0.3.0-alpha.2a", path = "../tower-make" }
+tower-service = { version = "0.3", path = "../tower-service" }
+tower-make = { version = "0.3", path = "../tower-make" }
 pin-project = "0.4"

--- a/tower-reconnect/src/future.rs
+++ b/tower-reconnect/src/future.rs
@@ -6,6 +6,7 @@ use std::{
     task::{Context, Poll},
 };
 
+/// Future that resolves to the response or failure to connect.
 #[pin_project]
 #[derive(Debug)]
 pub struct ResponseFuture<F> {

--- a/tower-reconnect/src/lib.rs
+++ b/tower-reconnect/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tower-reconnect/0.3.0-alpha.2")]
+#![doc(html_root_url = "https://docs.rs/tower-reconnect/0.3.0")]
 #![warn(missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 #![allow(missing_docs)] // TODO
 #![allow(elided_lifetimes_in_paths)]
@@ -16,6 +16,7 @@ use std::{
 use tower_make::MakeService;
 use tower_service::Service;
 
+/// Reconnect to failed services.
 pub struct Reconnect<M, Target>
 where
     M: Service<Target>,
@@ -38,6 +39,7 @@ impl<M, Target> Reconnect<M, Target>
 where
     M: Service<Target>,
 {
+    /// Lazily connect and reconnect to a Service.
     pub fn new<S, Request>(mk_service: M, target: Target) -> Self
     where
         M: Service<Target, Response = S>,
@@ -48,6 +50,15 @@ where
         Reconnect {
             mk_service,
             state: State::Idle,
+            target,
+        }
+    }
+
+    /// Reconnect to a already connected Service.
+    pub fn with_connection(init_conn: M::Response, mk_service: M, target: Target) -> Self {
+        Reconnect {
+            mk_service,
+            state: State::Connected(init_conn),
             target,
         }
     }

--- a/tower-test/CHANGELOG.md
+++ b/tower-test/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.3.0 (December 1, 2019)
+
+- Remove `futures-executor` dependency
+- Update to non-alpha versions
+- Add `mock::task_fn` util fn
+
 # 0.3.0-alpha.2 (September 30, 2019)
 
 - Move to `futures-*-preview 0.3.0-alpha.19`

--- a/tower-test/Cargo.toml
+++ b/tower-test/Cargo.toml
@@ -8,7 +8,7 @@ name = "tower-test"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"
@@ -22,9 +22,8 @@ categories = ["asynchronous", "network-programming"]
 edition = "2018"
 
 [dependencies]
-futures-util-preview = "=0.3.0-alpha.19"
-futures-executor-preview = "=0.3.0-alpha.19"
-tokio-test = "=0.2.0-alpha.6"
-tokio-sync = "=0.2.0-alpha.6"
-tower-service = { version = "=0.3.0-alpha.2", path = "../tower-service" }
+futures-util = "0.3"
+tokio = { version = "0.2", features = ["sync"]}
+tokio-test = "0.2"
+tower-service = { version = "0.3", path = "../tower-service" }
 pin-project = "0.4"

--- a/tower-test/src/lib.rs
+++ b/tower-test/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tower-test/0.3.0-alpha.2")]
+#![doc(html_root_url = "https://docs.rs/tower-test/0.3.0")]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tower-test/src/macros.rs
+++ b/tower-test/src/macros.rs
@@ -14,15 +14,11 @@
 /// use tower_service::Service;
 /// use tower_test::mock;
 /// use std::task::{Poll, Context};
-/// use tokio_test::{task, assert_ready};
+/// use tokio_test::assert_ready;
 /// use futures_util::pin_mut;
 ///
 /// # fn main() {
-/// task::mock(|cx|{
-///     let (mut mock, mut handle) = mock::pair();
-///     pin_mut!(mock);
-///     pin_mut!(handle);
-///
+/// mock::task_fn(|cx, mock, handle|{
 ///     assert_ready!(mock.poll_ready(cx));
 ///
 ///     let _response = mock.call("hello");

--- a/tower-test/src/mock/future.rs
+++ b/tower-test/src/mock/future.rs
@@ -3,7 +3,7 @@
 use crate::mock::error::{self, Error};
 use futures_util::ready;
 use pin_project::pin_project;
-use tokio_sync::oneshot;
+use tokio::sync::oneshot;
 
 use std::{
     future::Future,

--- a/tower-timeout/CHANGELOG.md
+++ b/tower-timeout/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.0 (December 1, 2019)
+
+- Update to `tower-service 0.3`
+
 # 0.3.0-alpha.2 (September 30, 2019)
 
 - Move to `futures-*-preview 0.3.0-alpha.19`

--- a/tower-timeout/Cargo.toml
+++ b/tower-timeout/Cargo.toml
@@ -7,14 +7,14 @@ name = "tower-timeout"
 #   - Cargo.toml
 #   - README.md
 # - Update CHANGELOG.md.
-# - Create "v0.1.x" git tag.
-version = "0.3.0-alpha.2"
+# - Create "v0.3.x" git tag.
+version = "0.3.0"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tower-rs/tower"
 homepage = "https://github.com/tower-rs/tower"
-documentation = "https://docs.rs/tower-timeout/0.3.0-alpha.2"
+documentation = "https://docs.rs/tower-timeout/0.3.0"
 description = """
 Apply a timeout to requests, ensuring completion within a fixed time duration.
 """
@@ -22,7 +22,7 @@ categories = ["asynchronous", "network-programming"]
 edition = "2018"
 
 [dependencies]
-tower-service = { version = "=0.3.0-alpha.2", path = "../tower-service" }
-tower-layer = { version = "=0.3.0-alpha.2", path = "../tower-layer" }
-tokio-timer = "=0.3.0-alpha.6"
+tower-service = { version = "0.3", path = "../tower-service" }
+tower-layer = { version = "0.3", path = "../tower-layer" }
+tokio = { version = "0.2", features = ["time"] }
 pin-project = "0.4"

--- a/tower-timeout/src/future.rs
+++ b/tower-timeout/src/future.rs
@@ -7,7 +7,7 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tokio_timer::Delay;
+use tokio::time::Delay;
 
 /// `Timeout` response future
 #[pin_project]

--- a/tower-timeout/src/lib.rs
+++ b/tower-timeout/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tower-timeout/0.3.0-alpha.2")]
+#![doc(html_root_url = "https://docs.rs/tower-timeout/0.3.0")]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tower-timeout/src/lib.rs
+++ b/tower-timeout/src/lib.rs
@@ -19,11 +19,8 @@ pub use crate::layer::TimeoutLayer;
 
 use crate::{error::Error, future::ResponseFuture};
 use std::task::{Context, Poll};
-use tokio_timer::{clock, delay};
-
-use tower_service::Service;
-
 use std::time::Duration;
+use tower_service::Service;
 
 /// Applies a timeout to requests.
 #[derive(Debug, Clone)]
@@ -59,7 +56,7 @@ where
 
     fn call(&mut self, request: Request) -> Self::Future {
         let response = self.inner.call(request);
-        let sleep = delay(clock::now() + self.timeout);
+        let sleep = tokio::time::delay_for(self.timeout);
 
         ResponseFuture::new(response, sleep)
     }


### PR DESCRIPTION
`tower-test` needs a better refactor to follow what we do in `tokio/tests`.