### PR TITLE
spawn_ready: put back `poll_closed`

### DIFF
--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -55,13 +55,13 @@ hdrhistogram = { version = "6.0", optional = true }
 indexmap = { version = "1.0.2", optional = true }
 rand = { version = "0.7", features = ["small_rng"], optional = true }
 slab = { version = "0.4", optional = true }
-tokio = { version = "0.3", optional = true, features = ["sync"] }
+tokio = { version = "0.3.2", optional = true, features = ["sync"] }
 
 [dev-dependencies]
 futures-util = { version = "0.3", default-features = false, features = ["alloc", "async-await"] }
 hdrhistogram = "6.0"
 quickcheck = { version = "0.9", default-features = false }
-tokio = { version = "0.3", features = ["macros", "stream", "sync", "test-util", "rt-multi-thread"] }
+tokio = { version = "0.3.2", features = ["macros", "stream", "sync", "test-util", "rt-multi-thread"] }
 tokio-test = "0.3"
 tower-test = { version = "0.4", path = "../tower-test" }
 tracing-subscriber = "0.2.14"

--- a/tower/src/spawn_ready/future.rs
+++ b/tower/src/spawn_ready/future.rs
@@ -53,14 +53,7 @@ where
         // Note that we must actually poll the sender's closed future here,
         // rather than just calling `is_closed` on it, since we want to be
         // notified if the receiver is dropped.
-        let closed = {
-            // TODO(eliza): once `tokio` 0.3.2 is released, we can change this back
-            // to just using `Sender::poll_closed`, which is being re-added.
-            let closed = this.tx.as_mut().expect("illegal state").closed();
-            tokio::pin!(closed);
-            closed.poll(cx)
-        };
-        if let Poll::Ready(_) = closed {
+        if let Poll::Ready(_) = this.tx.as_mut().expect("illegal state").poll_closed(cx) {
             return Poll::Ready(());
         }
 


### PR DESCRIPTION
Tokio put this method back in 0.3.2, so we can use it again.

Closes #478