### PR TITLE
Upgrade to tokio 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [workspace]
-
 members = [
   "tower",
   "tower-layer",
   "tower-service",
   "tower-test",
+  "examples"
 ]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # If you copy one of the examples into a new project, you should be using
 # [dependencies] instead.
 [dev-dependencies]
-tower = { path = "../tower", features = ["full"] }
+tower = { version = "0.4", path = "../tower", features = ["full"] }
 tower-service = "0.3" 
 tokio = { version = "0.3", features = ["full"] }
 rand = "0.7"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "examples"
+version = "0.0.0"
+publish = false
+edition = "2018"
+
+# If you copy one of the examples into a new project, you should be using
+# [dependencies] instead.
+[dev-dependencies]
+tower = { path = "../tower", features = ["full"] }
+tower-service = "0.3" 
+tokio = { version = "0.3", features = ["full"] }
+rand = "0.7"
+pin-project = "1.0"
+futures = "0.3"
+tracing = "0.1"
+tracing-subscriber = "0.2"
+hdrhistogram = "7"
+
+[[example]]
+name = "balance"
+path = "balance.rs"

--- a/examples/balance.rs
+++ b/examples/balance.rs
@@ -1,7 +1,6 @@
 //! Exercises load balancers with mocked services.
 
-use futures_core::{Stream, TryStream};
-use futures_util::{stream, stream::StreamExt, stream::TryStreamExt};
+use futures::stream::{self, Stream, StreamExt, TryStream, TryStreamExt};
 use hdrhistogram::Histogram;
 use pin_project::pin_project;
 use rand::{self, Rng};
@@ -118,7 +117,7 @@ fn gen_disco() -> impl Discover<
                     let latency = Duration::from_millis(rand::thread_rng().gen_range(0, maxms));
 
                     async move {
-                        time::delay_until(start + latency).await;
+                        time::sleep_until(start + latency).await;
                         let latency = start.elapsed();
                         Ok(Rsp { latency, instance })
                     }

--- a/tower-test/Cargo.toml
+++ b/tower-test/Cargo.toml
@@ -23,11 +23,11 @@ edition = "2018"
 
 [dependencies]
 futures-util = { version = "0.3", default-features = false }
-tokio = { version = "0.2", features = ["sync"]}
+tokio02 = { version = "0.2", package = "tokio", features = ["sync"]}
 tower-layer = { version = "0.3", path = "../tower-layer" }
 tokio-test = "0.2"
 tower-service = { version = "0.3" }
 pin-project = "0.4.17"
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "0.3", features = ["macros"] }

--- a/tower-test/src/mock/future.rs
+++ b/tower-test/src/mock/future.rs
@@ -3,7 +3,7 @@
 use crate::mock::error::{self, Error};
 use futures_util::ready;
 use pin_project::pin_project;
