### PR TITLE
util: fix oneshot dropping pending services immediately

### DIFF
--- a/tower/tests/util/main.rs
+++ b/tower/tests/util/main.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "util")]
 
 mod call_all;
+mod oneshot;
 mod service_fn;

--- a/tower/tests/util/oneshot.rs
+++ b/tower/tests/util/oneshot.rs
@@ -1,0 +1,39 @@
+use std::task::{Context, Poll};
+use std::{future::Future, pin::Pin};
+use tower::util::ServiceExt;
+use tower_service::Service;
+
+#[tokio::test]
+async fn service_driven_to_readiness() {
+    // This test ensures that `oneshot` will repeatedly call `poll_ready` until
+    // the service is ready.
+
+    struct PollMeTwice {
+        ready: bool,
+    };
+    impl Service<()> for PollMeTwice {
+        type Error = ();
+        type Response = ();
+        type Future = Pin<
+            Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + Sync + 'static>,
+        >;
+
+        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), ()>> {
+            if self.ready {
+                Poll::Ready(Ok(()))
+            } else {
+                self.ready = true;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        }
+
+        fn call(&mut self, _: ()) -> Self::Future {
+            assert!(self.ready, "service not driven to readiness!");
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    let svc = PollMeTwice { ready: false };
+    svc.oneshot(()).await;
+}


### PR DESCRIPTION
## Motivation

Commit #330 introduced a regression when porting `tower-util::Oneshot`
from `futures` 0.1 to `std::future`. The *intended* behavior is that a
oneshot future should repeatedly call `poll_ready` on the oneshotted
service until it is ready, and then call the service and drive the
returned future. However, #330 inadvertently changed the oneshot future
to poll the service _once_, call it if it is ready, and then drop it,
regardless of its readiness.

In bthe #330 version of oneshot, an `Option` is used to store the
request while waiting for the service to become ready, so that it can be
`take`n and moved into the service's `call`. However, the `Option`
contains both the request _and_ the service itself, and is taken the
first time the service is polled. `futures::ready!` is then used when
polling the service, so the method returns immediate if it is not ready.
This means that the service itself (and the request), which were taken
out of the `Option`, will be dropped, and if the oneshot future is
polled again, it will panic.

## Solution

This commit changes the `Oneshot` future so that only the request lives
in the `Option`, and it is only taken when the service is called, rather
than every time it is polled. This fixes the bug.

I've also added a test for this which fails against master, but passes
after this change.