### PR TITLE
Add get_ref functions to more service layers

### DIFF
--- a/tower/src/retry/mod.rs
+++ b/tower/src/retry/mod.rs
@@ -31,6 +31,21 @@ impl<P, S> Retry<P, S> {
     pub fn new(policy: P, service: S) -> Self {
         Retry { policy, service }
     }
+
+    /// Get a reference to the inner service
+    pub fn get_ref(&self) -> &S {
+        &self.service
+    }
+
+    /// Get a mutable reference to the inner service
+    pub fn get_mut(&mut self) -> &mut S {
+        &mut self.service
+    }
+
+    /// Consume `self`, returning the inner service
+    pub fn into_inner(self) -> S {
+        self.service
+    }
 }
 
 impl<P, S, Request> Service<Request> for Retry<P, S>

--- a/tower/src/timeout/mod.rs
+++ b/tower/src/timeout/mod.rs
@@ -28,6 +28,21 @@ impl<T> Timeout<T> {
     pub fn new(inner: T, timeout: Duration) -> Self {
         Timeout { inner, timeout }
     }
+
+    /// Get a reference to the inner service
+    pub fn get_ref(&self) -> &T {
+        &self.inner
+    }
+
+    /// Get a mutable reference to the inner service
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
+    /// Consume `self`, returning the inner service
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
 }
 
 impl<S, Request> Service<Request> for Timeout<S>


### PR DESCRIPTION
Many of the tower layers have accessor functions for the inner layer. This PR implements them for `Retry` and `Timeout`.