### PR TITLE
Use only one alias for Box<dyn Error>

### DIFF
--- a/tower/src/balance/error.rs
+++ b/tower/src/balance/error.rs
@@ -2,11 +2,9 @@
 
 use std::fmt;
 
-pub(crate) type Error = Box<dyn std::error::Error + Send + Sync>;
-
 /// An error returned when the balancer's endpoint discovery stream fails.
 #[derive(Debug)]
-pub struct Discover(pub(crate) Error);
+pub struct Discover(pub(crate) crate::BoxError);
 
 impl fmt::Display for Discover {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/tower/src/balance/p2c/make.rs
+++ b/tower/src/balance/p2c/make.rs
@@ -1,4 +1,3 @@
-use super::super::error;
 use super::Balance;
 use crate::discover::Discover;
 use futures_core::ready;
@@ -52,7 +51,7 @@ where
     S::Response: Discover,
     <S::Response as Discover>::Key: Hash,
     <S::Response as Discover>::Service: Service<Req>,
-    <<S::Response as Discover>::Service as Service<Req>>::Error: Into<error::Error>,
+    <<S::Response as Discover>::Service as Service<Req>>::Error: Into<crate::BoxError>,
 {
     type Response = Balance<S::Response, Req>;
     type Error = S::Error;
@@ -77,7 +76,7 @@ where
     T: Discover,
     <T as Discover>::Key: Hash,
     <T as Discover>::Service: Service<Req>,
-    <<T as Discover>::Service as Service<Req>>::Error: Into<error::Error>,
+    <<T as Discover>::Service as Service<Req>>::Error: Into<crate::BoxError>,
 {
     type Output = Result<Balance<T, Req>, E>;
 

--- a/tower/src/balance/p2c/service.rs
+++ b/tower/src/balance/p2c/service.rs
@@ -92,7 +92,7 @@ where
     D: Discover,
     D::Key: Hash,
     D::Service: Service<Req>,
-    <D::Service as Service<Req>>::Error: Into<error::Error>,
+    <D::Service as Service<Req>>::Error: Into<crate::BoxError>,
 {
     /// Initializes a P2C load balancer from the provided randomization source.
     pub fn new(discover: D, rng: SmallRng) -> Self {
@@ -121,10 +121,10 @@ impl<D, Req> Balance<D, Req>
 where
     D: Discover + Unpin,
     D::Key: Hash + Clone,
-    D::Error: Into<error::Error>,
+    D::Error: Into<crate::BoxError>,
     D::Service: Service<Req> + Load,
     <D::Service as Load>::Metric: std::fmt::Debug,
-    <D::Service as Service<Req>>::Error: Into<error::Error>,
+    <D::Service as Service<Req>>::Error: Into<crate::BoxError>,
 {
     /// Polls `discover` for updates, adding new items to `not_ready`.
     ///
@@ -227,16 +227,16 @@ impl<D, Req> Service<Req> for Balance<D, Req>
 where
     D: Discover + Unpin,
     D::Key: Hash + Clone,
-    D::Error: Into<error::Error>,
+    D::Error: Into<crate::BoxError>,
     D::Service: Service<Req> + Load,
     <D::Service as Load>::Metric: std::fmt::Debug,
-    <D::Service as Service<Req>>::Error: Into<error::Error>,
+    <D::Service as Service<Req>>::Error: Into<crate::BoxError>,
 {
     type Response = <D::Service as Service<Req>>::Response;
-    type Error = error::Error;
+    type Error = crate::BoxError;
     type Future = future::MapErr<
         <D::Service as Service<Req>>::Future,
-        fn(<D::Service as Service<Req>>::Error) -> error::Error,
+        fn(<D::Service as Service<Req>>::Error) -> crate::BoxError,
     >;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/tower/src/balance/pool/mod.rs
+++ b/tower/src/balance/pool/mod.rs
@@ -14,7 +14,6 @@
 //! added or removed.
 #![deny(missing_docs)]
 
-use super::error;
 use super::p2c::Balance;
 use crate::discover::Change;
 use crate::load::Load;
@@ -82,8 +81,8 @@ where
 impl<MS, Target, Request> Stream for PoolDiscoverer<MS, Target, Request>
 where
     MS: MakeService<Target, Request>,
-    MS::MakeError: Into<error::Error>,
-    MS::Error: Into<error::Error>,
+    MS::MakeError: Into<crate::BoxError>,
+    MS::Error: Into<crate::BoxError>,
     Target: Clone,
 {
     type Item = Result<Change<usize, DropNotifyService<MS::Service>>, MS::MakeError>;
@@ -273,8 +272,8 @@ impl Builder {
         MS: MakeService<Target, Request>,
         MS::Service: Load,
         <MS::Service as Load>::Metric: std::fmt::Debug,
-        MS::MakeError: Into<error::Error>,
-        MS::Error: Into<error::Error>,
+        MS::MakeError: Into<crate::BoxError>,
+        MS::Error: Into<crate::BoxError>,
         Target: Clone,
     {
         let (died_tx, died_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -301,8 +300,8 @@ impl Builder {
 pub struct Pool<MS, Target, Request>
 where
     MS: MakeService<Target, Request>,
-    MS::MakeError: Into<error::Error>,
-    MS::Error: Into<error::Error>,
+    MS::MakeError: Into<crate::BoxError>,
+    MS::Error: Into<crate::BoxError>,
     Target: Clone,
 {
     // the Pin<Box<_>> here is needed since Balance requires the Service to be Unpin
@@ -314,8 +313,8 @@ where
 impl<MS, Target, Request> fmt::Debug for Pool<MS, Target, Request>
 where
     MS: MakeService<Target, Request> + fmt::Debug,
-    MS::MakeError: Into<error::Error>,
-    MS::Error: Into<error::Error>,
+    MS::MakeError: Into<crate::BoxError>,
+    MS::Error: Into<crate::BoxError>,
     Target: Clone + fmt::Debug,
     MS::Service: fmt::Debug,
     Request: fmt::Debug,
@@ -334,8 +333,8 @@ where
     MS: MakeService<Target, Request>,
     MS::Service: Load,
     <MS::Service as Load>::Metric: std::fmt::Debug,
-    MS::MakeError: Into<error::Error>,
-    MS::Error: Into<error::Error>,
+    MS::MakeError: Into<crate::BoxError>,
+    MS::Error: Into<crate::BoxError>,
     Target: Clone,
 {
     /// Construct a new dynamically sized `Pool`.
@@ -356,8 +355,8 @@ where
     MS: MakeService<Target, Req>,
     MS::Service: Load,
     <MS::Service as Load>::Metric: std::fmt::Debug,
-    MS::MakeError: Into<error::Error>,
-    MS::Error: Into<error::Error>,
+    MS::MakeError: Into<crate::BoxError>,
+    MS::Error: Into<crate::BoxError>,
     Target: Clone,
 {
     type Response = <PinBalance<PoolDiscoverer<MS, Target, Req>, Req> as Service<Req>>::Response;

--- a/tower/src/buffer/error.rs
+++ b/tower/src/buffer/error.rs
@@ -1,11 +1,12 @@
 //! Error types for the `Buffer` middleware.
 
+use crate::BoxError;
 use std::{fmt, sync::Arc};
 
 /// An error produced by a `Service` wrapped by a `Buffer`
 #[derive(Debug)]
 pub struct ServiceError {
-    inner: Arc<Error>,
+    inner: Arc<BoxError>,
 }
 
 /// An error produced when the a buffer's worker closes unexpectedly.
@@ -13,13 +14,10 @@ pub struct Closed {
     _p: (),
 }
 
-/// Errors produced by `Buffer`.
-pub(crate) type Error = Box<dyn std::error::Error + Send + Sync>;
-
 // ===== impl ServiceError =====
 
 impl ServiceError {
-    pub(crate) fn new(inner: Error) -> ServiceError {
+    pub(crate) fn new(inner: BoxError) -> ServiceError {
         let inner = Arc::new(inner);
         ServiceError { inner }
     }

--- a/tower/src/buffer/layer.rs
+++ b/tower/src/buffer/layer.rs
@@ -1,4 +1,4 @@
-use super::{error::Error, service::Buffer};
+use super::service::Buffer;
 use std::{fmt, marker::PhantomData};
 use tower_layer::Layer;
 use tower_service::Service;
@@ -41,7 +41,7 @@ impl<S, Request> Layer<S> for BufferLayer<Request>
 where
     S: Service<Request> + Send + 'static,
     S::Future: Send,
-    S::Error: Into<Error> + Send + Sync,
+    S::Error: Into<crate::BoxError> + Send + Sync,
     Request: Send + 'static,
 {
     type Service = Buffer<S, Request>;

--- a/tower/src/buffer/service.rs
+++ b/tower/src/buffer/service.rs
@@ -1,5 +1,4 @@
 use super::{
-    error::Error,
     future::ResponseFuture,
     message::Message,
     worker::{Handle, Worker},
@@ -25,7 +24,7 @@ where
 impl<T, Request> Buffer<T, Request>
 where
     T: Service<Request>,
-    T::Error: Into<Error>,
+    T::Error: Into<crate::BoxError>,
 {
     /// Creates a new `Buffer` wrapping `service`.
     ///
@@ -73,7 +72,7 @@ where
         (Buffer { tx, handle }, worker)
     }
 
-    fn get_worker_error(&self) -> Error {
+    fn get_worker_error(&self) -> crate::BoxError {
         self.handle.get_error_on_closed()
     }
 }
@@ -81,10 +80,10 @@ where
 impl<T, Request> Service<Request> for Buffer<T, Request>
 where
     T: Service<Request>,
-    T::Error: Into<Error>,
+    T::Error: Into<crate::BoxError>,
 {
     type Response = T::Response;
-    type Error = Error;
+    type Error = crate::BoxError;
     type Future = ResponseFuture<T::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/tower/src/filter/error.rs
+++ b/tower/src/filter/error.rs
@@ -5,10 +5,8 @@ use std::{error, fmt};
 /// Error produced by `Filter`
 #[derive(Debug)]
 pub struct Error {
-    source: Option<Source>,
+    source: Option<crate::BoxError>,
 }
-
-pub(crate) type Source = Box<dyn error::Error + Send + Sync>;
 
 impl Error {
     /// Create a new `Error` representing a rejected request.
@@ -19,7 +17,7 @@ impl Error {
     /// Create a new `Error` representing an inner service error.
     pub fn inner<E>(source: E) -> Error
     where
-        E: Into<Source>,
+        E: Into<crate::BoxError>,
     {
         Error {
             source: Some(source.into()),

--- a/tower/src/filter/future.rs
+++ b/tower/src/filter/future.rs
@@ -1,6 +1,6 @@
 //! Future types
 
-use super::error::{self, Error};
+use super::error::Error;
 use futures_core::ready;
 use pin_project::{pin_project, project};
 use std::{
@@ -40,7 +40,7 @@ impl<F, T, S, Request> ResponseFuture<F, S, Request>
 where
     F: Future<Output = Result<T, Error>>,
     S: Service<Request>,
-    S::Error: Into<error::Source>,
+    S::Error: Into<crate::BoxError>,
 {
     pub(crate) fn new(request: Request, check: F, service: S) -> Self {
         ResponseFuture {
@@ -55,7 +55,7 @@ impl<F, T, S, Request> Future for ResponseFuture<F, S, Request>
 where
     F: Future<Output = Result<T, Error>>,
     S: Service<Request>,
-    S::Error: Into<error::Source>,
+    S::Error: Into<crate::BoxError>,
 {
     type Output = Result<S::Response, Error>;
 

--- a/tower/src/filter/mod.rs
+++ b/tower/src/filter/mod.rs
@@ -30,7 +30,7 @@ impl<T, U> Filter<T, U> {
 impl<T, U, Request> Service<Request> for Filter<T, U>
 where
     T: Service<Request> + Clone,
-    T::Error: Into<error::Source>,
+    T::Error: Into<crate::BoxError>,
     U: Predicate<Request>,
 {
     type Response = T::Response;

--- a/tower/src/hedge/delay.rs
+++ b/tower/src/hedge/delay.rs
@@ -41,7 +41,7 @@ impl<P, S> Delay<P, S> {
     where
         P: Policy<Request>,
         S: Service<Request> + Clone,
-        S::Error: Into<super::Error>,
+        S::Error: Into<crate::BoxError>,
     {
         Delay { policy, service }
     }
@@ -51,10 +51,10 @@ impl<Request, P, S> Service<Request> for Delay<P, S>
 where
     P: Policy<Request>,
     S: Service<Request> + Clone,
-    S::Error: Into<super::Error>,
+    S::Error: Into<crate::BoxError>,
 {
     type Response = S::Response;
-    type Error = super::Error;
+    type Error = crate::BoxError;
     type Future = ResponseFuture<Request, S, S::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -79,10 +79,10 @@ where
 impl<Request, S, F, T, E> Future for ResponseFuture<Request, S, F>
 where
     F: Future<Output = Result<T, E>>,
-    E: Into<super::Error>,
+    E: Into<crate::BoxError>,
     S: Service<Request, Future = F, Response = T, Error = E>,
 {
-    type Output = Result<T, super::Error>;
+    type Output = Result<T, crate::BoxError>;
 
     #[project]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/tower/src/hedge/latency.rs
+++ b/tower/src/hedge/latency.rs
@@ -40,7 +40,7 @@ where
     pub fn new<Request>(rec: R, service: S) -> Self
     where
         S: Service<Request>,
-        S::Error: Into<super::Error>,
+        S::Error: Into<crate::BoxError>,
     {
         Latency { rec, service }
     }
@@ -49,11 +49,11 @@ where
 impl<S, R, Request> Service<Request> for Latency<R, S>
 where
     S: Service<Request>,
-    S::Error: Into<super::Error>,
+    S::Error: Into<crate::BoxError>,
     R: Record + Clone,
 {
     type Response = S::Response;
-    type Error = super::Error;
+    type Error = crate::BoxError;
     type Future = ResponseFuture<R, S::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -73,9 +73,9 @@ impl<R, F, T, E> Future for ResponseFuture<R, F>
 where
     R: Record,
     F: Future<Output = Result<T, E>>,
-    E: Into<super::Error>,
+    E: Into<crate::BoxError>,
 {
-    type Output = Result<T, super::Error>;
+    type Output = Result<T, crate::BoxError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();

--- a/tower/src/hedge/select.rs
+++ b/tower/src/hedge/select.rs
@@ -37,9 +37,9 @@ impl<P, A, B> Select<P, A, B> {
     where
         P: Policy<Request>,
         A: Service<Request>,
-        A::Error: Into<super::Error>,
+        A::Error: Into<crate::BoxError>,
         B: Service<Request, Response = A::Response>,
-        B::Error: Into<super::Error>,
+        B::Error: Into<crate::BoxError>,
     {
         Select { policy, a, b }
     }
@@ -49,12 +49,12 @@ impl<P, A, B, Request> Service<Request> for Select<P, A, B>
 where
     P: Policy<Request>,
     A: Service<Request>,
-    A::Error: Into<super::Error>,
+    A::Error: Into<crate::BoxError>,
     B: Service<Request, Response = A::Response>,
-    B::Error: Into<super::Error>,
+    B::Error: Into<crate::BoxError>,
 {
     type Response = A::Response;
-    type Error = super::Error;
+    type Error = crate::BoxError;
     type Future = ResponseFuture<A::Future, B::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -82,11 +82,11 @@ where
 impl<AF, BF, T, AE, BE> Future for ResponseFuture<AF, BF>
 where
     AF: Future<Output = Result<T, AE>>,
-    AE: Into<super::Error>,
+    AE: Into<crate::BoxError>,
     BF: Future<Output = Result<T, BE>>,
-    BE: Into<super::Error>,
+    BE: Into<crate::BoxError>,
 {
-    type Output = Result<T, super::Error>;
+    type Output = Result<T, crate::BoxError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();

--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -81,3 +81,6 @@ pub use tower_service::Service;
 mod sealed {
     pub trait Sealed<T> {}
 }
+
+/// Alias for a type-erased error type.
+pub type BoxError = Box<dyn std::error::Error + Send + Sync>;

--- a/tower/src/load_shed/error.rs
+++ b/tower/src/load_shed/error.rs
@@ -2,8 +2,6 @@
 
 use std::fmt;
 
-pub(crate) type Error = Box<dyn std::error::Error + Send + Sync>;
-
 /// An error returned by `Overload` when the underlying service
 /// is not ready to handle any requests at the time of being
 /// called.

--- a/tower/src/load_shed/future.rs
+++ b/tower/src/load_shed/future.rs
@@ -8,7 +8,7 @@ use std::task::{Context, Poll};
 use futures_core::ready;
 use pin_project::{pin_project, project};
 
-use super::error::{Error, Overloaded};
+use super::error::Overloaded;
 
 /// Future for the `LoadShed` service.
 #[pin_project]
@@ -40,9 +40,9 @@ impl<F> ResponseFuture<F> {
 impl<F, T, E> Future for ResponseFuture<F>
 where
     F: Future<Output = Result<T, E>>,
-    E: Into<Error>,
+    E: Into<crate::BoxError>,
 {
-    type Output = Result<T, Error>;
+    type Output = Result<T, crate::BoxError>;
 
     #[project]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/tower/src/load_shed/mod.rs
+++ b/tower/src/load_shed/mod.rs
@@ -7,7 +7,6 @@ pub mod error;
 pub mod future;
 mod layer;
 
-use self::error::Error;
 use self::future::ResponseFuture;
 pub use self::layer::LoadShedLayer;
 
@@ -33,10 +32,10 @@ impl<S> LoadShed<S> {
 impl<S, Req> Service<Req> for LoadShed<S>
 where
     S: Service<Req>,
-    S::Error: Into<Error>,
+    S::Error: Into<crate::BoxError>,
 {
     type Response = S::Response;
-    type Error = Error;
+    type Error = crate::BoxError;
     type Future = ResponseFuture<S::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/tower/src/ready_cache/cache.rs
+++ b/tower/src/ready_cache/cache.rs
@@ -187,8 +187,8 @@ impl<K, S, Req> ReadyCache<K, S, Req>
 where
     K: Clone + Eq + Hash,
     S: Service<Req>,
-    <S as Service<Req>>::Error: Into<error::Error>,
-    S::Error: Into<error::Error>,
+    <S as Service<Req>>::Error: Into<crate::BoxError>,
+    S::Error: Into<crate::BoxError>,
 {
     /// Pushes a new service onto the pending set.
     ///

--- a/tower/src/ready_cache/error.rs
+++ b/tower/src/ready_cache/error.rs
@@ -1,11 +1,8 @@
 //! Errors
 
-/// A generic error type.
-pub type Error = Box<dyn std::error::Error + Send + Sync>;
-
 /// An error indicating that the service with a `K`-typed key failed with an
 /// error.
-pub struct Failed<K>(pub K, pub Error);
+pub struct Failed<K>(pub K, pub crate::BoxError);
 
 // === Failed ===
 

--- a/tower/src/reconnect/future.rs
+++ b/tower/src/reconnect/future.rs
@@ -1,4 +1,3 @@
-use super::Error;
 use pin_project::{pin_project, project};
 use std::{
     future::Future,
@@ -38,10 +37,10 @@ impl<F, E> ResponseFuture<F, E> {
 impl<F, T, E, ME> Future for ResponseFuture<F, ME>
 where
     F: Future<Output = Result<T, E>>,
-    E: Into<Error>,
-    ME: Into<Error>,
+    E: Into<crate::BoxError>,
+    ME: Into<crate::BoxError>,
 {
-    type Output = Result<T, Error>;
+    type Output = Result<T, crate::BoxError>;
 
     #[project]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/tower/src/reconnect/mod.rs
+++ b/tower/src/reconnect/mod.rs
@@ -26,8 +26,6 @@ use std::{
 use tower_service::Service;
 use tracing::trace;
 
-pub(crate) type Error = Box<dyn std::error::Error + Send + Sync>;
-
 /// Reconnect to failed services.
 pub struct Reconnect<M, Target>
 where
@@ -76,11 +74,11 @@ where
     M: Service<Target, Response = S>,
     S: Service<Request>,
     M::Future: Unpin,
-    Error: From<M::Error> + From<S::Error>,
+    crate::BoxError: From<M::Error> + From<S::Error>,
     Target: Clone,
 {
     type Response = S::Response;
-    type Error = Error;
+    type Error = crate::BoxError;
     type Future = ResponseFuture<S::Future, M::Error>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/tower/src/spawn_ready/future.rs
+++ b/tower/src/spawn_ready/future.rs
@@ -1,6 +1,5 @@
 //! Background readiness types
 
-use super::Error;
 use futures_core::ready;
 use pin_project::pin_project;
 use std::marker::PhantomData;
@@ -17,7 +16,7 @@ use tower_service::Service;
 #[derive(Debug)]
 pub struct BackgroundReady<T, Request> {
     service: Option<T>,
-    tx: Option<oneshot::Sender<Result<T, Error>>>,
+    tx: Option<oneshot::Sender<Result<T, crate::BoxError>>>,
     _req: PhantomData<Request>,
 }
 
@@ -25,11 +24,11 @@ pub(crate) fn background_ready<T, Request>(
     service: T,
 ) -> (
     BackgroundReady<T, Request>,
-    oneshot::Receiver<Result<T, Error>>,
+    oneshot::Receiver<Result<T, crate::BoxError>>,
 )
 where
     T: Service<Request>,
-    T::Error: Into<Error>,
+    T::Error: Into<crate::BoxError>,
 {
     let (tx, rx) = oneshot::channel();
     let bg = BackgroundReady {
@@ -43,7 +42,7 @@ where
 impl<T, Request> Future for BackgroundReady<T, Request>
 where
     T: Service<Request>,
-    T::Error: Into<Error>,
+    T::Error: Into<crate::BoxError>,
 {
     type Output = ();
 

--- a/tower/src/spawn_ready/mod.rs
+++ b/tower/src/spawn_ready/mod.rs
@@ -9,6 +9,3 @@ mod service;
 pub use self::layer::SpawnReadyLayer;
 pub use self::make::{MakeFuture, MakeSpawnReady};
 pub use self::service::SpawnReady;
-
-/// Errors produced by `SpawnReady`.
-pub(crate) type Error = Box<dyn std::error::Error + Send + Sync>;

--- a/tower/src/timeout/error.rs
+++ b/tower/src/timeout/error.rs
@@ -2,8 +2,6 @@
 
 use std::{error, fmt};
 
-pub(crate) type Error = Box<dyn error::Error + Send + Sync>;
-
 /// The timeout elapsed.
 #[derive(Debug)]
 pub struct Elapsed(pub(super) ());

--- a/tower/src/timeout/future.rs
+++ b/tower/src/timeout/future.rs
@@ -1,6 +1,6 @@
 //! Future types
 
-use super::error::{Elapsed, Error};
+use super::error::Elapsed;
 use pin_project::pin_project;
 use std::{
     future::Future,
@@ -28,9 +28,9 @@ impl<T> ResponseFuture<T> {
 impl<F, T, E> Future for ResponseFuture<F>
 where
     F: Future<Output = Result<T, E>>,
-    E: Into<Error>,
+    E: Into<crate::BoxError>,
 {
-    type Output = Result<T, Error>;
+    type Output = Result<T, crate::BoxError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();

--- a/tower/src/timeout/mod.rs
+++ b/tower/src/timeout/mod.rs
@@ -9,7 +9,7 @@ mod layer;
 
 pub use self::layer::TimeoutLayer;
 
-use self::{error::Error, future::ResponseFuture};
+use self::future::ResponseFuture;
 use std::task::{Context, Poll};
 use std::time::Duration;
 use tower_service::Service;
@@ -33,10 +33,10 @@ impl<T> Timeout<T> {
 impl<S, Request> Service<Request> for Timeout<S>
 where
     S: Service<Request>,
-    S::Error: Into<Error>,
+    S::Error: Into<crate::BoxError>,
 {
     type Response = S::Response;
-    type Error = Error;
+    type Error = crate::BoxError;
     type Future = ResponseFuture<S::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/tower/src/util/call_all/common.rs
+++ b/tower/src/util/call_all/common.rs
@@ -1,4 +1,3 @@
-use super::Error;
 use futures_core::{ready, Stream};
 use pin_project::pin_project;
 use std::{
@@ -31,7 +30,7 @@ pub(crate) trait Drive<F: Future> {
 impl<Svc, S, Q> CallAll<Svc, S, Q>
 where
     Svc: Service<S::Item>,
-    Svc::Error: Into<Error>,
+    Svc::Error: Into<crate::BoxError>,
     S: Stream,
     Q: Drive<Svc::Future>,
 {
@@ -67,11 +66,11 @@ where
 impl<Svc, S, Q> Stream for CallAll<Svc, S, Q>
 where
     Svc: Service<S::Item>,
-    Svc::Error: Into<Error>,
+    Svc::Error: Into<crate::BoxError>,
     S: Stream,
     Q: Drive<Svc::Future>,
 {
-    type Item = Result<Svc::Response, Error>;
+    type Item = Result<Svc::Response, crate::BoxError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();

--- a/tower/src/util/call_all/mod.rs
+++ b/tower/src/util/call_all/mod.rs
@@ -6,5 +6,3 @@ mod unordered;
 
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::{ordered::CallAll, unordered::CallAllUnordered};
-
-type Error = Box<dyn std::error::Error + Send + Sync>;

--- a/tower/src/util/call_all/ordered.rs
+++ b/tower/src/util/call_all/ordered.rs
@@ -1,6 +1,6 @@
 //! `Stream<Item = Request>` + `Service<Request>` => `Stream<Item = Response>`.
 
-use super::{common, Error};
+use super::common;
 use futures_core::Stream;
 use futures_util::stream::FuturesOrdered;
 use pin_project::pin_project;
@@ -90,7 +90,7 @@ where
 impl<Svc, S> CallAll<Svc, S>
 where
     Svc: Service<S::Item>,
-    Svc::Error: Into<Error>,
+    Svc::Error: Into<crate::BoxError>,
     S: Stream,
 {
     /// Create new `CallAll` combinator.
@@ -138,10 +138,10 @@ where
 impl<Svc, S> Stream for CallAll<Svc, S>
 where
     Svc: Service<S::Item>,
-    Svc::Error: Into<Error>,
+    Svc::Error: Into<crate::BoxError>,
     S: Stream,
 {
-    type Item = Result<Svc::Response, Error>;
+    type Item = Result<Svc::Response, crate::BoxError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.project().inner.poll_next(cx)

--- a/tower/src/util/call_all/unordered.rs
+++ b/tower/src/util/call_all/unordered.rs
@@ -1,6 +1,6 @@
 //! `Stream<Item = Request>` + `Service<Request>` => `Stream<Item = Response>`.
 
-use super::{common, Error};
+use super::common;
 use futures_core::Stream;
 use futures_util::stream::FuturesUnordered;
 use pin_project::pin_project;
@@ -29,7 +29,7 @@ where
 impl<Svc, S> CallAllUnordered<Svc, S>
 where
     Svc: Service<S::Item>,
-    Svc::Error: Into<Error>,
+    Svc::Error: Into<crate::BoxError>,
     S: Stream,
 {
     /// Create new `CallAllUnordered` combinator.
@@ -67,10 +67,10 @@ where
 impl<Svc, S> Stream for CallAllUnordered<Svc, S>
 where
     Svc: Service<S::Item>,
-    Svc::Error: Into<Error>,
+    Svc::Error: Into<crate::BoxError>,
     S: Stream,
 {
-    type Item = Result<Svc::Response, Error>;
+    type Item = Result<Svc::Response, crate::BoxError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.project().inner.poll_next(cx)

--- a/tower/src/util/either.rs
+++ b/tower/src/util/either.rs
@@ -25,17 +25,15 @@ pub enum Either<A, B> {
     B(#[pin] B),
 }
 
-type Error = Box<dyn std::error::Error + Send + Sync>;
-
 impl<A, B, Request> Service<Request> for Either<A, B>
 where
     A: Service<Request>,
-    A::Error: Into<Error>,
+    A::Error: Into<crate::BoxError>,
     B: Service<Request, Response = A::Response>,
-    B::Error: Into<Error>,
+    B::Error: Into<crate::BoxError>,
 {
     type Response = A::Response;
-    type Error = Error;
+    type Error = crate::BoxError;
     type Future = Either<A::Future, B::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -60,11 +58,11 @@ where
 impl<A, B, T, AE, BE> Future for Either<A, B>
 where
     A: Future<Output = Result<T, AE>>,
-    AE: Into<Error>,
+    AE: Into<crate::BoxError>,
     B: Future<Output = Result<T, BE>>,
-    BE: Into<Error>,
+    BE: Into<crate::BoxError>,
 {
-    type Output = Result<T, Error>;
+    type Output = Result<T, crate::BoxError>;
 
     #[project]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -21,9 +21,6 @@ pub use self::{
 
 pub use self::call_all::{CallAll, CallAllUnordered};
 
-#[doc(hidden)]
-pub type Error = Box<dyn std::error::Error + Send + Sync>;
-
 pub mod error {
     //! Error types
 
@@ -80,7 +77,7 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     fn call_all<S>(self, reqs: S) -> CallAll<Self, S>
     where
         Self: Sized,
-        Self::Error: Into<Error>,
+        Self::Error: Into<crate::BoxError>,
         S: futures_core::Stream<Item = Request>,
     {
         CallAll::new(self, reqs)

--- a/tower/src/util/optional/error.rs
+++ b/tower/src/util/optional/error.rs
@@ -4,8 +4,6 @@ use std::{error, fmt};
 #[derive(Debug)]
 pub struct None(());
 
-pub(crate) type Error = Box<dyn error::Error + Send + Sync>;
-
 impl None {
     pub(crate) fn new() -> None {
         None(())

--- a/tower/src/util/optional/future.rs
+++ b/tower/src/util/optional/future.rs
@@ -1,4 +1,4 @@
-use super::{error, Error};
+use super::error;
 use futures_core::ready;
 use pin_project::pin_project;
 use std::{
@@ -24,9 +24,9 @@ impl<T> ResponseFuture<T> {
 impl<F, T, E> Future for ResponseFuture<F>
 where
     F: Future<Output = Result<T, E>>,
-    E: Into<Error>,
+    E: Into<crate::BoxError>,
 {
-    type Output = Result<T, Error>;
+    type Output = Result<T, crate::BoxError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.project().inner.as_pin_mut() {

--- a/tower/src/util/optional/mod.rs
+++ b/tower/src/util/optional/mod.rs
@@ -8,7 +8,7 @@ pub mod error;
 /// Future types for `OptionalService`.
 pub mod future;
 
-use self::{error::Error, future::ResponseFuture};
+use self::future::ResponseFuture;
 use std::task::{Context, Poll};
 use tower_service::Service;
 
@@ -25,7 +25,7 @@ impl<T> Optional<T> {
     pub fn new<Request>(inner: Option<T>) -> Optional<T>
     where
         T: Service<Request>,
-        T::Error: Into<Error>,
+        T::Error: Into<crate::BoxError>,
     {
         Optional { inner }
     }
@@ -34,10 +34,10 @@ impl<T> Optional<T> {
 impl<T, Request> Service<Request> for Optional<T>
 where
     T: Service<Request>,
-    T::Error: Into<Error>,
+    T::Error: Into<crate::BoxError>,
 {
     type Response = T::Response;
-    type Error = Error;
+    type Error = crate::BoxError;
     type Future = ResponseFuture<T::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {


### PR DESCRIPTION
This was a mostly mechanical change. I think in at least one place it
results in a `'static` bound being added, but the next tower release
will be breaking anyway, so that's okay.

I think it helps to also document the alias at the top to (eventually)
explain how people can interact with the error they get back to discover
the "deeper cause".