### PR TITLE
Add `Pending` which impls `Service` for `Future<Output = impl Service>`

### DIFF
--- a/tower/src/util/future_service.rs
+++ b/tower/src/util/future_service.rs
@@ -19,12 +19,19 @@ use tower_service::Service;
 ///
 /// # fn main() {
 /// # async {
-/// let mut future_of_a_service = future_service(Box::pin(async {
+/// // A future which outputs a type implementing `Service`.
+/// let future_of_a_service = async {
 ///     let svc = service_fn(|_req: ()| async { Ok::<_, Infallible>("ok") });
 ///     Ok::<_, Infallible>(svc)
-/// }));
+/// };
 ///
-/// let svc = future_of_a_service.ready_and().await.unwrap();
+/// // Wrap the future with a `FutureService`, allowing it to be used
+/// // as a service without awaiting the future's completion:
+/// let mut svc = future_service(Box::pin(future_of_a_service));
+///
+/// // Now, when we wait for the service to become ready, it will
+/// // drive the future to completion internally.
+/// let svc = svc.ready_and().await.unwrap();
 /// let res = svc.call(()).await.unwrap();
 /// # };
 /// # }

--- a/tower/src/util/future_service.rs
+++ b/tower/src/util/future_service.rs
@@ -8,6 +8,9 @@ use tower_service::Service;
 
 /// Returns a new `FutureService` for the given future.
 ///
+/// A `FutureService` allows you to treat a future that resolves to a service as a service. This
+/// can be useful for services that are created asynchronously.
+///
 /// # Example
 /// ```
 /// use tower::{service_fn, Service, ServiceExt};
@@ -46,6 +49,8 @@ where
 }
 
 /// A type that implements `Service` for a `Future` that produces a `Service`.
