### PR TITLE
Add `MakeService::into_service` and `MakeService::as_service`

### DIFF
--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
-- Added `MakeService::into_service` for converting owned `MakeService`s into `Service`s.
+- Added `MakeService::into_service` and `MakeService::as_service` for
+  converting `MakeService`s into `Service`s.
 
 ### Changed
 

--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
+- Added `MakeService::into_service` for converting owned `MakeService`s into `Service`s.
+
 ### Changed
 
  - All middleware `tower-*` crates were merged into `tower` and placed

--- a/tower/src/make/make_connection.rs
+++ b/tower/src/make/make_connection.rs
@@ -4,7 +4,7 @@ use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tower_service::Service;
 
-/// The MakeConnection trait is used to create transports.
+/// The `MakeConnection` trait is used to create transports.
 ///
 /// The goal of this service is to allow composable methods for creating
 /// `AsyncRead + AsyncWrite` transports. This could mean creating a TLS

--- a/tower/src/make/make_service.rs
+++ b/tower/src/make/make_service.rs
@@ -1,4 +1,5 @@
 use crate::sealed::Sealed;
+use std::fmt;
 use std::future::Future;
 use std::marker::PhantomData;
 use std::task::{Context, Poll};
@@ -148,15 +149,37 @@ where
     }
 }
 
-/// Service returned by [`MakeService::into_service`][into]. 
-/// 
+/// Service returned by [`MakeService::into_service`][into].
+///
 /// See the documentation on [`into_service`][into] for details.
 ///
 /// [into]: MakeService::into_service
-#[derive(Debug, Clone)]
 pub struct IntoService<M, Request> {
     make: M,
     _marker: PhantomData<Request>,
+}
+
+impl<M, Request> Clone for IntoService<M, Request>
+where
+    M: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            make: self.make.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<M, Request> fmt::Debug for IntoService<M, Request>
+where
+    M: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IntoService")
+            .field("make", &self.make)
+            .finish()
+    }
 }
 
 impl<M, S, Target, Request> Service<Target> for IntoService<M, Request>
@@ -177,15 +200,25 @@ where
     }
 }
 
-/// Service returned by [`MakeService::as_service`][as]. 
-/// 
+/// Service returned by [`MakeService::as_service`][as].
+///
 /// See the documentation on [`as_service`][as] for details.
 ///
 /// [as]: MakeService::as_service
-#[derive(Debug)]
 pub struct AsService<'a, M, Request> {
     make: &'a mut M,
     _marker: PhantomData<Request>,
+}
+
+impl<M, Request> fmt::Debug for AsService<'_, M, Request>
+where
+    M: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AsService")
+            .field("make", &self.make)
+            .finish()
+    }
 }
 
 impl<M, S, Target, Request> Service<Target> for AsService<'_, M, Request>

--- a/tower/src/make/make_service.rs
+++ b/tower/src/make/make_service.rs
@@ -1,3 +1,5 @@
+//! Contains `MakeService` which is a trait alias for a `Service` of `Service`s.
+
 use crate::sealed::Sealed;
 use std::fmt;
 use std::future::Future;

--- a/tower/src/make/make_service.rs
+++ b/tower/src/make/make_service.rs
@@ -148,6 +148,11 @@ where
     }
 }
 
+/// Service returned by [`MakeService::into_service`][into]. 
+/// 
+/// See the documentation on [`into_service`][into] for details.
+///
+/// [into]: MakeService::into_service
 #[derive(Debug, Clone)]
 pub struct IntoService<M, Request> {
     make: M,
@@ -172,6 +177,11 @@ where
     }
 }
 
+/// Service returned by [`MakeService::as_service`][as]. 
+/// 
+/// See the documentation on [`as_service`][as] for details.
+///
+/// [as]: MakeService::as_service
 #[derive(Debug)]
 pub struct AsService<'a, M, Request> {
     make: &'a mut M,

--- a/tower/src/make/make_service.rs
+++ b/tower/src/make/make_service.rs
@@ -191,10 +191,12 @@ where
     type Error = M::Error;
     type Future = M::Future;
 
+    #[inline]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.make.poll_ready(cx)
     }
 
+    #[inline]
     fn call(&mut self, target: Target) -> Self::Future {
         self.make.make_service(target)
     }
@@ -230,10 +232,12 @@ where
     type Error = M::Error;
     type Future = M::Future;
 
+    #[inline]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.make.poll_ready(cx)
     }
 
+    #[inline]
     fn call(&mut self, target: Target) -> Self::Future {
         self.make.make_service(target)
     }

--- a/tower/src/make/mod.rs
+++ b/tower/src/make/mod.rs
@@ -5,4 +5,4 @@ mod make_connection;
 mod make_service;
 
 pub use self::make_connection::MakeConnection;
-pub use self::make_service::{MakeService, AsService, IntoService};
+pub use self::make_service::{AsService, IntoService, MakeService};

--- a/tower/src/make/mod.rs
+++ b/tower/src/make/mod.rs
@@ -2,8 +2,7 @@
 
 mod make_connection;
 
-pub mod make_service;
+mod make_service;
 
 pub use self::make_connection::MakeConnection;
-#[doc(inline)]
-pub use self::make_service::MakeService;
+pub use self::make_service::{MakeService, AsService, IntoService};

--- a/tower/src/make/mod.rs
+++ b/tower/src/make/mod.rs
@@ -1,7 +1,9 @@
 //! Trait aliases for Services that produce specific types of Responses.
 
 mod make_connection;
-mod make_service;
+
+pub mod make_service;
 
 pub use self::make_connection::MakeConnection;
+#[doc(inline)]
 pub use self::make_service::MakeService;


### PR DESCRIPTION
Resolves https://github.com/tower-rs/tower/issues/253

Adds `MakeService::into_service` and `MakeService::as_service` which converts `MakeService`s into `Service`s. `into_service` consumes `self` and `as_service` borrows `self` mutably.