### PR TITLE
Show MakeConnection on docs.rs documentation.

### DIFF
--- a/tower-make/Cargo.toml
+++ b/tower-make/Cargo.toml
@@ -19,3 +19,7 @@ connect = ["tokio"]
 [dependencies]
 tower-service = "0.3"
 tokio = { version = "0.2", optional = true }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/tower-make/src/lib.rs
+++ b/tower-make/src/lib.rs
@@ -5,14 +5,17 @@
     rust_2018_idioms,
     unreachable_pub
 )]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Trait aliases for Services that produce specific types of Responses.
 
 #[cfg(feature = "connect")]
+#[cfg_attr(docsrs, doc(cfg(feature = "connect")))]
 mod make_connection;
 mod make_service;
 
 #[cfg(feature = "connect")]
+#[cfg_attr(docsrs, doc(cfg(feature = "connect")))]
 pub use crate::make_connection::MakeConnection;
 pub use crate::make_service::MakeService;
 


### PR DESCRIPTION
Shows MakeConnection in the docs.rs documentation. Highlight the fact that it requires a feature.