### PR TITLE
buffer: Add Clone + Copy impls for BufferLayer

### DIFF
--- a/tower/src/buffer/layer.rs
+++ b/tower/src/buffer/layer.rs
@@ -58,3 +58,14 @@ impl<Request> fmt::Debug for BufferLayer<Request> {
             .finish()
     }
 }
+
+impl<Request> Clone for BufferLayer<Request> {
+    fn clone(&self) -> Self {
+        Self {
+            bound: self.bound,
+            _p: self._p,
+        }
+    }
+}
+
+impl<Request> Copy for BufferLayer<Request> {}


### PR DESCRIPTION
It's generally the case that layers need to be shareable. There's no
reason that `BufferLayer` should not implement both `Clone` and `Copy`.

This change adds manual `Clone` and `Copy` implementations for
`BufferLayer`.