### PR TITLE
start working on panic propagation

### DIFF
--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -24,7 +24,7 @@ keywords = ["io", "async", "non-blocking", "futures", "service"]
 edition = "2018"
 
 [features]
-default = ["log", "buffer"]
+default = ["log"]
 log = ["tracing/log"]
 balance = ["discover", "load", "ready-cache", "make", "rand", "slab", "tokio/stream"]
 buffer = ["tokio/sync", "tokio/rt", "tokio/stream"]

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -24,7 +24,7 @@ keywords = ["io", "async", "non-blocking", "futures", "service"]
 edition = "2018"
 
 [features]
-default = ["log"]
+default = ["log", "buffer"]
 log = ["tracing/log"]
 balance = ["discover", "load", "ready-cache", "make", "rand", "slab", "tokio/stream"]
 buffer = ["tokio/sync", "tokio/rt", "tokio/stream"]


### PR DESCRIPTION
This is an extremely rough sketch ATM but I'm starting to work on the panic propagation issue https://github.com/tower-rs/tower/issues/455.

Right now I'm pretty unhappy with the initial approach and am re-evaluating. Also, I ran into a lot of compiler errors just working with the `master` copy of tower and I'm unsure whether that was my fault or if the same problem would occur in CI, so I decided I'd open the PR now so I could get feedback and see how the CI goes.

The things that are currently frustrating:

* cannot clone a `JoinHandle`
* cannot propagate panics when worker is spawned via `pair`

Part of me wonders if the worker itself should be catching panics and propagating it through its own `Handle` type.