### PR TITLE
tower: Allow opting out of tracing/log

### DIFF
--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -24,11 +24,12 @@ keywords = ["io", "async", "non-blocking", "futures", "service"]
 edition = "2018"
 
 [features]
-default = ["full"]
+default = ["full", "log"]
 full = []
+log = ["tower-buffer/log"]
 
 [dependencies]
-tower-buffer = { version = "0.3", path = "../tower-buffer" }
+tower-buffer = { version = "0.3", path = "../tower-buffer", default-features = false }
 tower-discover = { version = "0.3", path = "../tower-discover" }
 tower-layer = "0.3"
 tower-limit = { version = "0.3", path = "../tower-limit" }


### PR DESCRIPTION
This is of particular importance since the `log` feature of `tracing` (currently) fails to compile if the `tracing` dependency is renamed. Without a way to disable it in `tower`, any package that both depends on `tower` **and** renames `tracing` in its dependencies is doomed.