### PR TITLE
Fix broken documentation links

### DIFF
--- a/tower-layer/src/lib.rs
+++ b/tower-layer/src/lib.rs
@@ -11,7 +11,7 @@
 //! A layer decorates an service and provides additional functionality. It
 //! allows other services to be composed with the service that implements layer.
 //!
-//! A middleware implements the [`Layer`] and [`Service`] trait.
+//! A middleware implements the [`Layer`] and [`Service`](tower_service::Service) trait.
 
 mod identity;
 mod stack;

--- a/tower-test/src/macros.rs
+++ b/tower-test/src/macros.rs
@@ -1,7 +1,7 @@
 /// Asserts that the mock handle receives a new request equal to the given
 /// value.
 ///
-/// On success, the [`SendResponse`] handle for the matched request is returned,
+/// On success, the [`SendResponse`](crate::mock::SendResponse) handle for the matched request is returned,
 /// allowing the caller to respond to the request. On failure, the macro panics.
 ///
 /// # Examples

--- a/tower/src/balance/mod.rs
+++ b/tower/src/balance/mod.rs
@@ -16,7 +16,7 @@
 //!
 //! Second, [`pool`] implements a dynamically sized pool of services. It estimates the overall
 //! current load by tracking successful and unsuccessful calls to `poll_ready`, and uses an
-//! exponentially weighted moving average to add (using [`tower::make_service::MakeService`]) or
+//! exponentially weighted moving average to add (using [`tower::make::MakeService`](crate::make::MakeService)) or
 //! remove (by dropping) services in response to increases or decreases in load. Use this if you
 //! are able to dynamically add more service endpoints to the system to handle added load.
 //!

--- a/tower/src/balance/p2c/layer.rs
+++ b/tower/src/balance/p2c/layer.rs
@@ -8,12 +8,15 @@ use tower_layer::Layer;
 ///
 /// This construction may seem a little odd at first glance. This is not a layer that takes
 /// requests and produces responses in the traditional sense. Instead, it is more like
-/// [`MakeService`](tower::make_service::MakeService) in that it takes service _descriptors_ (see
+/// [`MakeService`](crate::make::MakeService) in that it takes service _descriptors_ (see
 /// `Target` on `MakeService`) and produces _services_. Since [`Balance`] spreads requests across a
 /// _set_ of services, the inner service should produce a [`Discover`], not just a single
-/// [`Service`], given a service descriptor.
+/// [`Service`](tower_service::Service), given a service descriptor.
 ///
 /// See the [module-level documentation](..) for details on load balancing.
+///
+/// [`Balance`]: crate::balance::p2c::service::Balance
+/// [`Discover`]: crate::discover::Discover
 #[derive(Clone)]
 pub struct MakeBalanceLayer<D, Req> {
     rng: SmallRng,

--- a/tower/src/balance/p2c/make.rs
+++ b/tower/src/balance/p2c/make.rs
@@ -14,7 +14,7 @@ use tower_service::Service;
 
 /// Constructs load balancers over dynamic service sets produced by a wrapped "inner" service.
 ///
-/// This is effectively an implementation of [`MakeService`](tower::make_service::MakeService),
+/// This is effectively an implementation of [`MakeService`](crate::make::MakeService),
 /// except that it forwards the service descriptors (`Target`) to an inner service (`S`), and
 /// expects that service to produce a service set in the form of a [`Discover`]. It then wraps the
 /// service set in a [`Balance`] before returning it as the "made" service.

--- a/tower/src/balance/p2c/mod.rs
+++ b/tower/src/balance/p2c/mod.rs
@@ -3,7 +3,7 @@
 //! It is a simple but robust technique for spreading load across services with only inexact load
 //! measurements. As its name implies, whenever a request comes in, it samples two ready services
 //! at random, and issues the request to whichever service is less loaded. How loaded a service is
-//! is determined by the return value of [`Load`](tower::load::Load).
+//! is determined by the return value of [`Load`](crate::load::Load).
 //!
 //! As described in the [Finagle Guide][finagle]:
 //!
@@ -16,9 +16,9 @@
 //!
 //! The balance service and layer implementations rely on _service discovery_ to provide the
 //! underlying set of services to balance requests across. This happens through the
-//! [`Discover`](tower::discover::Discover) trait, which is essentially a `Stream` that indicates
+//! [`Discover`](crate::discover::Discover) trait, which is essentially a `Stream` that indicates
 //! when services become available or go away. If you have a fixed set of services, consider using
-//! [`ServiceList`](tower::discover::ServiceList).
+//! [`ServiceList`](crate::discover::ServiceList).
 //!
 //! Since the load balancer needs to perform _random_ choices, the constructors in this module
 //! usually come in two forms: one that uses randomness provided by the operating system, and one

--- a/tower/src/load/mod.rs
+++ b/tower/src/load/mod.rs
@@ -7,11 +7,11 @@
 //!  - [`PendingRequests`] — Measures load by tracking the number of in-flight requests.
 //!  - [`PeakEwma`] — Measures load using a moving average of the peak latency for the service.
 //!
-//! In general, you will want to use one of these when using the types in [`tower::balance`] which
+//! In general, you will want to use one of these when using the types in [`tower::balance`](crate::balance) which
 //! balance services depending on their load. Which load metric to use depends on your exact
 //! use-case, but the ones above should get you quite far!
 //!
-//! When the `discover` feature is enabled, wrapper types for [`tower::discover::Discover`] that
+//! When the `discover` feature is enabled, wrapper types for [`tower::discover::Discover`](crate::discover::Discover) that
 //! wrap the discovered services with the given load estimator are also provided.
 //!
 //! # When does a request complete?
@@ -27,7 +27,7 @@
 //! `CompleteOnOnResponse` is what you would normally expect for a request-response cycle: when the
 //! response is produced, the request is considered "finished", and load goes down. This can be
 //! overriden by your own user-defined type to track more complex request completion semantics. See
-//! the documentation for [`tower::load::completion`] for more details.
+//! the documentation for [`tower::load::completion`](crate::load::completion) for more details.
 //!
 //! # Examples
 //!


### PR DESCRIPTION
**Fixes**
- Fix `...::make_service::...` links.
- Replace links with root given explicitly by `crate::...`
