### PR TITLE
ci: install `cargo hack` from GitHub release binary

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,28 +25,7 @@ jobs:
         command: check
         args: --all --all-targets --all-features
 
-  cache-cargo-hack:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Fetch latest release version of cargo-hack
-      run: |
-        mkdir -p .github/caching
-        curl -sL https://api.github.com/repos/taiki-e/cargo-hack/releases/latest | jq -r '.name' > .github/caching/cargo-hack.lock
-    - name: Cache cargo-hack/bin
-      id: cache-cargo-hack
-      uses: actions/cache@v1
-      with:
-        path: ${{ runner.tool_cache }}/cargo-hack/bin
-        key: cargo-hack-bin-${{ hashFiles('.github/caching/cargo-hack.lock') }}
-    - name: Install cargo-hack
-      if: "steps.cache-cargo-hack.outputs.cache-hit != 'true'"
-      uses: actions-rs/cargo@v1
-      with:
-        command: install
-        args: --root ${{ runner.tool_cache }}/cargo-hack --force cargo-hack
-
   cargo-hack:
-    needs: cache-cargo-hack
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
@@ -54,19 +33,9 @@ jobs:
       with:
         toolchain: stable
         profile: minimal
-    - name: Fetch latest release version of cargo-hack
+    - name: Install cargo-hack
       run: |
-        mkdir -p .github/caching
-        curl -sL https://api.github.com/repos/taiki-e/cargo-hack/releases/latest | jq -r '.name' > .github/caching/cargo-hack.lock
-    - name: Restore cargo-hack/bin
-      uses: actions/cache@v1
-      with:
-        path: ${{ runner.tool_cache }}/cargo-hack/bin
-        key: cargo-hack-bin-${{ hashFiles('.github/caching/cargo-hack.lock') }}
-    - run: echo "::add-path::${{ runner.tool_cache }}/cargo-hack/bin"
-    # if `cargo-hack` somehow doesn't exist after loading it from the cache,
-    # make *sure* it's there.
-    - run: cargo hack --help || { cargo install --force cargo-hack; }
+        curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
     - name: cargo hack check
       working-directory: ${{ matrix.subcrate }}
       run: cargo hack check --each-feature --no-dev-deps --all


### PR DESCRIPTION
CI is currently busted due to [issues with caching `cargo-hack`][1].
Currently, we cache the `cargo-hack` executable to speed up builds by
avoiding the overhead of compiling it from source in every build.

Recently, `cargo-hack` has started publishing binaries on GitHub
Releases. Rather than compiling it on CI and caching it, we can just
download the binary instead. This ought to fix the build.

See also taiki-e/cargo-hack#89 and taiki-e/cargo-hack#91.

[1]: https://github.com/tower-rs/tower/runs/1425940763