### PR TITLE
limit: Fix rate limit not reseting state correctly

### DIFF
--- a/tower-limit/src/rate/service.rs
+++ b/tower-limit/src/rate/service.rs
@@ -85,9 +85,7 @@ where
                 // If the period has elapsed, reset it.
                 if now >= until {
                     until = now + self.rate.per();
-                    let rem = self.rate.num();
-
-                    self.state = State::Ready { until, rem }
+                    rem = self.rate.num();
                 }
 
                 if rem > 1 {


### PR DESCRIPTION
We were running into an issue in `Vector` where the rate limit remaining count never got reset and we always hit the branch that sets the limited state. This was because we were double over writing the state. In the first if statement we would `self.state = State::Ready { .. }` but then we would go to the next if statement and if the remaining was larger than 1 we would reset the state back to the original status with one more remaining subtracted. This would then override the fact that we were resetting the state in the previous if statement. This would then cause us to only reset the state in the poll_ready where we now would have to check the timer. This result of this is that we were probably rate limiting more than expected and logging the trace log much more than expected.

cc @lukesteensen 

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>