### PR TITLE
Derive Clone for combinator services

### DIFF
--- a/tower/src/util/map_err.rs
+++ b/tower/src/util/map_err.rs
@@ -6,7 +6,7 @@ use tower_service::Service;
 /// Service returned by the [`map_err`] combinator.
 ///
 /// [`map_err`]: crate::util::ServiceExt::map_err
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MapErr<S, F> {
     inner: S,
     f: F,

--- a/tower/src/util/map_ok.rs
+++ b/tower/src/util/map_ok.rs
@@ -6,7 +6,7 @@ use tower_service::Service;
 /// Service returned by the [`map_ok`] combinator.
 ///
 /// [`map_ok`]: crate::util::ServiceExt::map_ok
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MapOk<S, F> {
     inner: S,
     f: F,

--- a/tower/src/util/try_with.rs
+++ b/tower/src/util/try_with.rs
@@ -6,7 +6,7 @@ use tower_service::Service;
 /// Service returned by the [`try_with`] combinator.
 ///
 /// [`try_with`]: crate::util::ServiceExt::try_with
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct TryWith<S, F> {
     inner: S,
     f: F,

--- a/tower/src/util/with.rs
+++ b/tower/src/util/with.rs
@@ -5,7 +5,7 @@ use tower_service::Service;
 /// Service returned by the [`with`] combinator.
 ///
 /// [`with`]: crate::util::ServiceExt::with
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct With<S, F> {
     inner: S,
     f: F,


### PR DESCRIPTION
Improves ergonomics because many applications require that a service enjoys `Clone`.

The `F` inside of the combinators are intended to be `FnOnce(_) -> _ + Clone`, and so when inner services are `Clone` the combinator service will too.