### PR TITLE
ready-cache: Prepare for 0.3.1 release

### DIFF
--- a/tower-ready-cache/CHANGELOG.md
+++ b/tower-ready-cache/CHANGELOG.md
@@ -1,0 +1,5 @@
+# 0.3.1 (February 24, 2020)
+
+- Fix spurious panic (#420).
+- Restore assertion from pre-`std::future::Future` (#418).
+- Fix documentation URLs to point to 0.3.

--- a/tower-ready-cache/Cargo.toml
+++ b/tower-ready-cache/Cargo.toml
@@ -8,13 +8,13 @@ name = "tower-ready-cache"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tower-rs/tower"
 homepage = "https://github.com/tower-rs/tower"
-documentation = "https://docs.rs/tower-ready-cache/0.1.0"
+documentation = "https://docs.rs/tower-ready-cache/0.3.1"
 description = """
 Caches a set of services
 """

--- a/tower-ready-cache/src/lib.rs
+++ b/tower-ready-cache/src/lib.rs
@@ -1,6 +1,6 @@
 //! A cache of services
 
-#![doc(html_root_url = "https://docs.rs/tower-ready-cache/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/tower-ready-cache/0.3.1")]
 #![deny(missing_docs)]
 #![deny(rust_2018_idioms)]
 #![allow(elided_lifetimes_in_paths)]


### PR DESCRIPTION
This also fixes up the various documentation URLs, which were still
pointing to 0.1.x.