### PR TITLE
Add Buffer::new note on how to set bound

### DIFF
--- a/tower-buffer/src/service.rs
+++ b/tower-buffer/src/service.rs
@@ -36,7 +36,7 @@ where
     /// must be called while on the Tokio runtime.
     ///
     /// # Note on setting `bound`
-    /// `Buffer`'s implementation of `poll_ready` will, if it will return `Poll::Ready`, reserve a
+    /// When `Buffer`'s implementation of `poll_ready` returns `Poll::Ready`, it reserves a
     /// slot in the channel for the forthcoming `call()`. However, if this call doesn't arrive,
     /// this reserved slot may be held up for a long time. As a result, it's advisable to set
     /// `bound` to be at least the maximum number of concurrent requests the `Buffer` will see.

--- a/tower-buffer/src/service.rs
+++ b/tower-buffer/src/service.rs
@@ -34,6 +34,12 @@ where
     ///
     /// The default Tokio executor is used to run the given service, which means that this method
     /// must be called while on the Tokio runtime.
+    ///
+    /// # Note on setting `bound`
+    /// `Buffer`'s implementation of `poll_ready` will, if it will return `Poll::Ready`, reserve a
+    /// slot in the channel for the forthcoming `call()`. However, if this call doesn't arrive,
+    /// this reserved slot may be held up for a long time. As a result, it's advisable to set
+    /// `bound` to be at least the maximum number of concurrent requests the `Buffer` will see.
     pub fn new(service: T, bound: usize) -> Self
     where
         T: Send + 'static,


### PR DESCRIPTION
Related to https://github.com/tower-rs/tower/issues/408. 
While the above issue is resolved, tower-buffer should document its behavior and offer guidance on setting the channel size.

cc @jonhoo 