### PR TITLE
layer: Add a layer_fn helper

### DIFF
--- a/tower-layer/src/layer_fn.rs
+++ b/tower-layer/src/layer_fn.rs
@@ -1,0 +1,24 @@
+use crate::Layer;
+
+/// Makes an anonymous `Layer` from a closure.
+pub fn layer_fn<S, T, F>(f: F) -> impl Layer<S, Service = T> + Clone
+where
+    F: Fn(S) -> T,
+    F: Clone,
+{
+    LayerFn(f)
+}
+
+#[derive(Clone)]
+struct LayerFn<F>(F);
+
+impl<F, S, T> Layer<S> for LayerFn<F>
+where
+    F: Fn(S) -> T,
+{
+    type Service = T;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        (self.0)(inner)
+    }
+}

--- a/tower-layer/src/lib.rs
+++ b/tower-layer/src/lib.rs
@@ -14,9 +14,10 @@
 //! A middleware implements the [`Layer`] and [`Service`] trait.
 
 mod identity;
+mod layer_fn;
 mod stack;
 
-pub use self::{identity::Identity, stack::Stack};
+pub use self::{identity::Identity, layer_fn::layer_fn, stack::Stack};
 
 /// Decorates a `Service`, transforming either the request or the response.
 ///

--- a/tower/src/layer.rs
+++ b/tower/src/layer.rs
@@ -4,5 +4,5 @@ pub use tower_layer::Layer;
 
 /// `util` exports an Identity Layer and Chain, a mechanism for chaining them.
 pub mod util {
-    pub use tower_layer::{Identity, Stack};
+    pub use tower_layer::{layer_fn, Identity, Stack};
 }


### PR DESCRIPTION
It's frequently unnecessary to create concrete types for all layer
implementations.

This change adds a `layer_fn` helper, like `service_fn`, that supports
creating layer implementations from a simple `Fn`.

This is adapted from a utility that we use heavily in the `linkerd2-proxy`
repo.