### PR TITLE
service: Improve example in docs

### DIFF
--- a/tower-service/CHANGELOG.md
+++ b/tower-service/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Improve example in `Service` docs.
+
 # 0.3.0 (November 29, 2019)
 
 - Update to `futures 0.3`.

--- a/tower-service/Cargo.toml
+++ b/tower-service/Cargo.toml
@@ -25,3 +25,6 @@ edition = "2018"
 
 [dev-dependencies]
 http = "0.2"
+tower-layer = { version = "0.3", path = "../tower-layer" }
+tokio = { version = "1" }
+futures = "0.3"

--- a/tower-service/src/lib.rs
+++ b/tower-service/src/lib.rs
@@ -163,7 +163,7 @@ use std::task::{Context, Poll};
 ///     // Errors may be either `Expired` if the timeout expired, or the inner service's
 ///     // `Error` type. Therefore, we return a boxed `dyn Error` trait object to erase
 ///     // the error's type.
-///     type Error = Box<dyn Error>;
+///     type Error = Box<dyn Error + Send + Sync>;
 ///     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
 ///
 ///     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/tower-service/src/lib.rs
+++ b/tower-service/src/lib.rs
@@ -155,7 +155,7 @@ use std::task::{Context, Poll};
 /// where
 ///     T: Service<Request>,
 ///     T::Future: 'static,
-///     T::Error: Into<Box<dyn Error>> + 'static,
+///     T::Error: Into<Box<dyn Error + Send + Sync>> + 'static,
 ///     T::Response: 'static,
 /// {
 ///     // `Timeout` doesn't modify the response type, so we use `T`'s response type

--- a/tower-service/src/lib.rs
+++ b/tower-service/src/lib.rs
@@ -191,7 +191,7 @@ use std::task::{Context, Poll};
 ///                     res.map_err(|err| err.into())
 ///                 },
 ///                 _ = timeout => {
-///                     Err(Box::new(Expired) as Box<dyn Error>)
+///                     Err(Box::new(Expired) as Box<dyn Error + Send + Sync>)
 ///                 },
 ///             }
 ///         };

--- a/tower-service/src/lib.rs
+++ b/tower-service/src/lib.rs
@@ -179,12 +179,12 @@ use std::task::{Context, Poll};
 ///         // Call the inner service and get a future that resolves to the response
 ///         let fut = self.inner.call(req);
 ///
-///         // wrap those two futures in another future that completes when either one completes
+///         // Wrap those two futures in another future that completes when either one completes
 ///         //
-///         // if the inner service is too slow the `sleep` future will complete first
-///         // and an error will be returned and `fut` will be dropped and not polled again
+///         // If the inner service is too slow the `sleep` future will complete first
+///         // And an error will be returned and `fut` will be dropped and not polled again
 ///         //
-///         // we have to box the errors so the types match
+///         // We have to box the errors so the types match
 ///         let f = async move {
 ///             tokio::select! {
 ///                 res = fut => {

--- a/tower-service/src/lib.rs
+++ b/tower-service/src/lib.rs
@@ -161,7 +161,7 @@ use std::task::{Context, Poll};
 ///     // `Timeout` doesn't modify the response type, so we use `T`'s response type
 ///     type Response = T::Response;
 ///     // Errors may be either `Expired` if the timeout expired, or the inner service's
-///     // `Error` type. Therefore, we return a boxed `dyn Error` trait object to erase
+///     // `Error` type. Therefore, we return a boxed `dyn Error + Send + Sync` trait object to erase
 ///     // the error's type.
 ///     type Error = Box<dyn Error + Send + Sync>;
 ///     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;

--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -33,7 +33,7 @@
 //! asynchronous function from a request type to a response type, a [`Layer`] is
 //! a function taking a [`Service`] of one type and returning a [`Service`] of a
 //! different type. The [`ServiceBuilder`] type is used to add middleware to a
-//! service by composing it with multiple multiple [`Layer`]s.
+//! service by composing it with multiple [`Layer`]s.
 //!
 //! ## The Tower Ecosystem
 //!

--- a/tower/src/steer/mod.rs
+++ b/tower/src/steer/mod.rs
@@ -20,17 +20,17 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! // service that responds to `GET /`
+//! // Service that responds to `GET /`
 //! let root = service_fn(|req: Request<String>| async move {
 //!     # assert_eq!(req.uri().path(), "/");
 //!     let res = Response::new("Hello, World!".to_string());
 //!     Ok::<_, Infallible>(res)
 //! });
-//! // we have to box the service so its type gets erased and we can put it in a `Vec` with other
+//! // We have to box the service so its type gets erased and we can put it in a `Vec` with other
 //! // services
 //! let root = BoxService::new(root);
 //!
-//! // service that responds with `404 Not Found` to all requests
+//! // Service that responds with `404 Not Found` to all requests
 //! let not_found = service_fn(|req: Request<String>| async move {
 //!     let res = Response::builder()
 //!         .status(StatusCode::NOT_FOUND)
@@ -38,28 +38,28 @@
 //!         .expect("response is valid");
 //!     Ok::<_, Infallible>(res)
 //! });
-//! // box that as well
+//! // Box that as well
 //! let not_found = BoxService::new(not_found);
 //!
 //! let mut svc = Steer::new(
-//!     // all services we route between
+//!     // All services we route between
 //!     vec![root, not_found],
-//!     // how we pick which service to send the request to
+//!     // How we pick which service to send the request to
 //!     |req: &Request<String>, _services: &[_]| {
 //!         if req.method() == Method::GET && req.uri().path() == "/" {
-//!             0 // index of `root`
+//!             0 // Index of `root`
 //!         } else {
-//!             1 // index of `not_found`
+//!             1 // Index of `not_found`
 //!         }
 //!     },
 //! );
 //!
-//! // this request will get sent to `root`
+//! // This request will get sent to `root`
 //! let req = Request::get("/").body(String::new()).unwrap();
 //! let res = svc.ready_and().await?.call(req).await?;
 //! assert_eq!(res.into_body(), "Hello, World!");
 //!
-//! // this request will get sent to `not_found`
+//! // This request will get sent to `not_found`
 //! let req = Request::get("/does/not/exist").body(String::new()).unwrap();
 //! let res = svc.ready_and().await?.call(req).await?;
 //! assert_eq!(res.status(), StatusCode::NOT_FOUND);

--- a/tower/src/steer/mod.rs
+++ b/tower/src/steer/mod.rs
@@ -26,7 +26,7 @@
 //!     let res = Response::new("Hello, World!".to_string());
 //!     Ok::<_, Infallible>(res)
 //! });
-//! // we have to box the service so its type gets erased and we can put in a `Vec` with other
+//! // we have to box the service so its type gets erased and we can put it in a `Vec` with other
 //! // services
 //! let root = BoxService::new(root);
 //!


### PR DESCRIPTION
- Fixed a couple of typos that I happen to discover.
- Makes the `Timeout` example from the `Service` docs runnable and adds some comments to the code.