### PR TITLE
Add and_then combinator

### DIFF
--- a/tower/src/util/and_then.rs
+++ b/tower/src/util/and_then.rs
@@ -1,0 +1,81 @@
+use std::marker::PhantomData;
+use std::task::{Context, Poll};
+
+use futures_core::TryFuture;
+use futures_util::{future::AndThen as AndThenFut, TryFutureExt};
+use tower_layer::Layer;
+use tower_service::Service;
+
+/// Service returned by the [`and_then`] combinator.
+///
+/// [`and_then`]: crate::util::ServiceExt::and_then
+#[derive(Clone, Debug)]
+pub struct AndThen<S, F, Fut> {
+    inner: S,
+    f: F,
+    _fut: PhantomData<Fut>,
+}
+
+impl<S, F, Fut> AndThen<S, F, Fut> {
+    /// Creates a new `AndThen` service.
+    pub fn new(inner: S, f: F) -> Self {
+        AndThen {
+            f,
+            inner,
+            _fut: Default::default(),
+        }
+    }
+}
+
+impl<S, F, Request, Fut> Service<Request> for AndThen<S, F, Fut>
+where
+    S: Service<Request>,
+    F: FnOnce(S::Response) -> Fut + Clone,
+    Fut: TryFuture<Error = S::Error>,
+{
+    type Response = Fut::Ok;
+    type Error = Fut::Error;
+    type Future = AndThenFut<S::Future, Fut, F>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        self.inner.call(request).and_then(self.f.clone())
+    }
+}
+
+/// A [`Layer`] that produces a [`AndThen`] service.
+///
+/// [`Layer`]: tower_layer::Layer
+#[derive(Debug)]
+pub struct AndThenLayer<F, Fut> {
+    f: F,
+    _fut: PhantomData<Fut>,
+}
+
+impl<F, Fut> AndThenLayer<F, Fut> {
+    /// Creates a new [`AndThenLayer`] layer.
+    pub fn new(f: F) -> Self {
+        AndThenLayer {
+            f,
+            _fut: Default::default(),
+        }
+    }
+}
+
+impl<S, F, Fut> Layer<S> for AndThenLayer<F, Fut>
+where
+    F: Clone,
+{
+    type Service = AndThen<S, F, Fut>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AndThen {
+            f: self.f.clone(),
+            inner,
+            _fut: Default::default(),
+        }
+    }
+}

--- a/tower/src/util/and_then.rs
+++ b/tower/src/util/and_then.rs
@@ -17,6 +17,14 @@ pub struct AndThen<S, F> {
     f: F,
 }
 
