### PR TITLE
ready-cache: Properly expose error source

### DIFF
--- a/tower/src/ready_cache/error.rs
+++ b/tower/src/ready_cache/error.rs
@@ -6,9 +6,12 @@ pub struct Failed<K>(pub K, pub crate::BoxError);
 
 // === Failed ===
 
-impl<K> std::fmt::Debug for Failed<K> {
+impl<K: std::fmt::Debug> std::fmt::Debug for Failed<K> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.debug_tuple("Failed").field(&"_").field(&self.1).finish()
+        f.debug_tuple("Failed")
+            .field(&self.0)
+            .field(&self.1)
+            .finish()
     }
 }
 
@@ -18,7 +21,7 @@ impl<K> std::fmt::Display for Failed<K> {
     }
 }
 
-impl<K> std::error::Error for Failed<K> {
+impl<K: std::fmt::Debug> std::error::Error for Failed<K> {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(&*self.1)
     }

--- a/tower/src/ready_cache/error.rs
+++ b/tower/src/ready_cache/error.rs
@@ -8,7 +8,7 @@ pub struct Failed<K>(pub K, pub crate::BoxError);
 
 impl<K> std::fmt::Debug for Failed<K> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        std::fmt::Debug::fmt(&self.1, f)
+        f.debug_tuple("Failed").field(&"_").field(&self.1).finish()
     }
 }
 
@@ -20,6 +20,6 @@ impl<K> std::fmt::Display for Failed<K> {
 
 impl<K> std::error::Error for Failed<K> {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.1.source()
+        Some(&*self.1)
     }
 }


### PR DESCRIPTION
The `ready_cache::error::Failed` type does not actually expose its inner
error type via `Error::source`. This change fixes this and improves
debug formatting.