### PR TITLE
ready-cache: restore assert for dropped cancel tx

### DIFF
--- a/tower-ready-cache/src/cache.rs
+++ b/tower-ready-cache/src/cache.rs
@@ -363,7 +363,8 @@ where
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut fut = self.cancel.as_mut().expect("polled after complete");
-        if let Poll::Ready(Ok(_)) = Pin::new(&mut fut).poll(cx) {
+        if let Poll::Ready(r) = Pin::new(&mut fut).poll(cx) {
+            assert!(r.is_ok(), "cancel sender lost");
             let key = self.key.take().expect("polled after complete");
             return Err(PendingError::Canceled(key)).into();
         }


### PR DESCRIPTION
When ready-cache was upgraded from futures 0.1 to `std::future` in
e2f1a49cf3bb29ec7a72feee2f31d9b8ab39d32a, this `expect` was removed, and
the code instead silently ignores the error. That's probably not what we
want, so this patch restores that assertion.