-use tokio::sync::oneshot;
+use tokio02::sync::oneshot;
 
 use std::{
     future::Future,

--- a/tower-test/src/mock/mod.rs
+++ b/tower-test/src/mock/mod.rs
@@ -9,7 +9,7 @@ pub use spawn::Spawn;
 use crate::mock::{error::Error, future::ResponseFuture};
 use core::task::Waker;
 
-use tokio::sync::{mpsc, oneshot};
+use tokio02::sync::{mpsc, oneshot};
 use tower_layer::Layer;
 use tower_service::Service;
 

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -25,9 +25,10 @@ edition = "2018"
 
 [features]
 default = ["log"]
+full = ["log", "balance", "buffer", "discover", "filter", "hedge", "limit", "load", "load-shed", "make", "ready-cache", "reconnect", "retry", "spawn-ready", "steer", "timeout", "util"]
 log = ["tracing/log"]
 balance = ["discover", "load", "ready-cache", "make", "rand", "slab"]
-buffer = ["tokio/sync", "tokio/rt-core"]
+buffer = ["tokio02/sync", "tokio/rt"]
 discover = []
 filter = []
 hedge = ["util", "filter", "futures-util", "hdrhistogram", "tokio/time"]
@@ -35,17 +36,17 @@ limit = ["tokio/time"]
 load = ["tokio/time"]
 load-shed = []
 make = ["tokio/io-std"]
-ready-cache = ["futures-util", "indexmap", "tokio/sync"]
+ready-cache = ["futures-util", "indexmap", "tokio02/sync"]
 reconnect = ["make", "tokio/io-std"]
 retry = ["tokio/time"]
-spawn-ready = ["futures-util", "tokio/sync", "tokio/rt-core"]
+spawn-ready = ["futures-util", "tokio02/sync", "tokio/rt"]
 steer = ["futures-util"]
 timeout = ["tokio/time"]
 util = ["futures-util"]
 
 [dependencies]
 futures-core = "0.3"
-pin-project = "0.4.17"
+pin-project = "1.0"
 tower-layer = { version = "0.3", path = "../tower-layer" }
 tower-service = { version = "0.3" }
 tracing = "0.1.2"
@@ -55,18 +56,17 @@ hdrhistogram = { version = "6.0", optional = true }
 indexmap = { version = "1.0.2", optional = true }
 rand = { version = "0.7", features = ["small_rng"], optional = true }
 slab = { version = "0.4", optional = true }
-tokio = { version = "0.2", optional = true, features = ["sync"] }
+tokio = { version = "0.3", optional = true, features = ["time"] }
+tokio02 = { version = "0.2", package = "tokio", optional = true, features = ["sync"] }
 
 [dev-dependencies]
 futures-util = { version = "0.3", default-features = false, features = ["alloc", "async-await"] }
 hdrhistogram = "6.0"
 quickcheck = { version = "0.9", default-features = false }
-tokio = { version = "0.2", features = ["macros", "stream", "sync", "test-util" ] }
+tokio = { version = "0.3", features = ["macros", "stream", "sync", "test-util" ] }
 tokio-test = "0.2"
 tower-test = { version = "0.3", path = "../tower-test" }
 tracing-subscriber = "0.1.1"
-# env_logger = { version = "0.5.3", default-features = false }
-# log = "0.4.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -27,12 +27,12 @@ edition = "2018"
 default = ["log"]
 full = ["log", "balance", "buffer", "discover", "filter", "hedge", "limit", "load", "load-shed", "make", "ready-cache", "reconnect", "retry", "spawn-ready", "steer", "timeout", "util"]
 log = ["tracing/log"]
-balance = ["discover", "load", "ready-cache", "make", "rand", "slab"]
+balance = ["discover", "load", "ready-cache", "make", "rand", "slab", "tokio02/sync"]
 buffer = ["tokio02/sync", "tokio/rt"]
 discover = []
 filter = []
 hedge = ["util", "filter", "futures-util", "hdrhistogram", "tokio/time"]
-limit = ["tokio/time"]
+limit = ["tokio/time", "tokio02/sync"]
 load = ["tokio/time"]
 load-shed = []
 make = ["tokio/io-std"]
@@ -57,7 +57,7 @@ indexmap = { version = "1.0.2", optional = true }
 rand = { version = "0.7", features = ["small_rng"], optional = true }
 slab = { version = "0.4", optional = true }
 tokio = { version = "0.3", optional = true, features = ["time"] }
-tokio02 = { version = "0.2", package = "tokio", optional = true, features = ["sync"] }
+tokio02 = { version = "0.2", package = "tokio", optional = true, features = ["sync", "stream"] }
 
 [dev-dependencies]
 futures-util = { version = "0.3", default-features = false, features = ["alloc", "async-await"] }

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -8,7 +8,7 @@ name = "tower"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "vX.X.X" git tag.
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"

--- a/tower/src/balance/p2c/service.rs
+++ b/tower/src/balance/p2c/service.rs
@@ -14,7 +14,7 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tokio::sync::oneshot;
+use tokio02::sync::oneshot;
 use tower_service::Service;
 use tracing::{debug, trace};
 

--- a/tower/src/balance/pool/mod.rs
+++ b/tower/src/balance/pool/mod.rs
@@ -27,6 +27,7 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
+use tokio02::sync::mpsc;
 use tower_service::Service;
 
 #[cfg(test)]
@@ -55,9 +56,9 @@ where
     target: Target,
     load: Level,
     services: Slab<()>,
-    died_tx: tokio::sync::mpsc::UnboundedSender<usize>,
+    died_tx: mpsc::UnboundedSender<usize>,
     #[pin]
-    died_rx: tokio::sync::mpsc::UnboundedReceiver<usize>,
+    died_rx: mpsc::UnboundedReceiver<usize>,
     limit: Option<usize>,
 }
 
