### PR TITLE
make all combinator futures opaque

### DIFF
--- a/tower/src/filter/mod.rs
+++ b/tower/src/filter/mod.rs
@@ -33,7 +33,6 @@ pub use self::{
 
 use self::future::{AsyncResponseFuture, ResponseFuture};
 use crate::BoxError;
-use futures_core::ready;
 use futures_util::{future::Either, TryFutureExt};
 use std::task::{Context, Poll};
 use tower_service::Service;

--- a/tower/src/spawn_ready/future.rs
+++ b/tower/src/spawn_ready/future.rs
@@ -20,6 +20,13 @@ pub struct BackgroundReady<T, Request> {
     _req: PhantomData<Request>,
 }
 
+opaque_future! {
+    /// Response future from [`SpawnReady`] services.
+    ///
+    /// [`SpawnReady`]: crate::spawn_ready::SpawnReady
+    pub type ResponseFuture<F, E> = futures_util::future::MapErr<F, fn(E) -> crate::BoxError>;
+
+
 pub(crate) fn background_ready<T, Request>(
     service: T,
 ) -> (

--- a/tower/src/spawn_ready/future.rs
+++ b/tower/src/spawn_ready/future.rs
@@ -25,7 +25,7 @@ opaque_future! {
     ///
     /// [`SpawnReady`]: crate::spawn_ready::SpawnReady
     pub type ResponseFuture<F, E> = futures_util::future::MapErr<F, fn(E) -> crate::BoxError>;
-
+}
 
 pub(crate) fn background_ready<T, Request>(
     service: T,

--- a/tower/src/spawn_ready/service.rs
+++ b/tower/src/spawn_ready/service.rs
@@ -1,6 +1,6 @@
 use super::future::{background_ready, ResponseFuture};
 use futures_core::ready;
-use futures_util::future::{MapErr, TryFutureExt};
+use futures_util::future::TryFutureExt;
 use std::{
     future::Future,
     pin::Pin,

--- a/tower/src/spawn_ready/service.rs
+++ b/tower/src/spawn_ready/service.rs
@@ -1,4 +1,4 @@
-use super::future::background_ready;
+use super::future::{background_ready, ResponseFuture};
 use futures_core::ready;
 use futures_util::future::{MapErr, TryFutureExt};
 use std::{
@@ -40,7 +40,7 @@ where
 {
     type Response = T::Response;
     type Error = crate::BoxError;
-    type Future = MapErr<T::Future, fn(T::Error) -> crate::BoxError>;
+    type Future = ResponseFuture<T::Future, T::Error>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         loop {

--- a/tower/src/spawn_ready/service.rs
+++ b/tower/src/spawn_ready/service.rs
@@ -66,7 +66,9 @@ where
 
     fn call(&mut self, request: Request) -> Self::Future {
         match self.inner {
-            Inner::Service(Some(ref mut svc)) => svc.call(request).map_err(Into::into),
+            Inner::Service(Some(ref mut svc)) => {
+                ResponseFuture(svc.call(request).map_err(Into::into))
+            }
             _ => unreachable!("poll_ready must be called"),
         }
     }

--- a/tower/src/util/map_err.rs
+++ b/tower/src/util/map_err.rs
@@ -1,10 +1,7 @@
-use futures_util::TryFutureExt;
+use futures_util::{future, TryFutureExt};
 use std::task::{Context, Poll};
 use tower_layer::Layer;
 use tower_service::Service;
-
-#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-pub use futures_util::future::MapErr as MapErrFuture;
 
 /// Service returned by the [`map_err`] combinator.
 ///
@@ -21,6 +18,13 @@ pub struct MapErr<S, F> {
 #[derive(Debug)]
 pub struct MapErrLayer<F> {
     f: F,
+}
+
+opaque_future! {
+    /// Response future from [`MapErr`] services.
+    ///
+    /// [`MapErr`]: crate::util::MapErr
+    pub type MapErrFuture<F, N> = future::MapErr<F, N>;
 }
 
 impl<S, F> MapErr<S, F> {
@@ -46,7 +50,7 @@ where
 
     #[inline]
     fn call(&mut self, request: Request) -> Self::Future {
-        self.inner.call(request).map_err(self.f.clone())
+        MapErrFuture(self.inner.call(request).map_err(self.f.clone()))
     }
 }
 

--- a/tower/src/util/map_result.rs
+++ b/tower/src/util/map_result.rs
@@ -1,10 +1,7 @@
-use futures_util::FutureExt;
+use futures_util::{future::Map, FutureExt};
 use std::task::{Context, Poll};
 use tower_layer::Layer;
 use tower_service::Service;
-
-#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-pub use futures_util::future::Map as MapResultFuture;
 
 /// Service returned by the [`map_result`] combinator.
 ///
@@ -21,6 +18,13 @@ pub struct MapResult<S, F> {
 #[derive(Debug, Clone)]
 pub struct MapResultLayer<F> {
     f: F,
+}
+
+opaque_future! {
+    /// Response future from [`MapResult`] services.
+    ///
+    /// [`MapResult`]: crate::util::MapResult
+    pub type MapResultFuture<F, N> = Map<F, N>;
 }
 
 impl<S, F> MapResult<S, F> {
@@ -47,7 +51,7 @@ where
 
     #[inline]
     fn call(&mut self, request: Request) -> Self::Future {
-        self.inner.call(request).map(self.f.clone())
+        MapResultFuture(self.inner.call(request).map(self.f.clone()))
     }
 }
 


### PR DESCRIPTION
For stability reasons, we probably don't want to expose future
combinator types from the `futures_util` crate in public APIs. If we
were to change which combinators are used to implement these futures, or
if `futures_util` made breaking changes, this could cause API breakage.

This branch wraps all publicly exposed `futures_util` types in the
`opaque_future!` macro added in #508, to wrap them in newtypes that hide
their internal details. This way, we can change these futures' internals
whenever we like.