### PR TITLE
chore: downgrade `multiple-versions` to `warn` in cargo-deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -13,11 +13,9 @@ allow-osi-fsf-free = "either"
 confidence-threshold = 0.8
 
 [bans]
-multiple-versions = "deny"
+multiple-versions = "warn"
 highlight = "all"
-skip-tree = [
-    { name = "tower", version = "=0.3"}
-]
+skip-tree = [{ name = "tower", version = "=0.3" }]
 
 [sources]
 unknown-registry = "warn"


### PR DESCRIPTION
It's definitely preferable to avoid multiple versions of the same
dependency in our tree. However, in many cases, a duplicate dependency
is a transitive dependency --- a dependency of two other dependencies
that require incompatible versions. In that case, there's basically
nothing *we* can do in-repo to resolve the issue. The upstream
dependencies would need to be patched, which means opening a PR against
them and waiting for a new version to be released. We can definitely
_do_ this, but it takes some time.

We currently have a duplicate transitive dependency where two of our
dev-dependencies depend on different versions of `wasi`. This doesn't
pose any kind of issue for our downstreams: they won't see duplicate
dependencies in their dependency trees, since these are dev-deps.
However, this is failing our CI builds.

I'd prefer it if waiting for upstream to fix duplicate dependencies
didn't block merging all PRs.  Therefore, this branch changes the
`multiple-versions` setting in `deny.toml` from `deny` to `warn` so that
we can still merge PRs when there are duplicate transitive dependencies.

In an ideal world, it would be nice if `cargo-deny` could be configured
to deny multiple versions of _direct_ dependencies, which we can fix by
ensuring our direct deps have compatible versions, but only warn for
transitive dependencies that we may have no control over. However, I
don't think this is currently possible.