### PR TITLE
Update buffer and prepare for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 members = [
   # "tower",
   # "tower-balance",
-  # "tower-buffer",
+  "tower-buffer",
   # "tower-discover",
   # "tower-filter",
   # "tower-hedge",

--- a/tower-buffer/CHANGELOG.md
+++ b/tower-buffer/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.3.0 (December 4, 2019)
+
+- Update to `tokio 0.2`
+- Update to `futures-core 0.3`
+- Update to `tower-service 0.3`
+- Update to `tower-layer 0.3`
+
 # 0.3.0-alpha.2 (September 30, 2019)
 
 - Move to `futures-*-preview 0.3.0-alpha.19`

--- a/tower-buffer/Cargo.toml
+++ b/tower-buffer/Cargo.toml
@@ -8,7 +8,7 @@ name = "tower-buffer"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.3.0-alpha.2"
+version = "0.3.0"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"
@@ -26,15 +26,14 @@ log = ["tracing/log"]
 default = ["log"]
 
 [dependencies]
-futures-core-preview = "=0.3.0-alpha.19"
+futures-core = "0.3"
 pin-project = "0.4"
-tower-service = { version = "=0.3.0-alpha.2", path = "../tower-service" }
-tower-layer = { version = "=0.3.0-alpha.2", path = "../tower-layer" }
-tokio-executor = "=0.2.0-alpha.6"
-tokio-sync = "=0.2.0-alpha.6"
+tower-service = { version = "0.3", path = "../tower-service" }
+tower-layer = { version = "0.3", path = "../tower-layer" }
+tokio = { version = "0.2", features = ["sync"] }
 tracing = "0.1.2"
 
 [dev-dependencies]
-tower-test = { version = "=0.3.0-alpha.2", path = "../tower-test" }
-tokio-test = { version = "=0.2.0-alpha.6" }
-futures-util-preview = "=0.3.0-alpha.19"
+tower-test = { version = "0.3", path = "../tower-test" }
+tokio-test = { version = "0.2" }
+tokio = { version = "0.2", features = ["macros"] }

--- a/tower-buffer/src/error.rs
+++ b/tower-buffer/src/error.rs
@@ -14,12 +14,6 @@ pub struct Closed {
     _p: (),
 }
 
-/// Error produced when spawning the worker fails
-#[derive(Debug)]
-pub struct SpawnError {
-    _p: (),
-}
-
 /// Errors produced by `Buffer`.
 pub(crate) type Error = Box<dyn std::error::Error + Send + Sync>;
 
@@ -66,19 +60,3 @@ impl fmt::Display for Closed {
 }
 
 impl std::error::Error for Closed {}
-
-// ===== impl SpawnError =====
-
-impl SpawnError {
-    pub(crate) fn new() -> SpawnError {
-        SpawnError { _p: () }
-    }
-}
-
-impl fmt::Display for SpawnError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "failed to spawn Buffer worker task")
-    }
-}
-
-impl std::error::Error for SpawnError {}

--- a/tower-buffer/src/lib.rs
+++ b/tower-buffer/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tower-buffer/0.3.0-alpha.2")]
+#![doc(html_root_url = "https://docs.rs/tower-buffer/0.3.0")]
 #![warn(
     missing_debug_implementations,
     missing_docs,
@@ -23,4 +23,3 @@ mod worker;
 
 pub use crate::layer::BufferLayer;
 pub use crate::service::Buffer;
-pub use crate::worker::WorkerExecutor;

--- a/tower-buffer/src/message.rs
+++ b/tower-buffer/src/message.rs
@@ -1,5 +1,5 @@
 use crate::error::ServiceError;
-use tokio_sync::oneshot;
+use tokio::sync::oneshot;
 
 /// Message sent over buffer
 #[derive(Debug)]

--- a/tower-buffer/src/service.rs
+++ b/tower-buffer/src/service.rs
@@ -49,7 +49,7 @@ where
 
     /// Creates a new `Buffer` wrapping `service` but returns the background worker.
     ///
-    /// This is useful if you do not want to spawn directly onto the tokio runtime
+    /// This is useful if you do not want to spawn directly onto the `tokio` runtime
     /// but instead want to use your own executor. This will return the `Buffer` and
     /// the background `Worker` that you can then spawn.
     pub fn pair(service: T, bound: usize) -> (Buffer<T, Request>, Worker<T, Request>)

