### PR TITLE
hedge: use auto-resizing histograms

### DIFF
--- a/tower/src/hedge/rotating_histogram.rs
+++ b/tower/src/hedge/rotating_histogram.rs
@@ -19,10 +19,10 @@ pub struct RotatingHistogram {
 impl RotatingHistogram {
     pub fn new(period: Duration) -> RotatingHistogram {
         RotatingHistogram {
-            read: Histogram::<u64>::new_with_bounds(1, 10_000, 3)
-                .expect("Invalid histogram params"),
-            write: Histogram::<u64>::new_with_bounds(1, 10_000, 3)
-                .expect("Invalid histogram params"),
+            // Use an auto-resizing histogram to avoid choosing
+            // a maximum latency bound for all users.
+            read: Histogram::<u64>::new(3).expect("Invalid histogram params"),
+            write: Histogram::<u64>::new(3).expect("Invalid histogram params"),
             last_rotation: Instant::now(),
             period,
         }


### PR DESCRIPTION
The previous code used a fixed-size histogram with an upper bound of 10_000 ms
(10s).  This meant that the `Hedge` middleware would display errors when used
with services that take longer than 10s to complete a response.  Instead, use a
constructor that produces an auto-resizing histogram.  In the future, if the
auto-resizing behavior is an issue, Tower could add a second constructor for
the Hedge middleware that allows specifying bounds, but for now this change is
transparent and avoids spurious errors.