### PR TITLE
Remove uses of pin_project::project attribute

### DIFF
--- a/tower-test/Cargo.toml
+++ b/tower-test/Cargo.toml
@@ -27,7 +27,7 @@ tokio = { version = "0.2", features = ["sync"]}
 tower-layer = { version = "0.3", path = "../tower-layer" }
 tokio-test = "0.2"
 tower-service = { version = "0.3" }
-pin-project = "0.4"
+pin-project = "0.4.17"
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["macros"] }

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -45,7 +45,7 @@ util = ["futures-util"]
 
 [dependencies]
 futures-core = "0.3"
-pin-project = "0.4"
+pin-project = "0.4.17"
 tower-layer = { version = "0.3", path = "../tower-layer" }
 tower-service = { version = "0.3" }
 tracing = "0.1.2"

--- a/tower/src/util/either.rs
+++ b/tower/src/util/either.rs
@@ -3,7 +3,7 @@
 //! See `Either` documentation for more details.
 
 use futures_core::ready;
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 use std::{
     future::Future,
     pin::Pin,
@@ -16,7 +16,7 @@ use tower_service::Service;
 /// Both services must be of the same request, response, and error types.
 /// `Either` is useful for handling conditional branching in service middleware
 /// to different inner service types.
-#[pin_project]
+#[pin_project(project = EitherProj)]
 #[derive(Clone, Debug)]
 pub enum Either<A, B> {
     /// One type of backing `Service`.
@@ -64,12 +64,10 @@ where
 {
     type Output = Result<T, crate::BoxError>;
 
-    #[project]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        #[project]
         match self.project() {
-            Either::A(fut) => Poll::Ready(Ok(ready!(fut.poll(cx)).map_err(Into::into)?)),
-            Either::B(fut) => Poll::Ready(Ok(ready!(fut.poll(cx)).map_err(Into::into)?)),
+            EitherProj::A(fut) => Poll::Ready(Ok(ready!(fut.poll(cx)).map_err(Into::into)?)),
+            EitherProj::B(fut) => Poll::Ready(Ok(ready!(fut.poll(cx)).map_err(Into::into)?)),
         }
     }
 }


### PR DESCRIPTION
pin-project will deprecate the project attribute due to some unfixable
limitations.

Refs: https://github.com/taiki-e/pin-project/issues/225

*Although the deprecation of the project attribute has not been released yet, this PR is submitted in advance to avoid the CI from being broken by deprecated warnings.*
