### PR TITLE
Some more spring clean fixes.

### DIFF
--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -24,11 +24,9 @@ pub mod buffer;
 pub mod discover;
 #[cfg(feature = "filter")]
 #[cfg_attr(docsrs, doc(cfg(feature = "filter")))]
-#[doc(hidden)] // not yet released
 pub mod filter;
 #[cfg(feature = "hedge")]
 #[cfg_attr(docsrs, doc(cfg(feature = "hedge")))]
-#[doc(hidden)] // not yet released
 pub mod hedge;
 #[cfg(feature = "limit")]
 #[cfg_attr(docsrs, doc(cfg(feature = "limit")))]

--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -6,6 +6,7 @@
     unreachable_pub
 )]
 #![allow(elided_lifetimes_in_paths)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! `fn(Request) -> Future<Response>`
 //!
@@ -13,44 +14,61 @@
 //! robust networking clients and servers.
 
 #[cfg(feature = "balance")]
+#[cfg_attr(docsrs, doc(cfg(feature = "balance")))]
 pub mod balance;
 #[cfg(feature = "buffer")]
+#[cfg_attr(docsrs, doc(cfg(feature = "buffer")))]
 pub mod buffer;
 #[cfg(feature = "discover")]
+#[cfg_attr(docsrs, doc(cfg(feature = "discover")))]
 pub mod discover;
 #[cfg(feature = "filter")]
+#[cfg_attr(docsrs, doc(cfg(feature = "filter")))]
 #[doc(hidden)] // not yet released
 pub mod filter;
 #[cfg(feature = "hedge")]
+#[cfg_attr(docsrs, doc(cfg(feature = "hedge")))]
 #[doc(hidden)] // not yet released
 pub mod hedge;
 #[cfg(feature = "limit")]
+#[cfg_attr(docsrs, doc(cfg(feature = "limit")))]
 pub mod limit;
 #[cfg(feature = "load")]
+#[cfg_attr(docsrs, doc(cfg(feature = "load")))]
 pub mod load;
 #[cfg(feature = "load-shed")]
+#[cfg_attr(docsrs, doc(cfg(feature = "load-shed")))]
 pub mod load_shed;
 #[cfg(feature = "make")]
+#[cfg_attr(docsrs, doc(cfg(feature = "make")))]
 pub mod make;
 #[cfg(feature = "ready-cache")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ready-cache")))]
 pub mod ready_cache;
 #[cfg(feature = "reconnect")]
+#[cfg_attr(docsrs, doc(cfg(feature = "reconnect")))]
 pub mod reconnect;
 #[cfg(feature = "retry")]
+#[cfg_attr(docsrs, doc(cfg(feature = "retry")))]
 pub mod retry;
 #[cfg(feature = "spawn-ready")]
+#[cfg_attr(docsrs, doc(cfg(feature = "spawn-ready")))]
 pub mod spawn_ready;
 #[cfg(feature = "steer")]
+#[cfg_attr(docsrs, doc(cfg(feature = "steer")))]
 pub mod steer;
 #[cfg(feature = "timeout")]
+#[cfg_attr(docsrs, doc(cfg(feature = "timeout")))]
 pub mod timeout;
 #[cfg(feature = "util")]
+#[cfg_attr(docsrs, doc(cfg(feature = "util")))]
 pub mod util;
 
 pub mod builder;
 pub mod layer;
 
 #[cfg(feature = "util")]
+#[cfg_attr(docsrs, doc(cfg(feature = "util")))]
 #[doc(inline)]
 pub use self::util::{service_fn, ServiceExt};
 


### PR DESCRIPTION
This adds `doc(feature)` annotations to each top-level module for docs.rs, and also removes the `doc(hidden)` for previously unpublished middleware since we should _either_ publish them or remove them.