### PR TITLE
layer: fix+improve doc links

### DIFF
--- a/tower-layer/src/lib.rs
+++ b/tower-layer/src/lib.rs
@@ -12,6 +12,8 @@
 //! allows other services to be composed with the service that implements layer.
 //!
 //! A middleware implements the [`Layer`] and [`Service`] trait.
+//!
+//! [`Service`]: ../tower/trait.Service.html
 
 mod identity;
 mod stack;

--- a/tower-layer/src/lib.rs
+++ b/tower-layer/src/lib.rs
@@ -20,7 +20,7 @@ mod stack;
 
 pub use self::{identity::Identity, stack::Stack};
 
-/// Decorates a `Service`, transforming either the request or the response.
+/// Decorates a [`Service`], transforming either the request or the response.
 ///
 /// Often, many of the pieces needed for writing network applications can be
 /// reused across multiple services. The `Layer` trait can be used to write
@@ -83,6 +83,8 @@ pub use self::{identity::Identity, stack::Stack};
 /// The above log implementation is decoupled from the underlying protocol and
 /// is also decoupled from client or server concerns. In other words, the same
 /// log middleware could be used in either a client or a server.
+///
+/// [`Service`]: ../tower/trait.Service.html
 pub trait Layer<S> {
     /// The wrapped service
     type Service;


### PR DESCRIPTION
- Fixes a link to the `Service` trait on the `tower_layer` module page. ([current page](https://docs.rs/tower-layer/0.3.0/tower_layer/index.html))
- Adds a link to `Service` on the `Layer` trait page. ([current page](https://docs.rs/tower-layer/0.3.0/tower_layer/trait.Layer.html))

These changes use old style links - intra-rustdoc links won't work here because `tower`/`tower_service` aren't referenced by this crate.