### PR TITLE
balance: Remove MakeBalance::from_rng

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 tower = { version = "0.4", path = "../tower", features = ["full"] }
 tower-service = "0.3" 
 tokio = { version = "0.3", features = ["full"] }
-rand = "0.7"
+rand = "0.8"
 pin-project = "1.0"
 futures = "0.3"
 tracing = "0.1"

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -53,7 +53,7 @@ tracing = "0.1.2"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
 hdrhistogram = { version = "6.0", optional = true }
 indexmap = { version = "1.0.2", optional = true }
-rand = { version = "0.7", features = ["small_rng"], optional = true }
+rand = { version = "0.8", features = ["small_rng"], optional = true }
 slab = { version = "0.4", optional = true }
 tokio = { version = "1", optional = true, features = ["sync"] }
 tokio-stream = { version = "0.1.0", optional = true }

--- a/tower/examples/tower-balance.rs
+++ b/tower/examples/tower-balance.rs
@@ -113,7 +113,8 @@ fn gen_disco() -> impl Discover<
                 let svc = tower::service_fn(move |_| {
                     let start = Instant::now();
 
-                    let maxms = latency.as_millis();
+                    let maxms = u64::from(latency.subsec_nanos() / 1_000 / 1_000)
+                        .saturating_add(latency.as_secs().saturating_mul(1_000));
                     let latency = Duration::from_millis(rand::thread_rng().gen_range(0..maxms));
 
                     async move {

--- a/tower/examples/tower-balance.rs
+++ b/tower/examples/tower-balance.rs
@@ -113,9 +113,18 @@ fn gen_disco() -> impl Discover<
                 let svc = tower::service_fn(move |_| {
                     let start = Instant::now();
 
+<<<<<<< HEAD
                     let maxms = u64::from(latency.subsec_nanos() / 1_000 / 1_000)
                         .saturating_add(latency.as_secs().saturating_mul(1_000));
                     let latency = Duration::from_millis(rand::thread_rng().gen_range(0..maxms));
+||||||| parent of c1418ac... fixup gen_range
+                    let maxms = u64::from(latency.subsec_nanos() / 1_000 / 1_000)
+                        .saturating_add(latency.as_secs().saturating_mul(1_000));
+                    let latency = Duration::from_millis(rand::thread_rng().gen_range(0, maxms));
+=======
+                    let maxms = latency.as_millis();
+                    let latency = Duration::from_millis(rand::thread_rng().gen_range(0..maxms));
+>>>>>>> c1418ac... fixup gen_range
 
                     async move {
                         time::sleep_until(start + latency).await;

--- a/tower/examples/tower-balance.rs
+++ b/tower/examples/tower-balance.rs
@@ -113,18 +113,8 @@ fn gen_disco() -> impl Discover<
                 let svc = tower::service_fn(move |_| {
                     let start = Instant::now();
 
-<<<<<<< HEAD
-                    let maxms = u64::from(latency.subsec_nanos() / 1_000 / 1_000)
-                        .saturating_add(latency.as_secs().saturating_mul(1_000));
-                    let latency = Duration::from_millis(rand::thread_rng().gen_range(0..maxms));
-||||||| parent of c1418ac... fixup gen_range
-                    let maxms = u64::from(latency.subsec_nanos() / 1_000 / 1_000)
-                        .saturating_add(latency.as_secs().saturating_mul(1_000));
-                    let latency = Duration::from_millis(rand::thread_rng().gen_range(0, maxms));
-=======
                     let maxms = latency.as_millis();
                     let latency = Duration::from_millis(rand::thread_rng().gen_range(0..maxms));
->>>>>>> c1418ac... fixup gen_range
 
                     async move {
                         time::sleep_until(start + latency).await;

--- a/tower/examples/tower-balance.rs
+++ b/tower/examples/tower-balance.rs
@@ -115,7 +115,7 @@ fn gen_disco() -> impl Discover<
 
                     let maxms = u64::from(latency.subsec_nanos() / 1_000 / 1_000)
                         .saturating_add(latency.as_secs().saturating_mul(1_000));
-                    let latency = Duration::from_millis(rand::thread_rng().gen_range(0, maxms));
+                    let latency = Duration::from_millis(rand::thread_rng().gen_range(0..maxms));
 
                     async move {
                         time::sleep_until(start + latency).await;

--- a/tower/src/balance/p2c/service.rs
+++ b/tower/src/balance/p2c/service.rs
@@ -87,14 +87,7 @@ where
 {
     /// Constructs a load balancer that uses operating system entropy.
     pub fn new(discover: D) -> Self {
-        Self {
-            rng: SmallRng::from_entropy(),
-            discover,
-            services: ReadyCache::default(),
-            ready_index: None,
-
-            _req: PhantomData,
-        }
+        Self::from_rng(discover, &mut rand::thread_rng()).expect("ThreadRNG must be valid")
     }
 
     /// Constructs a load balancer seeded with the provided random number generator.


### PR DESCRIPTION
`MakeBalance`'s use of `SmallRng` is problematic: since it clones the
`SmallRng` between `Balance` instances, each instance will have the same
state and produce an identical sequence of values. This probably isn't
_dangerous_, though it is certainly unexpected.

This change removes the `MakeBalance::from_rng` and
`MakeBalanceLayer::from_rng` helpers. The `MakeBalance` service now uses
the default RNG via `Balance::new`. `Balance::new` now creates its
`SmallRng` from the `thread_rng` instead of the default entropy source,
as the default entropy source may use the slower `getrandom`. From the
[`rand` docs][from_entropy]:

> In case the overhead of using getrandom to seed many PRNGs is an
> issue, one may prefer to seed from a local PRNG, e.g.
> from_rng(thread_rng()).unwrap().

Finally, this change updates the balancer to the most recent version of
`rand`, v0.8.0.

This seems like a change we should make before the next release/version
bump of `tower`.

[from_entropy]: https://docs.rs/rand/0.8.0/rand/trait.SeedableRng.html#method.from_entropy