+/// A [`Layer`] that produces a [`AndThen`] service.
+///
+/// [`Layer`]: tower_layer::Layer
+#[derive(Debug)]
+pub struct AndThenLayer<F> {
+    f: F,
+}
+
 impl<S, F> AndThen<S, F> {
     /// Creates a new `AndThen` service.
     pub fn new(inner: S, f: F) -> Self {
@@ -42,14 +50,6 @@ where
     fn call(&mut self, request: Request) -> Self::Future {
         self.inner.call(request).err_into().and_then(self.f.clone())
     }
-}
-
-/// A [`Layer`] that produces a [`AndThen`] service.
-///
-/// [`Layer`]: tower_layer::Layer
-#[derive(Debug)]
-pub struct AndThenLayer<F> {
-    f: F,
 }
 
 impl<F> AndThenLayer<F> {

--- a/tower/src/util/and_then.rs
+++ b/tower/src/util/and_then.rs
@@ -24,16 +24,16 @@ impl<S, F> AndThen<S, F> {
     }
 }
 
-impl<S, F, Request, Error, Fut> Service<Request> for AndThen<S, F>
+impl<S, F, Request, Fut> Service<Request> for AndThen<S, F>
 where
     S: Service<Request>,
-    S::Error: Into<Error>,
+    S::Error: Into<Fut::Error>,
     F: FnOnce(S::Response) -> Fut + Clone,
-    Fut: TryFuture<Error = Error>,
+    Fut: TryFuture,
 {
     type Response = Fut::Ok;
-    type Error = Error;
-    type Future = AndThenFut<ErrIntoFut<S::Future, Error>, Fut, F>;
+    type Error = Fut::Error;
+    type Future = AndThenFut<ErrIntoFut<S::Future, Fut::Error>, Fut, F>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx).map_err(Into::into)

--- a/tower/src/util/and_then.rs
+++ b/tower/src/util/and_then.rs
@@ -1,4 +1,3 @@
-use std::marker::PhantomData;
 use std::task::{Context, Poll};
 
 use futures_core::TryFuture;
@@ -10,24 +9,19 @@ use tower_service::Service;
 ///
 /// [`and_then`]: crate::util::ServiceExt::and_then
 #[derive(Clone, Debug)]
-pub struct AndThen<S, F, Fut> {
+pub struct AndThen<S, F> {
     inner: S,
     f: F,
-    _fut: PhantomData<Fut>,
 }
 
-impl<S, F, Fut> AndThen<S, F, Fut> {
+impl<S, F> AndThen<S, F> {
     /// Creates a new `AndThen` service.
     pub fn new(inner: S, f: F) -> Self {
-        AndThen {
-            f,
-            inner,
-            _fut: Default::default(),
-        }
+        AndThen { f, inner }
     }
 }
 
-impl<S, F, Request, Fut> Service<Request> for AndThen<S, F, Fut>
+impl<S, F, Request, Fut> Service<Request> for AndThen<S, F>
 where
     S: Service<Request>,
     F: FnOnce(S::Response) -> Fut + Clone,
@@ -50,32 +44,27 @@ where
 ///
 /// [`Layer`]: tower_layer::Layer
 #[derive(Debug)]
-pub struct AndThenLayer<F, Fut> {
+pub struct AndThenLayer<F> {
     f: F,
-    _fut: PhantomData<Fut>,
 }
 
-impl<F, Fut> AndThenLayer<F, Fut> {
+impl<F> AndThenLayer<F> {
     /// Creates a new [`AndThenLayer`] layer.
     pub fn new(f: F) -> Self {
-        AndThenLayer {
-            f,
-            _fut: Default::default(),
-        }
+        AndThenLayer { f }
     }
 }
 
-impl<S, F, Fut> Layer<S> for AndThenLayer<F, Fut>
+impl<S, F> Layer<S> for AndThenLayer<F>
 where
     F: Clone,
 {
-    type Service = AndThen<S, F, Fut>;
+    type Service = AndThen<S, F>;
 
     fn layer(&self, inner: S) -> Self::Service {
         AndThen {
             f: self.f.clone(),
             inner,
-            _fut: Default::default(),
         }
     }
 }

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -1,5 +1,6 @@
 //! Various utility types and functions that are generally with Tower.
 
+mod and_then;
 mod boxed;
 mod call_all;
 mod either;
@@ -17,6 +18,7 @@ mod service_fn;
 mod then;
 
 pub use self::{
+    and_then::{AndThen, AndThenLayer},
     boxed::{BoxService, UnsyncBoxService},
     either::Either,
     future_service::{future_service, FutureService},
@@ -88,6 +90,13 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
         S: futures_core::Stream<Item = Request>,
     {
         CallAll::new(self, reqs)
+    }
+    
+    fn and_then<F, Fut>(self, f: F) -> AndThen<Self, F, Fut>
+    where
+    Self: Sized,
+        F: FnOnce(Self::Response) -> Fut + Clone {
+            AndThen::new(self, f)
     }
 
     /// Maps this service's response value to a different value. This does not

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -91,12 +91,13 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     {
         CallAll::new(self, reqs)
     }
-    
-    fn and_then<F, Fut>(self, f: F) -> AndThen<Self, F, Fut>
+
+    fn and_then<F>(self, f: F) -> AndThen<Self, F>
     where
-    Self: Sized,
-        F: FnOnce(Self::Response) -> Fut + Clone {
-            AndThen::new(self, f)
+        Self: Sized,
+        F: Clone,
+    {
+        AndThen::new(self, f)
     }
 
     /// Maps this service's response value to a different value. This does not

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -45,6 +45,7 @@ pub mod error {
 pub mod future {
     //! Future types
 
+    pub use super::and_then::AndThenFuture;
     pub use super::map_err::MapErrFuture;
     pub use super::map_response::MapResponseFuture;
     pub use super::map_result::MapResultFuture;


### PR DESCRIPTION
**Motivation**
https://docs.rs/futures/0.3.8/futures/future/trait.TryFutureExt.html#method.and_then is a useful method on futures. Perhaps it'd be nice to replicate this for the `ServiceExt` API.

**TODO**
- [x] Documentation
- [ ] Are the generics sane?