### PR TITLE
Add basic "batteries-included" `retry::Policy`s.

### DIFF
--- a/tower-retry/Cargo.toml
+++ b/tower-retry/Cargo.toml
@@ -27,9 +27,9 @@ tower-layer = "0.3"
 tokio = { version = "0.2", features = ["time"] }
 pin-project = "0.4"
 futures-core = { version = "0.3", default-features = false }
+futures-util = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 tower-test = { version = "0.3", path = "../tower-test" }
 tokio = { version  = "0.2", features = ["macros", "test-util"] }
 tokio-test = "0.2"
-futures-util = { version = "0.3", default-features = false }

--- a/tower-retry/src/lib.rs
+++ b/tower-retry/src/lib.rs
@@ -12,9 +12,11 @@
 pub mod budget;
 pub mod future;
 mod layer;
+mod policies;
 mod policy;
 
 pub use crate::layer::RetryLayer;
+pub use crate::policies::{RetryErrors, RetryLimit};
 pub use crate::policy::Policy;
 
 use crate::future::ResponseFuture;

--- a/tower-retry/src/policies.rs
+++ b/tower-retry/src/policies.rs
@@ -1,0 +1,61 @@
+use super::Policy;
+use futures_util::future;
+
+/// A very basic retry policy with a limited number of retry attempts.
+///
+/// FIXME: explain why not to use this.
+#[derive(Clone, Debug)]
+pub struct RetryLimit {
+    remaining_tries: usize,
+}
+
+impl RetryLimit {
+    /// Create a policy with the given number of retry attempts.
+    pub fn new(retry_attempts: usize) -> Self {
+        RetryLimit {
+            remaining_tries: retry_attempts,
+        }
+    }
+}
+
+impl<Req: Clone, Res, E> Policy<Req, Res, E> for RetryLimit {
+    type Future = future::Ready<Self>;
+    fn retry(&self, _: &Req, result: Result<&Res, &E>) -> Option<Self::Future> {
+        if result.is_err() {
+            if self.remaining_tries > 0 {
+                Some(future::ready(RetryLimit {
+                    remaining_tries: self.remaining_tries - 1,
+                }))
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+
+    fn clone_request(&self, req: &Req) -> Option<Req> {
+        Some(req.clone())
+    }
+}
+
+/// A very basic retry policy that always retries failed requests.
+///
+/// FIXME: explain why not to use this.
+#[derive(Clone, Debug)]
+pub struct RetryErrors;
+
+impl<Req: Clone, Res, E> Policy<Req, Res, E> for RetryErrors {
+    type Future = future::Ready<Self>;
+    fn retry(&self, _: &Req, result: Result<&Res, &E>) -> Option<Self::Future> {
+        if result.is_err() {
+            Some(future::ready(RetryErrors))
+        } else {
+            None
+        }
+    }
+
+    fn clone_request(&self, req: &Req) -> Option<Req> {
+        Some(req.clone())
+    }
+}

--- a/tower-retry/src/policy.rs
+++ b/tower-retry/src/policy.rs
@@ -1,47 +1,6 @@
 use std::future::Future;
 
 /// A "retry policy" to classify if a request should be retried.
-///
-/// # Example
-///
-/// ```
-/// use tower_retry::Policy;
-/// use futures_util::future;
-///
-/// type Req = String;
-/// type Res = String;
-///
-/// struct Attempts(usize);
-///
-/// impl<E> Policy<Req, Res, E> for Attempts {
-///     type Future = future::Ready<Self>;
-///
-///     fn retry(&self, req: &Req, result: Result<&Res, &E>) -> Option<Self::Future> {
-///         match result {
-///             Ok(_) => {
-///                 // Treat all `Response`s as success,
-///                 // so don't retry...
-///                 None
-///             },
-///             Err(_) => {
-///                 // Treat all errors as failures...
-///                 // But we limit the number of attempts...
-///                 if self.0 > 0 {
-///                     // Try again!
-///                     Some(future::ready(Attempts(self.0 - 1)))
-///                 } else {
-///                     // Used all our attempts, no retry...
-///                     None
-///                 }
-///             }
-///         }
-///     }
-///
-///     fn clone_request(&self, req: &Req) -> Option<Req> {
-///         Some(req.clone())
-///     }
-/// }
-/// ```
 pub trait Policy<Req, Res, E>: Sized {
     /// The `Future` type returned by `Policy::retry()`.
     type Future: Future<Output = Self>;

--- a/tower-retry/src/policy.rs
+++ b/tower-retry/src/policy.rs
@@ -9,9 +9,9 @@ pub trait Policy<Req, Res, E>: Sized {
     /// This method is passed a reference to the original request, and either
     /// the `Service::Response` or `Service::Error` from the inner service.
     ///
-    /// If the request should **not** be retried, return `None`.
+    /// If the request **should not** be retried, return `None`.
     ///
-    /// If the request *should* be retried, return `Some` future of a new
+    /// If the request **should** be retried, return `Some` future of a new
     /// policy that would apply for the next request attempt.
     fn retry(&self, req: &Req, result: Result<&Res, &E>) -> Option<Self::Future>;
     /// Tries to clone a request before being passed to the inner service.


### PR DESCRIPTION
These are lifted out of the test and example code.  Two policies are provided:

* `RetryLimit`, with a bounded number of retry attempts;
* `RetryError`, with unbounded retry attempts.

Both policies require `Req: Clone` as it's not possible to write a generic
retry policy without being able to clone requests.

The docs should be updated with a little blurb that explains when they should
not be used.  Also, the `Policy` docs had an `Attempts` example corresponding
to `RetryLimit` (formerly `Limit` in the tests code); I removed it because
`RetryLimit` exists and can be view-sourced.