### PR TITLE
Default poll_ready implementation

### DIFF
--- a/tower-service/src/lib.rs
+++ b/tower-service/src/lib.rs
@@ -219,6 +219,8 @@ pub trait Service<Request> {
     /// Once `poll_ready` returns `Poll::Ready(Ok(()))`, a request may be dispatched to the
     /// service using `call`. Until a request is dispatched, repeated calls to
     /// `poll_ready` must return either `Poll::Ready(Ok(()))` or `Poll::Ready(Err(_))`.
+    /// 
+    /// By default, this returns `Poll::Ready(Ok(()))`.
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }

--- a/tower-service/src/lib.rs
+++ b/tower-service/src/lib.rs
@@ -219,7 +219,7 @@ pub trait Service<Request> {
     /// Once `poll_ready` returns `Poll::Ready(Ok(()))`, a request may be dispatched to the
     /// service using `call`. Until a request is dispatched, repeated calls to
     /// `poll_ready` must return either `Poll::Ready(Ok(()))` or `Poll::Ready(Err(_))`.
-    /// 
+    ///
     /// By default, this returns `Poll::Ready(Ok(()))`.
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))

--- a/tower-service/src/lib.rs
+++ b/tower-service/src/lib.rs
@@ -219,7 +219,9 @@ pub trait Service<Request> {
     /// Once `poll_ready` returns `Poll::Ready(Ok(()))`, a request may be dispatched to the
     /// service using `call`. Until a request is dispatched, repeated calls to
     /// `poll_ready` must return either `Poll::Ready(Ok(()))` or `Poll::Ready(Err(_))`.
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>;
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
 
     /// Process the request and return the response asynchronously.
     ///


### PR DESCRIPTION
**Rationale**
Often one wants to quickly whip up a basic service. Many basic services will always be ready and the more complex polling dynamics will arise from layers wrapping them. 

This makes `Poll::Ready(Ok(())` a canonical and reasonable choice for a default implementation.

**Result**
Less boilerplate.