### PR TITLE
Remove path deps for `tower-service`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,9 @@ confidence-threshold = 0.8
 [bans]
 multiple-versions = "deny"
 highlight = "all"
+skip-tree = [
+    { name = "tower", version = "=0.3"}
+]
 
 [sources]
 unknown-registry = "warn"

--- a/tower-layer/Cargo.toml
+++ b/tower-layer/Cargo.toml
@@ -24,4 +24,4 @@ edition = "2018"
 [dependencies]
 
 [dev-dependencies]
-tower-service = { version = "0.3.0", path = "../tower-service" }
+tower-service = { version = "0.3.0" }

--- a/tower-test/Cargo.toml
+++ b/tower-test/Cargo.toml
@@ -26,7 +26,7 @@ futures-util = { version = "0.3", default-features = false }
 tokio = { version = "0.2", features = ["sync"]}
 tower-layer = { version = "0.3", path = "../tower-layer" }
 tokio-test = "0.2"
-tower-service = { version = "0.3", path = "../tower-service" }
+tower-service = { version = "0.3" }
 pin-project = "0.4"
 
 [dev-dependencies]

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -47,7 +47,7 @@ util = ["futures-util"]
 futures-core = "0.3"
 pin-project = "0.4"
 tower-layer = { version = "0.3", path = "../tower-layer" }
-tower-service = { version = "0.3", path = "../tower-service" }
+tower-service = { version = "0.3" }
 tracing = "0.1.2"
 
 futures-util = { version = "0.3", default-features = false, features = ["alloc"], optional = true }


### PR DESCRIPTION
This is causing issues where depending from git will pull in the git version of tower-service while locally I want it to match with the crates version. I think this is fine in general because we do not plan to make any changes to `tower-service` before a `0.4` release.