### PR TITLE
buffer: wake tasks waiting for channel capacity when terminating

### DIFF
--- a/tower-test/tests/mock.rs
+++ b/tower-test/tests/mock.rs
@@ -1,7 +1,7 @@
 use tokio_test::{assert_pending, assert_ready};
 use tower_test::{assert_request_eq, mock};
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn single_request_ready() {
     let (mut service, mut handle) = mock::spawn();
 
@@ -16,7 +16,7 @@ async fn single_request_ready() {
     assert_eq!(response.await.unwrap(), "world");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 #[should_panic]
 async fn backpressure() {
     let (mut service, mut handle) = mock::spawn::<_, ()>();

--- a/tower/src/buffer/service.rs
+++ b/tower/src/buffer/service.rs
@@ -80,8 +80,8 @@ where
         Request: Send + 'static,
     {
         let (tx, rx) = mpsc::unbounded_channel();
-        let (handle, worker) = Worker::new(service, rx);
-        let semaphore = Semaphore::new(bound);
+        let (semaphore, wake_waiters) = Semaphore::new_with_close(bound);
+        let (handle, worker) = Worker::new(service, rx, wake_waiters);
         (
             Buffer {
                 tx,

--- a/tower/tests/balance/main.rs
+++ b/tower/tests/balance/main.rs
@@ -1,4 +1,6 @@
 #![cfg(feature = "balance")]
+#[path = "../support.rs"]
+mod support;
 
 use std::future::Future;
 use std::task::{Context, Poll};
@@ -32,6 +34,7 @@ impl tower::load::Load for Mock {
 
 #[test]
 fn stress() {
+    let _t = support::trace_init();
     let mut task = task::spawn(());
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Result<_, &'static str>>();
     let mut cache = Balance::<_, Req>::new(rx);

--- a/tower/tests/buffer/main.rs
+++ b/tower/tests/buffer/main.rs
@@ -4,6 +4,7 @@ mod support;
 use std::thread;
 use tokio_test::{assert_pending, assert_ready, assert_ready_err, assert_ready_ok, task};
 use tower::buffer::{error, Buffer};
+use tower::{util::ServiceExt, Service};
 use tower_test::{assert_request_eq, mock};
 
 fn let_worker_work() {
@@ -230,7 +231,6 @@ async fn waits_for_channel_capacity() {
 #[tokio::test(flavor = "current_thread")]
 async fn wakes_pending_waiters_on_close() {
     let _t = support::trace_init();
-    use tower::{util::ServiceExt, Service};
 
     let (service, mut handle) = mock::pair::<_, ()>();
 
@@ -289,8 +289,6 @@ async fn wakes_pending_waiters_on_close() {
 #[tokio::test(flavor = "current_thread")]
 async fn wakes_pending_waiters_on_failure() {
     let _t = support::trace_init();
-    use std::error::Error as StdError;
-    use tower::{util::ServiceExt, Service};
 
     let (service, mut handle) = mock::pair::<_, ()>();
 

--- a/tower/tests/buffer/main.rs
+++ b/tower/tests/buffer/main.rs
@@ -11,7 +11,7 @@ fn let_worker_work() {
     thread::sleep(::std::time::Duration::from_millis(100));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn req_and_res() {
     let _t = support::trace_init();
 
@@ -26,7 +26,7 @@ async fn req_and_res() {
     assert_eq!(assert_ready_ok!(response.poll()), "world");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn clears_canceled_requests() {
     let _t = support::trace_init();
 
@@ -64,7 +64,7 @@ async fn clears_canceled_requests() {
     assert_eq!(assert_ready_ok!(res3.poll()), "world3");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn when_inner_is_not_ready() {
     let _t = support::trace_init();
 
@@ -88,7 +88,7 @@ async fn when_inner_is_not_ready() {
     assert_eq!(assert_ready_ok!(res1.poll()), "world");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn when_inner_fails() {
     use std::error::Error as StdError;
     let _t = support::trace_init();
@@ -113,7 +113,7 @@ async fn when_inner_fails() {
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn poll_ready_when_worker_is_dropped_early() {
     let _t = support::trace_init();
 
@@ -130,7 +130,7 @@ async fn poll_ready_when_worker_is_dropped_early() {
     assert!(err.is::<error::Closed>(), "should be a Closed: {:?}", err);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn response_future_when_worker_is_dropped_early() {
     let _t = support::trace_init();
 
@@ -152,7 +152,7 @@ async fn response_future_when_worker_is_dropped_early() {
     assert!(err.is::<error::Closed>(), "should be a Closed: {:?}", err);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn waits_for_channel_capacity() {
     let _t = support::trace_init();
 

--- a/tower/tests/buffer/main.rs
+++ b/tower/tests/buffer/main.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "buffer")]
-
+#[path = "../support.rs"]
+mod support;
 use std::thread;
 use tokio_test::{assert_pending, assert_ready, assert_ready_err, assert_ready_ok, task};
 use tower::buffer::{error, Buffer};
@@ -12,6 +13,8 @@ fn let_worker_work() {
 
 #[tokio::test]
 async fn req_and_res() {
+    let _t = support::trace_init();
+
     let (mut service, mut handle) = new_service();
 
     assert_ready_ok!(service.poll_ready());
@@ -25,6 +28,8 @@ async fn req_and_res() {
 
 #[tokio::test]
 async fn clears_canceled_requests() {
+    let _t = support::trace_init();
+
     let (mut service, mut handle) = new_service();
 
     handle.allow(1);
@@ -61,6 +66,8 @@ async fn clears_canceled_requests() {
 
 #[tokio::test]
 async fn when_inner_is_not_ready() {
+    let _t = support::trace_init();
+
     let (mut service, mut handle) = new_service();
 
     // Make the service NotReady
@@ -84,6 +91,7 @@ async fn when_inner_is_not_ready() {
 #[tokio::test]
 async fn when_inner_fails() {
     use std::error::Error as StdError;
+    let _t = support::trace_init();
 
     let (mut service, mut handle) = new_service();
 
@@ -107,6 +115,8 @@ async fn when_inner_fails() {
 
 #[tokio::test]
 async fn poll_ready_when_worker_is_dropped_early() {
+    let _t = support::trace_init();
+
     let (service, _handle) = mock::pair::<(), ()>();
 
     let (service, worker) = Buffer::pair(service, 1);
@@ -122,6 +132,8 @@ async fn poll_ready_when_worker_is_dropped_early() {
 
 #[tokio::test]
 async fn response_future_when_worker_is_dropped_early() {
+    let _t = support::trace_init();
+
     let (service, mut handle) = mock::pair::<_, ()>();
 
     let (service, worker) = Buffer::pair(service, 1);
@@ -142,6 +154,8 @@ async fn response_future_when_worker_is_dropped_early() {
 
 #[tokio::test]
 async fn waits_for_channel_capacity() {
+    let _t = support::trace_init();
+
     let (service, mut handle) = mock::pair::<&'static str, &'static str>();
 
     let (service, worker) = Buffer::pair(service, 3);

--- a/tower/tests/builder.rs
+++ b/tower/tests/builder.rs
@@ -1,5 +1,5 @@
 #![cfg(all(feature = "buffer", feature = "limit", feature = "retry"))]
-
+mod support;
 use futures_util::{future::Ready, pin_mut};
 use std::time::Duration;
 use tower::builder::ServiceBuilder;
@@ -8,8 +8,10 @@ use tower::util::ServiceExt;
 use tower_service::*;
 use tower_test::{assert_request_eq, mock};
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn builder_service() {
+    let _t = support::trace_init();
+
     let (service, handle) = mock::pair();
     pin_mut!(handle);
 

--- a/tower/tests/filter/main.rs
+++ b/tower/tests/filter/main.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "filter")]
-
+#[path = "../support.rs"]
+mod support;
 use futures_util::{future::poll_fn, pin_mut};
 use std::future::Future;
 use tower::filter::{error::Error, Filter};
@@ -8,6 +9,8 @@ use tower_test::{assert_request_eq, mock};
 
 #[tokio::test]
 async fn passthrough_sync() {
+    let _t = support::trace_init();
+
     let (mut service, handle) = new_service(|_| async { Ok(()) });
 
     let th = tokio::spawn(async move {
@@ -39,6 +42,8 @@ async fn passthrough_sync() {
 
 #[tokio::test]
 async fn rejected_sync() {
+    let _t = support::trace_init();
+
     let (mut service, _handle) = new_service(|_| async { Err(Error::rejected()) });
 
     service.call("hello".into()).await.unwrap_err();

--- a/tower/tests/filter/main.rs
+++ b/tower/tests/filter/main.rs
@@ -7,7 +7,7 @@ use tower::filter::{error::Error, Filter};
 use tower_service::Service;
 use tower_test::{assert_request_eq, mock};
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn passthrough_sync() {
     let _t = support::trace_init();
 
@@ -40,7 +40,7 @@ async fn passthrough_sync() {
     th.await.unwrap();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn rejected_sync() {
     let _t = support::trace_init();
 

--- a/tower/tests/hedge/main.rs
+++ b/tower/tests/hedge/main.rs
@@ -1,4 +1,6 @@
 #![cfg(feature = "hedge")]
+#[path = "../support.rs"]
+mod support;
 
 use std::time::Duration;
 use tokio::time;
@@ -8,6 +10,7 @@ use tower_test::{assert_request_eq, mock};
 
 #[tokio::test]
 async fn hedge_orig_completes_first() {
+    let _t = support::trace_init();
     time::pause();
 
     let (mut service, mut handle) = new_service(TestPolicy);
@@ -35,6 +38,7 @@ async fn hedge_orig_completes_first() {
 
 #[tokio::test]
 async fn hedge_hedge_completes_first() {
+    let _t = support::trace_init();
     time::pause();
 
     let (mut service, mut handle) = new_service(TestPolicy);
@@ -63,6 +67,7 @@ async fn hedge_hedge_completes_first() {
 
 #[tokio::test]
 async fn completes_before_hedge() {
+    let _t = support::trace_init();
     let (mut service, mut handle) = new_service(TestPolicy);
 
     assert_ready_ok!(service.poll_ready());
@@ -82,6 +87,7 @@ async fn completes_before_hedge() {
 
 #[tokio::test]
 async fn request_not_retyable() {
+    let _t = support::trace_init();
     time::pause();
 
     let (mut service, mut handle) = new_service(TestPolicy);
@@ -109,6 +115,7 @@ async fn request_not_retyable() {
 
 #[tokio::test]
 async fn request_not_clonable() {
+    let _t = support::trace_init();
     time::pause();
 
     let (mut service, mut handle) = new_service(TestPolicy);

--- a/tower/tests/hedge/main.rs
+++ b/tower/tests/hedge/main.rs
@@ -8,7 +8,7 @@ use tokio_test::{assert_pending, assert_ready, assert_ready_ok, task};
 use tower::hedge::{Hedge, Policy};
 use tower_test::{assert_request_eq, mock};
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn hedge_orig_completes_first() {
     let _t = support::trace_init();
     time::pause();
@@ -36,7 +36,7 @@ async fn hedge_orig_completes_first() {
     assert_eq!(assert_ready_ok!(fut.poll()), "orig-done");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn hedge_hedge_completes_first() {
     let _t = support::trace_init();
     time::pause();
@@ -65,7 +65,7 @@ async fn hedge_hedge_completes_first() {
     assert_eq!(assert_ready_ok!(fut.poll()), "hedge-done");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn completes_before_hedge() {
     let _t = support::trace_init();
     let (mut service, mut handle) = new_service(TestPolicy);
@@ -85,7 +85,7 @@ async fn completes_before_hedge() {
     assert_eq!(assert_ready_ok!(fut.poll()), "orig-done");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn request_not_retyable() {
     let _t = support::trace_init();
     time::pause();
@@ -113,7 +113,7 @@ async fn request_not_retyable() {
     assert_eq!(assert_ready_ok!(fut.poll()), "orig-done");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn request_not_clonable() {
     let _t = support::trace_init();
     time::pause();

--- a/tower/tests/limit/concurrency.rs
+++ b/tower/tests/limit/concurrency.rs
@@ -4,7 +4,7 @@ use tokio_test::{assert_pending, assert_ready, assert_ready_ok};
 use tower::limit::concurrency::ConcurrencyLimitLayer;
 use tower_test::{assert_request_eq, mock};
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn basic_service_limit_functionality_with_poll_ready() {
     let _t = support::trace_init();
     let limit = ConcurrencyLimitLayer::new(2);
@@ -48,7 +48,7 @@ async fn basic_service_limit_functionality_with_poll_ready() {
     assert_eq!(r3.await.unwrap(), "world 3");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn basic_service_limit_functionality_without_poll_ready() {
     let _t = support::trace_init();
     let limit = ConcurrencyLimitLayer::new(2);
@@ -94,7 +94,7 @@ async fn basic_service_limit_functionality_without_poll_ready() {
     assert_eq!(r4.await.unwrap(), "world 4");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn request_without_capacity() {
     let _t = support::trace_init();
     let limit = ConcurrencyLimitLayer::new(0);
@@ -103,7 +103,7 @@ async fn request_without_capacity() {
     assert_pending!(service.poll_ready());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn reserve_capacity_without_sending_request() {
     let _t = support::trace_init();
     let limit = ConcurrencyLimitLayer::new(1);
@@ -129,7 +129,7 @@ async fn reserve_capacity_without_sending_request() {
     assert_ready_ok!(s2.poll_ready());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn service_drop_frees_capacity() {
     let _t = support::trace_init();
     let limit = ConcurrencyLimitLayer::new(1);
@@ -149,7 +149,7 @@ async fn service_drop_frees_capacity() {
     assert_ready_ok!(s2.poll_ready());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn response_error_releases_capacity() {
     let _t = support::trace_init();
     let limit = ConcurrencyLimitLayer::new(1);
@@ -170,7 +170,7 @@ async fn response_error_releases_capacity() {
     assert_ready_ok!(s2.poll_ready());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn response_future_drop_releases_capacity() {
     let _t = support::trace_init();
     let limit = ConcurrencyLimitLayer::new(1);
@@ -191,7 +191,7 @@ async fn response_future_drop_releases_capacity() {
     assert_ready_ok!(s2.poll_ready());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn multi_waiters() {
     let _t = support::trace_init();
     let limit = ConcurrencyLimitLayer::new(1);

--- a/tower/tests/limit/concurrency.rs
+++ b/tower/tests/limit/concurrency.rs
@@ -1,9 +1,12 @@
+#[path = "../support.rs"]
+mod support;
 use tokio_test::{assert_pending, assert_ready, assert_ready_ok};
 use tower::limit::concurrency::ConcurrencyLimitLayer;
 use tower_test::{assert_request_eq, mock};
 
 #[tokio::test]
 async fn basic_service_limit_functionality_with_poll_ready() {
+    let _t = support::trace_init();
     let limit = ConcurrencyLimitLayer::new(2);
     let (mut service, mut handle) = mock::spawn_layer(limit);
 
@@ -47,6 +50,7 @@ async fn basic_service_limit_functionality_with_poll_ready() {
 
 #[tokio::test]
 async fn basic_service_limit_functionality_without_poll_ready() {
+    let _t = support::trace_init();
     let limit = ConcurrencyLimitLayer::new(2);
     let (mut service, mut handle) = mock::spawn_layer(limit);
 
@@ -92,6 +96,7 @@ async fn basic_service_limit_functionality_without_poll_ready() {
 
 #[tokio::test]
 async fn request_without_capacity() {
+    let _t = support::trace_init();
     let limit = ConcurrencyLimitLayer::new(0);
     let (mut service, _) = mock::spawn_layer::<(), (), _>(limit);
 
@@ -100,6 +105,7 @@ async fn request_without_capacity() {
 
 #[tokio::test]
 async fn reserve_capacity_without_sending_request() {
+    let _t = support::trace_init();
     let limit = ConcurrencyLimitLayer::new(1);
     let (mut s1, mut handle) = mock::spawn_layer(limit);
 
@@ -125,6 +131,7 @@ async fn reserve_capacity_without_sending_request() {
 
 #[tokio::test]
 async fn service_drop_frees_capacity() {
+    let _t = support::trace_init();
     let limit = ConcurrencyLimitLayer::new(1);
     let (mut s1, _handle) = mock::spawn_layer::<(), (), _>(limit);
 
@@ -144,6 +151,7 @@ async fn service_drop_frees_capacity() {
 
 #[tokio::test]
 async fn response_error_releases_capacity() {
+    let _t = support::trace_init();
     let limit = ConcurrencyLimitLayer::new(1);
     let (mut s1, mut handle) = mock::spawn_layer::<_, (), _>(limit);
 
@@ -164,6 +172,7 @@ async fn response_error_releases_capacity() {
 
 #[tokio::test]
 async fn response_future_drop_releases_capacity() {
+    let _t = support::trace_init();
     let limit = ConcurrencyLimitLayer::new(1);
     let (mut s1, _handle) = mock::spawn_layer::<_, (), _>(limit);
 
@@ -184,6 +193,7 @@ async fn response_future_drop_releases_capacity() {
 
 #[tokio::test]
 async fn multi_waiters() {
+    let _t = support::trace_init();
     let limit = ConcurrencyLimitLayer::new(1);
     let (mut s1, _handle) = mock::spawn_layer::<(), (), _>(limit);
     let mut s2 = s1.clone();

--- a/tower/tests/limit/main.rs
+++ b/tower/tests/limit/main.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "limit")]
-
 mod concurrency;
 mod rate;
+#[path = "../support.rs"]
+pub(crate) mod support;

--- a/tower/tests/limit/rate.rs
+++ b/tower/tests/limit/rate.rs
@@ -5,7 +5,7 @@ use tokio_test::{assert_pending, assert_ready, assert_ready_ok};
 use tower::limit::rate::RateLimitLayer;
 use tower_test::{assert_request_eq, mock};
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn reaching_capacity() {
     let _t = support::trace_init();
     time::pause();
@@ -35,7 +35,7 @@ async fn reaching_capacity() {
     assert_eq!(response.await.unwrap(), "done");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn remaining_gets_reset() {
     // This test checks for the case where the `until` state gets reset
     // but the `rem` does not. This was a bug found `cd7dd12315706fc0860a35646b1eb7b60c50a5c1`.

--- a/tower/tests/limit/rate.rs
+++ b/tower/tests/limit/rate.rs
@@ -1,3 +1,4 @@
+use super::support;
 use std::time::Duration;
 use tokio::time;
 use tokio_test::{assert_pending, assert_ready, assert_ready_ok};
@@ -6,6 +7,7 @@ use tower_test::{assert_request_eq, mock};
 
 #[tokio::test]
 async fn reaching_capacity() {
+    let _t = support::trace_init();
     time::pause();
 
     let rate_limit = RateLimitLayer::new(1, Duration::from_millis(100));
@@ -42,7 +44,7 @@ async fn remaining_gets_reset() {
     // as ready. Then we can advance the clock to put us beyond the current period. When we make
     // subsequent requests the `rem` for the next window is continued from the previous when
     // it should be totally reset.
-
+    let _t = support::trace_init();
     time::pause();
 
     let rate_limit = RateLimitLayer::new(3, Duration::from_millis(100));

--- a/tower/tests/load_shed/main.rs
+++ b/tower/tests/load_shed/main.rs
@@ -6,7 +6,7 @@ use tokio_test::{assert_ready_err, assert_ready_ok, task};
 use tower::load_shed::LoadShedLayer;
 use tower_test::{assert_request_eq, mock};
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn when_ready() {
     let _t = support::trace_init();
 
@@ -21,7 +21,7 @@ async fn when_ready() {
     assert_eq!(assert_ready_ok!(response.poll()), "world");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn when_not_ready() {
     let _t = support::trace_init();
 

--- a/tower/tests/load_shed/main.rs
+++ b/tower/tests/load_shed/main.rs
@@ -1,4 +1,6 @@
 #![cfg(feature = "load-shed")]
+#[path = "../support.rs"]
+mod support;
 
 use tokio_test::{assert_ready_err, assert_ready_ok, task};
 use tower::load_shed::LoadShedLayer;
@@ -6,6 +8,8 @@ use tower_test::{assert_request_eq, mock};
 
 #[tokio::test]
 async fn when_ready() {
+    let _t = support::trace_init();
+
     let layer = LoadShedLayer::new();
     let (mut service, mut handle) = mock::spawn_layer(layer);
 
@@ -19,6 +23,8 @@ async fn when_ready() {
 
 #[tokio::test]
 async fn when_not_ready() {
+    let _t = support::trace_init();
+
     let layer = LoadShedLayer::new();
     let (mut service, mut handle) = mock::spawn_layer::<_, (), _>(layer);
 

--- a/tower/tests/ready_cache/main.rs
+++ b/tower/tests/ready_cache/main.rs
@@ -1,4 +1,6 @@
 #![cfg(feature = "ready-cache")]
+#[path = "../support.rs"]
+mod support;
 
 use tokio_test::{assert_pending, assert_ready, task};
 use tower::ready_cache::ReadyCache;
@@ -9,6 +11,8 @@ type Mock = mock::Mock<Req, Req>;
 
 #[test]
 fn poll_ready_inner_failure() {
+    let _t = support::trace_init();
+
     let mut task = task::spawn(());
     let mut cache = ReadyCache::<usize, Mock, Req>::default();
 
@@ -30,6 +34,8 @@ fn poll_ready_inner_failure() {
 
 #[test]
 fn poll_ready_not_ready() {
+    let _t = support::trace_init();
+
     let mut task = task::spawn(());
     let mut cache = ReadyCache::<usize, Mock, Req>::default();
 
@@ -50,6 +56,8 @@ fn poll_ready_not_ready() {
 
 #[test]
 fn poll_ready_promotes_inner() {
+    let _t = support::trace_init();
+
     let mut task = task::spawn(());
     let mut cache = ReadyCache::<usize, Mock, Req>::default();
 
@@ -74,6 +82,8 @@ fn poll_ready_promotes_inner() {
 
 #[test]
 fn evict_ready_then_error() {
+    let _t = support::trace_init();
+
     let mut task = task::spawn(());
     let mut cache = ReadyCache::<usize, Mock, Req>::default();
 
@@ -94,6 +104,8 @@ fn evict_ready_then_error() {
 
 #[test]
 fn evict_pending_then_error() {
+    let _t = support::trace_init();
+
     let mut task = task::spawn(());
     let mut cache = ReadyCache::<usize, Mock, Req>::default();
 
@@ -111,6 +123,8 @@ fn evict_pending_then_error() {
 
 #[test]
 fn push_then_evict() {
+    let _t = support::trace_init();
+
     let mut task = task::spawn(());
     let mut cache = ReadyCache::<usize, Mock, Req>::default();
 
@@ -125,6 +139,8 @@ fn push_then_evict() {
 
 #[test]
 fn error_after_promote() {
+    let _t = support::trace_init();
+
     let mut task = task::spawn(());
     let mut cache = ReadyCache::<usize, Mock, Req>::default();
 
@@ -143,6 +159,8 @@ fn error_after_promote() {
 
 #[test]
 fn duplicate_key_by_index() {
+    let _t = support::trace_init();
+
     let mut task = task::spawn(());
     let mut cache = ReadyCache::<usize, Mock, Req>::default();
 

--- a/tower/tests/retry/main.rs
+++ b/tower/tests/retry/main.rs
@@ -7,7 +7,7 @@ use tokio_test::{assert_pending, assert_ready_err, assert_ready_ok, task};
 use tower::retry::Policy;
 use tower_test::{assert_request_eq, mock};
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn retry_errors() {
     let _t = support::trace_init();
 
@@ -26,7 +26,7 @@ async fn retry_errors() {
     assert_eq!(fut.into_inner().await.unwrap(), "world");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn retry_limit() {
     let _t = support::trace_init();
 
@@ -46,7 +46,7 @@ async fn retry_limit() {
     assert_eq!(assert_ready_err!(fut.poll()).to_string(), "retry 3");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn retry_error_inspection() {
     let _t = support::trace_init();
 
@@ -62,7 +62,7 @@ async fn retry_error_inspection() {
     assert_eq!(assert_ready_err!(fut.poll()).to_string(), "reject");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn retry_cannot_clone_request() {
     let _t = support::trace_init();
 
@@ -75,7 +75,7 @@ async fn retry_cannot_clone_request() {
     assert_eq!(assert_ready_err!(fut.poll()).to_string(), "retry 1");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn success_with_cannot_clone() {
     let _t = support::trace_init();
 

--- a/tower/tests/retry/main.rs
+++ b/tower/tests/retry/main.rs
@@ -1,4 +1,6 @@
 #![cfg(feature = "retry")]
+#[path = "../support.rs"]
+mod support;
 
 use futures_util::future;
 use tokio_test::{assert_pending, assert_ready_err, assert_ready_ok, task};
@@ -7,6 +9,8 @@ use tower_test::{assert_request_eq, mock};
 
 #[tokio::test]
 async fn retry_errors() {
+    let _t = support::trace_init();
+
     let (mut service, mut handle) = new_service(RetryErrors);
 
     assert_ready_ok!(service.poll_ready());
@@ -24,6 +28,8 @@ async fn retry_errors() {
 
 #[tokio::test]
 async fn retry_limit() {
+    let _t = support::trace_init();
+
     let (mut service, mut handle) = new_service(Limit(2));
 
     assert_ready_ok!(service.poll_ready());
@@ -42,6 +48,8 @@ async fn retry_limit() {
 
 #[tokio::test]
 async fn retry_error_inspection() {
+    let _t = support::trace_init();
+
     let (mut service, mut handle) = new_service(UnlessErr("reject"));
 
     assert_ready_ok!(service.poll_ready());
@@ -56,6 +64,8 @@ async fn retry_error_inspection() {
 
 #[tokio::test]
 async fn retry_cannot_clone_request() {
+    let _t = support::trace_init();
+
     let (mut service, mut handle) = new_service(CannotClone);
 
     assert_ready_ok!(service.poll_ready());
@@ -67,6 +77,8 @@ async fn retry_cannot_clone_request() {
 
 #[tokio::test]
 async fn success_with_cannot_clone() {
+    let _t = support::trace_init();
+
     // Even though the request couldn't be cloned, if the first request succeeds,
     // it should succeed overall.
     let (mut service, mut handle) = new_service(CannotClone);

--- a/tower/tests/spawn_ready/main.rs
+++ b/tower/tests/spawn_ready/main.rs
@@ -1,4 +1,6 @@
 #![cfg(feature = "spawn-ready")]
+#[path = "../support.rs"]
+mod support;
 
 use std::{thread, time::Duration};
 use tokio_test::{assert_pending, assert_ready, assert_ready_err, assert_ready_ok};
@@ -7,6 +9,8 @@ use tower_test::mock;
 
 #[tokio::test]
 async fn when_inner_is_not_ready() {
+    let _t = support::trace_init();
+
     let layer = SpawnReadyLayer::new();
     let (mut service, mut handle) = mock::spawn_layer::<(), (), _>(layer);
 
@@ -23,6 +27,8 @@ async fn when_inner_is_not_ready() {
 
 #[tokio::test]
 async fn when_inner_fails() {
+    let _t = support::trace_init();
+
     let layer = SpawnReadyLayer::new();
     let (mut service, mut handle) = mock::spawn_layer::<(), (), _>(layer);
 

--- a/tower/tests/spawn_ready/main.rs
+++ b/tower/tests/spawn_ready/main.rs
@@ -7,7 +7,7 @@ use tokio_test::{assert_pending, assert_ready, assert_ready_err, assert_ready_ok
 use tower::spawn_ready::SpawnReadyLayer;
 use tower_test::mock;
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn when_inner_is_not_ready() {
     let _t = support::trace_init();
 
@@ -25,7 +25,7 @@ async fn when_inner_is_not_ready() {
     assert_ready_ok!(service.poll_ready());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn when_inner_fails() {
     let _t = support::trace_init();
 

--- a/tower/tests/steer/main.rs
+++ b/tower/tests/steer/main.rs
@@ -29,7 +29,7 @@ impl Service<String> for MyService {
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn pick_correctly() {
     let _t = support::trace_init();
     let srvs = vec![MyService(42, true), MyService(57, true)];
@@ -42,7 +42,7 @@ async fn pick_correctly() {
     assert_eq!(r, 57);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn pending_all_ready() {
     let _t = support::trace_init();
 

--- a/tower/tests/steer/main.rs
+++ b/tower/tests/steer/main.rs
@@ -1,4 +1,6 @@
 #![cfg(feature = "steer")]
+#[path = "../support.rs"]
+mod support;
 
 use futures_util::future::{ready, Ready};
 use std::task::{Context, Poll};
@@ -27,34 +29,31 @@ impl Service<String> for MyService {
     }
 }
 
-#[test]
-fn pick_correctly() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    rt.block_on(async move {
-        let srvs = vec![MyService(42, true), MyService(57, true)];
-        let mut st = Steer::new(srvs, |_: &_, _: &[_]| 1);
+#[tokio::test]
+async fn pick_correctly() {
+    let _t = support::trace_init();
+    let srvs = vec![MyService(42, true), MyService(57, true)];
+    let mut st = Steer::new(srvs, |_: &_, _: &[_]| 1);
 
-        futures_util::future::poll_fn(|cx| st.poll_ready(cx))
-            .await
-            .unwrap();
-        let r = st.call(String::from("foo")).await.unwrap();
-        assert_eq!(r, 57);
-    });
+    futures_util::future::poll_fn(|cx| st.poll_ready(cx))
+        .await
+        .unwrap();
+    let r = st.call(String::from("foo")).await.unwrap();
+    assert_eq!(r, 57);
 }
 
-#[test]
-fn pending_all_ready() {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    rt.block_on(async move {
-        let srvs = vec![MyService(42, true), MyService(57, false)];
-        let mut st = Steer::new(srvs, |_: &_, _: &[_]| 0);
+#[tokio::test]
+async fn pending_all_ready() {
+    let _t = support::trace_init();
 
-        let p = futures_util::poll!(futures_util::future::poll_fn(|cx| st.poll_ready(cx)));
-        match p {
-            Poll::Pending => (),
-            _ => panic!(
-                "Steer should not return poll_ready if at least one component service is not ready"
-            ),
-        }
-    });
+    let srvs = vec![MyService(42, true), MyService(57, false)];
+    let mut st = Steer::new(srvs, |_: &_, _: &[_]| 0);
+
+    let p = futures_util::poll!(futures_util::future::poll_fn(|cx| st.poll_ready(cx)));
+    match p {
+        Poll::Pending => (),
+        _ => panic!(
+            "Steer should not return poll_ready if at least one component service is not ready"
+        ),
+    }
 }

--- a/tower/tests/support.rs
+++ b/tower/tests/support.rs
@@ -1,0 +1,8 @@
+pub(crate) fn trace_init() -> tracing::subscriber::DefaultGuard {
+    let subscriber = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_max_level(tracing::Level::TRACE)
+        .with_thread_names(true)
+        .finish();
+    tracing::subscriber::set_default(subscriber)
+}

--- a/tower/tests/support.rs
+++ b/tower/tests/support.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 pub(crate) fn trace_init() -> tracing::subscriber::DefaultGuard {
     let subscriber = tracing_subscriber::fmt()
         .with_test_writer()

--- a/tower/tests/util/call_all.rs
+++ b/tower/tests/util/call_all.rs
@@ -39,6 +39,8 @@ impl Service<&'static str> for Srv {
 
 #[test]
 fn ordered() {
+    let _t = super::support::trace_init();
+
     let mut mock = task::spawn(());
 
     let admit = Rc::new(Cell::new(false));
@@ -108,8 +110,10 @@ fn ordered() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn unordered() {
+    let _t = super::support::trace_init();
+
     let (mock, handle) = mock::pair::<_, &'static str>();
     pin_mut!(handle);
 

--- a/tower/tests/util/main.rs
+++ b/tower/tests/util/main.rs
@@ -3,3 +3,5 @@
 mod call_all;
 mod oneshot;
 mod service_fn;
+#[path = "../support.rs"]
+pub(crate) mod support;

--- a/tower/tests/util/oneshot.rs
+++ b/tower/tests/util/oneshot.rs
@@ -3,10 +3,11 @@ use std::{future::Future, pin::Pin};
 use tower::util::ServiceExt;
 use tower_service::Service;
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn service_driven_to_readiness() {
     // This test ensures that `oneshot` will repeatedly call `poll_ready` until
     // the service is ready.
+    let _t = super::support::trace_init();
 
     struct PollMeTwice {
         ready: bool,

--- a/tower/tests/util/service_fn.rs
+++ b/tower/tests/util/service_fn.rs
@@ -2,8 +2,10 @@ use futures_util::future::ready;
 use tower::util::service_fn;
 use tower_service::Service;
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn simple() {
+    let _t = super::support::trace_init();
+
     let mut add_one = service_fn(|req| ready(Ok::<_, ()>(req + 1)));
     let answer = add_one.call(1).await.unwrap();
     assert_eq!(answer, 2);


### PR DESCRIPTION
Depends on #479

#476 introduces one regression in `buffer`: tasks _waiting_ for a
`buffer::Service` to become ready (in `poll_ready`) are no longer
notified when the buffer worker task terminates or the inner service
fails. This means that if a buffer is over its channel capacity, and
tasks are waiting for it to become ready again, and the buffered service
fails before sufficient channel capacity is released to wake those
tasks, those tasks are effectively leaked. They will never become ready.

This is because we are no longer using Tokio's bounded MPSC channel, and
are instead implementing our own bounded channel on top of the unbounded
MPSC using a semaphore. While the bounded MPSC sender's `poll_ready`
method would notify waiting tasks when the receiver is dropped, that
method no longer exists in Tokio 0.3, and we have to use an external
semaphore to provide a polling based API for waiting for channel
capacity. The semaphore does not wake pending tasks because it must live
in an `Arc` in order for the `Semaphore::acquire_owned` method to be
useable, and thus it will never be dropped while there are waiting
tasks. Not dropping the semaphore is necessary to uphold the safety
invariants of the intrusive wait list, but it means that the tasks will
not be woken by the semaphore being dropped.

This branch fixes this issue by adding the ability to wake all tasks
waiting on a semaphore by adding close to the maximum allowed number of
permits to it. This _should_ be sufficient to wake all waiters, but it's
a little bit janky. The ideal solution would be for Tokio to expose the
`close` method on the internal semaphore implementation in a public API.
However, this works now without requiring an upstream change.

I've also added tests for this behavior.