+///
+/// See `future_service` for more details.
 #[derive(Clone)]
 pub struct FutureService<F, S> {
     inner: State<F, S>,

--- a/tower/src/util/future_service.rs
+++ b/tower/src/util/future_service.rs
@@ -26,6 +26,15 @@ use tower_service::Service;
 /// # };
 /// # }
 /// ```
+///
+/// # Regarding the `Unpin` bound
+///
+/// The `Unpin` bound on `F` is necessary because the future will be polled in
+/// `Service::poll_ready` which doesn't have a pinned receiver (it takes `&mut self` and not `self:
+/// Pin<&mut Self>`). So we cannot put the future into a `Pin` without requiring `Unpin`.
+///
+/// This will most likely come up if you're calling `future_service` with an async block. In that
+/// case you can use `Box::pin(async { ... })` as shown in the example.
 pub fn future_service<F, S, R, E>(future: F) -> FutureService<F, S>
 where
     F: Future<Output = Result<S, E>> + Unpin,

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -3,12 +3,12 @@
 mod boxed;
 mod call_all;
 mod either;
+mod future_service;
 mod map;
 mod map_err;
 mod map_ok;
 mod oneshot;
 mod optional;
-mod pending;
 mod ready;
 mod service_fn;
 mod try_with;
@@ -17,12 +17,12 @@ mod with;
 pub use self::{
     boxed::{BoxService, UnsyncBoxService},
     either::Either,
+    future_service::{future_service, FutureService},
     map::{MapRequest, MapRequestLayer, MapResponse, MapResponseLayer},
     map_err::{MapErr, MapErrLayer},
     map_ok::{MapOk, MapOkLayer},
     oneshot::Oneshot,
     optional::Optional,
-    pending::{pending, Pending},
     ready::{Ready, ReadyAnd, ReadyOneshot},
     service_fn::{service_fn, ServiceFn},
     try_with::{TryWith, TryWithLayer},

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -8,6 +8,7 @@ mod map_err;
 mod map_ok;
 mod oneshot;
 mod optional;
+mod pending;
 mod ready;
 mod service_fn;
 mod try_with;
@@ -21,6 +22,7 @@ pub use self::{
     map_ok::{MapOk, MapOkLayer},
     oneshot::Oneshot,
     optional::Optional,
+    pending::{pending, Pending},
     ready::{Ready, ReadyAnd, ReadyOneshot},
     service_fn::{service_fn, ServiceFn},
     try_with::{TryWith, TryWithLayer},

--- a/tower/src/util/pending.rs
+++ b/tower/src/util/pending.rs
@@ -1,0 +1,141 @@
+use std::fmt;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower_service::Service;
+
+/// Returns a new `Pending` for the given future.
+///
+/// # Example
+/// ```
+/// use tower::{service_fn, Service, ServiceExt};
+/// use tower::util::pending;
+/// use std::convert::Infallible;
+///
+/// # fn main() {
+/// # async {
+/// let mut pending_svc = pending(Box::pin(async {
+///     let svc = service_fn(|_req: ()| async { Ok::<_, Infallible>("ok") });
+///     Ok::<_, Infallible>(svc)
+/// }));
+///
+/// let svc = pending_svc.ready_and().await.unwrap();
+/// let res = svc.call(()).await.unwrap();
+/// # };
+/// # }
+/// ```
+pub fn pending<F, S, R, E>(future: F) -> Pending<F, S>
+where
+    F: Future<Output = Result<S, E>> + Unpin,
+    S: Service<R, Error = E>,
+{
+    Pending {
+        inner: Inner::Future(future),
+    }
+}
+
+/// A type that implements `Service` for a `Future` that produces a `Service`.
+#[derive(Clone)]
+pub struct Pending<F, S> {
+    inner: Inner<F, S>,
+}
+
+impl<F, S> fmt::Debug for Pending<F, S>
+where
+    S: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[derive(Debug)]
+        struct Pending;
+
+        let mut f = f.debug_struct("Pending");
+        let f = match &self.inner {
+            Inner::Future(_) => f.field("service", &Pending),
+            Inner::Service(svc) => f.field("service", svc),
+        };
+        f.finish()
+    }
+}
+
+#[derive(Clone)]
+enum Inner<F, S> {
+    Future(F),
+    Service(S),
+}
+
+impl<F, S, R, E> Service<R> for Pending<F, S>
+where
+    F: Future<Output = Result<S, E>> + Unpin,
+    S: Service<R, Error = E>,
+{
+    type Response = S::Response;
+    type Error = E;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        loop {
+            self.inner = match &mut self.inner {
+                Inner::Future(fut) => {
+                    let fut = Pin::new(fut);
+                    let svc = match fut.poll(cx) {
+                        Poll::Ready(Ok(svc)) => svc,
+                        Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                        Poll::Pending => return Poll::Pending,
+                    };
+                    Inner::Service(svc)
+                }
+                Inner::Service(svc) => return svc.poll_ready(cx),
+            };
+        }
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
+        if let Inner::Service(svc) = &mut self.inner {
+            svc.call(req)
+        } else {
+            panic!("Pending::call was called before Pending::poll_ready")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::{pending, ServiceExt};
+    use crate::Service;
+    use futures::future::{ready, Ready};
+    use std::convert::Infallible;
+
+    #[tokio::test]
+    async fn pending_service_debug_impl() {
+        let mut pending_svc = pending(ready(Ok(DebugService)));
+
+        assert_eq!(format!("{:?}", pending_svc), "Pending { service: Pending }");
+
+        pending_svc.ready_and().await.unwrap();
+
+        assert_eq!(
+            format!("{:?}", pending_svc),
+            "Pending { service: DebugService }"
+        );
+    }
+
+    #[derive(Debug)]
+    struct DebugService;
+
+    impl Service<()> for DebugService {
+        type Response = ();
+        type Error = Infallible;
+        type Future = Ready<Result<Self::Response, Self::Error>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Ok(()).into()
+        }
+
+        fn call(&mut self, _req: ()) -> Self::Future {
+            ready(Ok(()))
+        }
+    }
+}

--- a/tower/src/util/pending.rs
+++ b/tower/src/util/pending.rs
@@ -79,11 +79,7 @@ where
             self.inner = match &mut self.inner {
                 Inner::Future(fut) => {
                     let fut = Pin::new(fut);
-                    let svc = match fut.poll(cx) {
-                        Poll::Ready(Ok(svc)) => svc,
-                        Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-                        Poll::Pending => return Poll::Pending,
-                    };
+                    let svc = futures_core::ready!(fut.poll(cx)?);
                     Inner::Service(svc)
                 }
                 Inner::Service(svc) => return svc.poll_ready(cx),


### PR DESCRIPTION
Resolves https://github.com/tower-rs/tower/issues/264#issuecomment-751400523

Based on https://github.com/linkerd/linkerd2-proxy/blob/1be301f2b0605367be733b4cd96de88108b8889b/linkerd/stack/src/future_service.rs

I thought `Pending` was a better name than `FutureService` but thats up for bike shedding ofc.

Also thought it would be nice to avoid the `Unpin` bound but not sure there is a way around that without always using `Box::pin` or using unsafe.