@@ -276,7 +277,7 @@ impl Builder {
         MS::Error: Into<crate::BoxError>,
         Target: Clone,
     {
-        let (died_tx, died_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (died_tx, died_rx) = mpsc::unbounded_channel();
         let d = PoolDiscoverer {
             maker: make_service,
             making: None,
@@ -428,7 +429,7 @@ where
 pub struct DropNotifyService<Svc> {
     svc: Svc,
     id: usize,
-    notify: tokio::sync::mpsc::UnboundedSender<usize>,
+    notify: mpsc::UnboundedSender<usize>,
 }
 
 impl<Svc> Drop for DropNotifyService<Svc> {

--- a/tower/src/buffer/message.rs
+++ b/tower/src/buffer/message.rs
@@ -1,5 +1,5 @@
 use super::error::ServiceError;
-use tokio::sync::oneshot;
+use tokio02::sync::oneshot;
 
 /// Message sent over buffer
 #[derive(Debug)]

--- a/tower/src/buffer/service.rs
+++ b/tower/src/buffer/service.rs
@@ -6,7 +6,7 @@ use super::{
 
 use futures_core::ready;
 use std::task::{Context, Poll};
-use tokio::sync::{mpsc, oneshot};
+use tokio02::sync::{mpsc, oneshot};
 use tower_service::Service;
 
 /// Adds an mpsc buffer in front of an inner service.

--- a/tower/src/buffer/worker.rs
+++ b/tower/src/buffer/worker.rs
@@ -10,7 +10,7 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tokio::sync::mpsc;
+use tokio02::sync::mpsc;
 use tower_service::Service;
 
 /// Task that handles processing the buffer. This type should not be used
@@ -93,7 +93,8 @@ where
         }
 
         // Get the next request
-        while let Some(mut msg) = ready!(Pin::new(&mut self.rx).poll_recv(cx)) {
+        use futures_core::Stream;
+        while let Some(mut msg) = ready!(Pin::new(&mut self.rx).poll_next(cx)) {
             if msg.tx.poll_closed(cx).is_pending() {
                 tracing::trace!("processing new request");
                 return Poll::Ready(Some((msg, true)));

--- a/tower/src/hedge/delay.rs
+++ b/tower/src/hedge/delay.rs
@@ -37,7 +37,7 @@ where
 #[pin_project(project = StateProj)]
 #[derive(Debug)]
 enum State<Request, F> {
-    Delaying(#[pin] tokio::time::Delay, Option<Request>),
+    Delaying(#[pin] tokio::time::Sleep, Option<Request>),
     Called(#[pin] F),
 }
 
@@ -73,7 +73,7 @@ where
         let deadline = tokio::time::Instant::now() + self.policy.delay(&request);
         ResponseFuture {
             service: Some(self.service.clone()),
-            state: State::Delaying(tokio::time::delay_until(deadline), Some(request)),
+            state: State::Delaying(tokio::time::sleep_until(deadline), Some(request)),
         }
     }
 }

--- a/tower/src/hedge/mod.rs
+++ b/tower/src/hedge/mod.rs
@@ -1,12 +1,7 @@
 //! Pre-emptively retry requests which have been outstanding for longer
 //! than a given latency percentile.
 
-#![warn(
-    missing_debug_implementations,
-    missing_docs,
-    rust_2018_idioms,
-    unreachable_pub
-)]
+#![warn(missing_debug_implementations, missing_docs, unreachable_pub)]
 
 use crate::filter::Filter;
 use futures_util::future;

--- a/tower/src/limit/concurrency/future.rs
+++ b/tower/src/limit/concurrency/future.rs
@@ -7,7 +7,7 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tokio::sync::OwnedSemaphorePermit;
+use tokio02::sync::OwnedSemaphorePermit;
 
 /// Future for the `ConcurrencyLimit` service.
 #[pin_project]

--- a/tower/src/limit/concurrency/service.rs
+++ b/tower/src/limit/concurrency/service.rs
@@ -9,7 +9,7 @@ use std::mem;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio02::sync::{OwnedSemaphorePermit, Semaphore};
 
 /// Enforces a limit on the concurrent number of requests the underlying
 /// service can handle.

--- a/tower/src/limit/rate/service.rs
+++ b/tower/src/limit/rate/service.rs
@@ -5,7 +5,7 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tokio::time::{Delay, Instant};
+use tokio::time::{Instant, Sleep};
 use tower_service::Service;
 
 /// Enforces a rate limit on the number of requests the underlying
@@ -20,7 +20,7 @@ pub struct RateLimit<T> {
 #[derive(Debug)]
 enum State {
     // The service has hit its limit
-    Limited(Delay),
+    Limited(Sleep),
     Ready { until: Instant, rem: u64 },
 }
 
@@ -98,7 +98,7 @@ where
                     self.state = State::Ready { until, rem };
                 } else {
                     // The service is disabled until further notice
-                    let sleep = tokio::time::delay_until(until);
+                    let sleep = tokio::time::sleep_until(until);
                     self.state = State::Limited(sleep);
                 }
 

--- a/tower/src/ready_cache/cache.rs
+++ b/tower/src/ready_cache/cache.rs
@@ -9,7 +9,7 @@ use std::future::Future;
 use std::hash::Hash;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio::sync::oneshot;
+use tokio02::sync::oneshot;
 use tower_service::Service;
 use tracing::{debug, trace};
 

--- a/tower/src/spawn_ready/future.rs
+++ b/tower/src/spawn_ready/future.rs
@@ -8,13 +8,13 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tokio::sync::oneshot;
+use tokio02::sync::oneshot;
 use tower_service::Service;
 
 /// Drives a service to readiness.
 #[pin_project]
 #[derive(Debug)]
-pub struct BackgroundReady<T, Request> {
+pub(crate) struct BackgroundReady<T, Request> {
     service: Option<T>,
     tx: Option<oneshot::Sender<Result<T, crate::BoxError>>>,
     _req: PhantomData<Request>,

--- a/tower/src/spawn_ready/mod.rs
+++ b/tower/src/spawn_ready/mod.rs
@@ -1,7 +1,7 @@
 //! When an underlying service is not ready, drive it to readiness on a
 //! background task.
 
-pub mod future;
+mod future;
 mod layer;
 mod make;
 mod service;

--- a/tower/src/spawn_ready/service.rs
+++ b/tower/src/spawn_ready/service.rs
@@ -6,7 +6,7 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tokio::sync::oneshot;
+use tokio02::sync::oneshot;
 use tower_service::Service;
 
 /// Spawns tasks to drive an inner service to readiness.

--- a/tower/src/timeout/future.rs
+++ b/tower/src/timeout/future.rs
@@ -7,7 +7,7 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tokio::time::Delay;
+use tokio::time::Sleep;
 
 /// `Timeout` response future
 #[pin_project]
@@ -16,11 +16,11 @@ pub struct ResponseFuture<T> {
     #[pin]
     response: T,
     #[pin]
-    sleep: Delay,
+    sleep: Sleep,
 }
 
 impl<T> ResponseFuture<T> {
-    pub(crate) fn new(response: T, sleep: Delay) -> Self {
+    pub(crate) fn new(response: T, sleep: Sleep) -> Self {
         ResponseFuture { response, sleep }
     }
 }

--- a/tower/src/timeout/mod.rs
+++ b/tower/src/timeout/mod.rs
@@ -63,7 +63,7 @@ where
 
     fn call(&mut self, request: Request) -> Self::Future {
         let response = self.inner.call(request);
-        let sleep = tokio::time::delay_for(self.timeout);
+        let sleep = tokio::time::sleep(self.timeout);
 
         ResponseFuture::new(response, sleep)
     }

--- a/tower/src/util/call_all/ordered.rs
+++ b/tower/src/util/call_all/ordered.rs
@@ -46,7 +46,7 @@ use tower_service::Service;
 /// #[tokio::main]
 /// async fn main() {
 ///     // Next, we need a Stream of requests.
-///     let (mut reqs, rx) = tokio::sync::mpsc::unbounded_channel();
+///     let (mut reqs, rx) = tokio02::sync::mpsc::unbounded_channel();
 ///     // Note that we have to help Rust out here by telling it what error type to use.
 ///     // Specifically, it has to be From<Service::Error> + From<Stream::Error>.
 ///     let mut rsps = FirstLetter.call_all(rx);

--- a/tower/tests/balance/main.rs
+++ b/tower/tests/balance/main.rs
@@ -33,7 +33,7 @@ impl tower::load::Load for Mock {
 #[test]
 fn stress() {
     let mut task = task::spawn(());
-    let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Result<_, &'static str>>();
+    let (tx, rx) = tokio02::sync::mpsc::unbounded_channel::<Result<_, &'static str>>();
     let mut cache = Balance::<_, Req>::new(rx);
 
     let mut nready = 0;

--- a/tower/tests/util/call_all.rs
+++ b/tower/tests/util/call_all.rs
@@ -47,7 +47,7 @@ fn ordered() {
         count: count.clone(),
         admit: admit.clone(),
     };
-    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let (tx, rx) = tokio02::sync::mpsc::unbounded_channel();
     let ca = srv.call_all(rx);
     pin_mut!(ca);
 

--- a/tower/tests/util/oneshot.rs
+++ b/tower/tests/util/oneshot.rs
@@ -35,5 +35,5 @@ async fn service_driven_to_readiness() {
     }
 
     let svc = PollMeTwice { ready: false };
-    svc.oneshot(()).await;
+    svc.oneshot(()).await.unwrap();
 }


### PR DESCRIPTION
- Upgrade runtime aspects to 0.3 (time)
- Continue to use tokio 0.2 sync until we can get the correct workarounds
- Move examples out of the crate and minor clean up
- Add `full` feature flag

Closes #473