### PR TITLE
util: Add BoxService layer helpers

### DIFF
--- a/tower/src/util/boxed/sync.rs
+++ b/tower/src/util/boxed/sync.rs
@@ -42,7 +42,7 @@ impl<T, U, E> BoxService<T, U, E> {
     }
 
     /// Returns a [`Layer`] for wrapping a [`Service`] in a `BoxService` middleware.
-    pub fn layer<S>() -> impl Layer<S, Service = Self> + Clone
+    pub fn layer<S>() -> LayerFn<fn(S) -> Self>
     where
         S: Service<T, Response = U, Error = E> + Send + 'static,
         S::Future: Send + 'static,

--- a/tower/src/util/boxed/sync.rs
+++ b/tower/src/util/boxed/sync.rs
@@ -1,3 +1,4 @@
+use tower_layer::{layer_fn, Layer};
 use tower_service::Service;
 
 use std::fmt;
@@ -38,6 +39,15 @@ impl<T, U, E> BoxService<T, U, E> {
     {
         let inner = Box::new(Boxed { inner });
         BoxService { inner }
+    }
+
+    #[allow(missing_docs)]
+    pub fn layer<S>() -> impl Layer<S, Service = Self> + Clone
+    where
+        S: Service<T, Response = U, Error = E> + Send + 'static,
+        S::Future: Send + 'static,
+    {
+        layer_fn(Self::new)
     }
 }
 

--- a/tower/src/util/boxed/sync.rs
+++ b/tower/src/util/boxed/sync.rs
@@ -1,4 +1,4 @@
-use tower_layer::{layer_fn, Layer};
+use tower_layer::{layer_fn, LayerFn};
 use tower_service::Service;
 
 use std::fmt;

--- a/tower/src/util/boxed/sync.rs
+++ b/tower/src/util/boxed/sync.rs
@@ -41,7 +41,7 @@ impl<T, U, E> BoxService<T, U, E> {
         BoxService { inner }
     }
 
-    #[allow(missing_docs)]
+    /// Returns a [`Layer`] for wrapping a [`Service`] in a `BoxService` middleware.
     pub fn layer<S>() -> impl Layer<S, Service = Self> + Clone
     where
         S: Service<T, Response = U, Error = E> + Send + 'static,

--- a/tower/src/util/boxed/unsync.rs
+++ b/tower/src/util/boxed/unsync.rs
@@ -35,7 +35,7 @@ impl<T, U, E> UnsyncBoxService<T, U, E> {
         UnsyncBoxService { inner }
     }
 
-    #[allow(missing_docs)]
+    /// Returns a [`Layer`] for wrapping a [`Service`] in an `UnsyncBoxService` middleware.
     pub fn layer<S>() -> impl Layer<S, Service = Self> + Clone
     where
         S: Service<T, Response = U, Error = E> + 'static,

--- a/tower/src/util/boxed/unsync.rs
+++ b/tower/src/util/boxed/unsync.rs
@@ -1,3 +1,4 @@
+use tower_layer::{layer_fn, Layer};
 use tower_service::Service;
 
 use std::fmt;

--- a/tower/src/util/boxed/unsync.rs
+++ b/tower/src/util/boxed/unsync.rs
@@ -1,4 +1,4 @@
-use tower_layer::{layer_fn, Layer};
+use tower_layer::{layer_fn, LayerFn};
 use tower_service::Service;
 
 use std::fmt;

--- a/tower/src/util/boxed/unsync.rs
+++ b/tower/src/util/boxed/unsync.rs
@@ -36,7 +36,7 @@ impl<T, U, E> UnsyncBoxService<T, U, E> {
     }
 
     /// Returns a [`Layer`] for wrapping a [`Service`] in an `UnsyncBoxService` middleware.
-    pub fn layer<S>() -> impl Layer<S, Service = Self> + Clone
+    pub fn layer<S>() -> LayerFn<fn(S) -> Self>
     where
         S: Service<T, Response = U, Error = E> + 'static,
         S::Future: 'static,

--- a/tower/src/util/boxed/unsync.rs
+++ b/tower/src/util/boxed/unsync.rs
@@ -33,6 +33,15 @@ impl<T, U, E> UnsyncBoxService<T, U, E> {
         let inner = Box::new(UnsyncBoxed { inner });
         UnsyncBoxService { inner }
     }
+
+    #[allow(missing_docs)]
+    pub fn layer<S>() -> impl Layer<S, Service = Self> + Clone
+    where
+        S: Service<T, Response = U, Error = E> + 'static,
+        S::Future: 'static,
+    {
+        layer_fn(Self::new)
+    }
 }
 
 impl<T, U, E> Service<T> for UnsyncBoxService<T, U, E> {


### PR DESCRIPTION
This change adds `BoxService::layer` and `UnsyncBoxService::layer`
helpers to provide a convenience helper for boxing services in layered
stacks.