--- a/tower-buffer/tests/buffer.rs
+++ b/tower-buffer/tests/buffer.rs
@@ -1,223 +1,150 @@
-use futures_util::pin_mut;
-use std::future::Future;
-use std::{cell::RefCell, thread};
-use tokio_executor::{SpawnError, TypedExecutor};
+use std::thread;
 use tokio_test::{assert_pending, assert_ready, assert_ready_err, assert_ready_ok, task};
 use tower_buffer::{error, Buffer};
-use tower_service::Service;
 use tower_test::{assert_request_eq, mock};
 
 fn let_worker_work() {
     // Allow the Buffer's executor to do work
-    ::std::thread::sleep(::std::time::Duration::from_millis(100));
+    thread::sleep(::std::time::Duration::from_millis(100));
 }
 
-#[test]
-fn req_and_res() {
-    task::mock(|cx| {
-        let (mut service, handle) = new_service();
+#[tokio::test]
+async fn req_and_res() {
+    let (mut service, mut handle) = new_service();
 
-        let response = service.call("hello");
-        pin_mut!(response);
-        pin_mut!(handle);
+    let mut response = task::spawn(service.call("hello"));
 
-        assert_request_eq!(handle, "hello").send_response("world");
+    assert_request_eq!(handle, "hello").send_response("world");
 
-        let_worker_work();
-        assert_eq!(assert_ready_ok!(response.as_mut().poll(cx)), "world");
-    });
+    let_worker_work();
+    assert_eq!(assert_ready_ok!(response.poll()), "world");
 }
 
-#[test]
-fn clears_canceled_requests() {
-    task::mock(|cx| {
-        let (mut service, handle) = new_service();
-        pin_mut!(handle);
+#[tokio::test]
+async fn clears_canceled_requests() {
+    let (mut service, mut handle) = new_service();
 
-        handle.allow(1);
+    handle.allow(1);
 
-        let res1 = service.call("hello");
-        pin_mut!(res1);
+    let mut res1 = task::spawn(service.call("hello"));
 
-        let send_response1 = assert_request_eq!(handle, "hello");
+    let send_response1 = assert_request_eq!(handle, "hello");
 
-        // don't respond yet, new requests will get buffered
+    // don't respond yet, new requests will get buffered
 
-        let res2 = service.call("hello2");
+    let res2 = task::spawn(service.call("hello2"));
 
-        assert_pending!(handle.as_mut().poll_request(cx));
+    assert_pending!(handle.poll_request());
 
-        let res3 = service.call("hello3");
-        pin_mut!(res3);
+    let mut res3 = task::spawn(service.call("hello3"));
 
-        drop(res2);
+    drop(res2);
 
-        send_response1.send_response("world");
+    send_response1.send_response("world");
 
-        let_worker_work();
-        assert_eq!(assert_ready_ok!(res1.poll(cx)), "world");
+    let_worker_work();
+    assert_eq!(assert_ready_ok!(res1.poll()), "world");
 
-        // res2 was dropped, so it should have been canceled in the buffer
-        handle.allow(1);
+    // res2 was dropped, so it should have been canceled in the buffer
+    handle.allow(1);
 
-        assert_request_eq!(handle, "hello3").send_response("world3");
+    assert_request_eq!(handle, "hello3").send_response("world3");
 
-        let_worker_work();
-        assert_eq!(assert_ready_ok!(res3.poll(cx)), "world3");
-    });
+    let_worker_work();
+    assert_eq!(assert_ready_ok!(res3.poll()), "world3");
 }
 
-#[test]
-fn when_inner_is_not_ready() {
-    task::mock(|cx| {
-        let (mut service, handle) = new_service();
-        pin_mut!(handle);
+#[tokio::test]
+async fn when_inner_is_not_ready() {
+    let (mut service, mut handle) = new_service();
 
-        // Make the service NotReady
-        handle.allow(0);
+    // Make the service NotReady
+    handle.allow(0);
 
-        let res1 = service.call("hello");
-        pin_mut!(res1);
+    let mut res1 = task::spawn(service.call("hello"));
 
-        let_worker_work();
-        assert_pending!(res1.as_mut().poll(cx));
-        assert_pending!(handle.as_mut().poll_request(cx));
+    let_worker_work();
+    assert_pending!(res1.poll());
+    assert_pending!(handle.poll_request());
 
-        handle.allow(1);
+    handle.allow(1);
 
-        assert_request_eq!(handle, "hello").send_response("world");
+    assert_request_eq!(handle, "hello").send_response("world");
 
-        let_worker_work();
-        assert_eq!(assert_ready_ok!(res1.poll(cx)), "world");
-    });
+    let_worker_work();
+    assert_eq!(assert_ready_ok!(res1.poll()), "world");
 }
 
-#[test]
-fn when_inner_fails() {
-    task::mock(|cx| {
-        use std::error::Error as StdError;
+#[tokio::test]
+async fn when_inner_fails() {
+    use std::error::Error as StdError;
 
-        let (mut service, mut handle) = new_service();
+    let (mut service, mut handle) = new_service();
 
-        // Make the service NotReady
-        handle.allow(0);
-        handle.send_error("foobar");
+    // Make the service NotReady
+    handle.allow(0);
+    handle.send_error("foobar");
 
-        let res1 = service.call("hello");
-        pin_mut!(res1);
+    let mut res1 = task::spawn(service.call("hello"));
 
-        let_worker_work();
-        let e = assert_ready_err!(res1.poll(cx));
-        if let Some(e) = e.downcast_ref::<error::ServiceError>() {
-            let e = e.source().unwrap();
+    let_worker_work();
+    let e = assert_ready_err!(res1.poll());
+    if let Some(e) = e.downcast_ref::<error::ServiceError>() {
+        let e = e.source().unwrap();
 
-            assert_eq!(e.to_string(), "foobar");
-        } else {
-            panic!("unexpected error type: {:?}", e);
-        }
-    });
+        assert_eq!(e.to_string(), "foobar");
+    } else {
+        panic!("unexpected error type: {:?}", e);
+    }
 }
 
-#[test]
-fn when_spawn_fails() {
-    task::mock(|cx| {
-        let (service, _handle) = mock::pair::<(), ()>();
+#[tokio::test]
+async fn poll_ready_when_worker_is_dropped_early() {
+    let (service, _handle) = mock::pair::<(), ()>();
 
-        let mut exec = ExecFn(|_| Err(()));
+    let (service, worker) = Buffer::pair(service, 1);
 
-        let mut service = Buffer::with_executor(service, 1, &mut exec);
+    let mut service = mock::Spawn::new(service);
 
-        let err = assert_ready_err!(service.poll_ready(cx));
+    drop(worker);
 
-        assert!(
-            err.is::<error::SpawnError>(),
-            "should be a SpawnError: {:?}",
-            err
-        );
-    })
+    let err = assert_ready_err!(service.poll_ready());
+
+    assert!(err.is::<error::Closed>(), "should be a Closed: {:?}", err);
 }
 
-#[test]
-fn poll_ready_when_worker_is_dropped_early() {
-    task::mock(|cx| {
-        let (service, _handle) = mock::pair::<(), ()>();
+#[tokio::test]
+async fn response_future_when_worker_is_dropped_early() {
+    let (service, mut handle) = mock::pair::<_, ()>();
 
-        // drop that worker right on the floor!
-        let mut exec = ExecFn(|fut| {
-            drop(fut);
-            Ok(())
-        });
+    let (service, worker) = Buffer::pair(service, 1);
 
-        let mut service = Buffer::with_executor(service, 1, &mut exec);
+    let mut service = mock::Spawn::new(service);
 
-        let err = assert_ready_err!(service.poll_ready(cx));
+    // keep the request in the worker
+    handle.allow(0);
+    let mut response = task::spawn(service.call("hello"));
 
-        assert!(err.is::<error::Closed>(), "should be a Closed: {:?}", err);
-    });
-}
+    drop(worker); 
 
-#[test]
-fn response_future_when_worker_is_dropped_early() {
-    task::mock(|cx| {
-        let (service, mut handle) = mock::pair::<_, ()>();
-
-        // hold the worker in a cell until we want to drop it later
-        let cell = RefCell::new(None);
-        let mut exec = ExecFn(|fut| {
-            *cell.borrow_mut() = Some(fut);
-            Ok(())
-        });
-
-        let mut service = Buffer::with_executor(service, 1, &mut exec);
-
-        // keep the request in the worker
-        handle.allow(0);
-        let response = service.call("hello");
-        pin_mut!(response);
-
-        // drop the worker (like an executor closing up)
-        cell.borrow_mut().take();
-
-        let_worker_work();
-        let err = assert_ready_err!(response.poll(cx));
-        assert!(err.is::<error::Closed>(), "should be a Closed: {:?}", err);
-    })
+    let_worker_work();
+    let err = assert_ready_err!(response.poll());
+    assert!(err.is::<error::Closed>(), "should be a Closed: {:?}", err);
 }
 
 type Mock = mock::Mock<&'static str, &'static str>;
 type Handle = mock::Handle<&'static str, &'static str>;
 
-struct Exec;
-
-impl<F> TypedExecutor<F> for Exec
-where
-    F: Future<Output = ()> + Send + 'static,
-{
-    fn spawn(&mut self, fut: F) -> Result<(), SpawnError> {
-        thread::spawn(move || {
-            let mut mock = tokio_test::task::MockTask::new();
-            pin_mut!(fut);
-            while mock.poll(fut.as_mut()).is_pending() {}
-        });
-        Ok(())
-    }
-}
-
-struct ExecFn<Func>(Func);
-
-impl<Func, F> TypedExecutor<F> for ExecFn<Func>
-where
-    Func: Fn(F) -> Result<(), ()>,
-    F: Future<Output = ()> + Send + 'static,
-{
-    fn spawn(&mut self, fut: F) -> Result<(), SpawnError> {
-        (self.0)(fut).map_err(|()| SpawnError::shutdown())
-    }
-}
-
-fn new_service() -> (Buffer<Mock, &'static str>, Handle) {
-    let (service, handle) = mock::pair();
+fn new_service() -> (mock::Spawn<Buffer<Mock, &'static str>>, Handle) {
     // bound is >0 here because clears_canceled_requests needs multiple outstanding requests
-    let service = Buffer::with_executor(service, 10, &mut Exec);
-    (service, handle)
+    mock::spawn_with(|s| {
+        let (svc, worker) = Buffer::pair(s, 10);
+
+        thread::spawn(move || {
+            let mut fut = tokio_test::task::spawn(worker);
+            while fut.poll().is_pending() {}
+        });
+
+        svc
+    })
 }

--- a/tower-buffer/tests/buffer.rs
+++ b/tower-buffer/tests/buffer.rs
@@ -125,7 +125,7 @@ async fn response_future_when_worker_is_dropped_early() {
     handle.allow(0);
     let mut response = task::spawn(service.call("hello"));
 
-    drop(worker); 
+    drop(worker);
 
     let_worker_work();
     let err = assert_ready_err!(response.poll());

--- a/tower-test/src/mock/mod.rs
+++ b/tower-test/src/mock/mod.rs
@@ -4,7 +4,9 @@ pub mod error;
 pub mod future;
 pub mod spawn;
 
-use crate::mock::{error::Error, future::ResponseFuture, spawn::Spawn};
+pub use spawn::Spawn;
+
+use crate::mock::{error::Error, future::ResponseFuture};
 use core::task::Waker;
 
 use tokio::sync::{mpsc, oneshot};
@@ -33,6 +35,18 @@ where
 /// Spawn a Service onto a mock task.
 pub fn spawn<T, U>() -> (Spawn<Mock<T, U>>, Handle<T, U>) {
     let (svc, handle) = pair();
+
+    (Spawn::new(svc), handle)
+}
+
+/// Spawn a Service via the provided wrapper closure.
+pub fn spawn_with<T, U, F, S>(f: F) -> (Spawn<S>, Handle<T, U>)
+where
+    F: Fn(Mock<T, U>) -> S,
+{
+    let (svc, handle) = pair();
+
+    let svc = f(svc);
 
     (Spawn::new(svc), handle)
 }


### PR DESCRIPTION
Big change here is dropping executor support and defaulting layer to use `tokio::spawn` but also add a new `Buffer::pair` that will return the `Buffer` and `Worker` pair.