### PR TITLE
prepare Tower 0.4 for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ pattern. If your protocol is entirely stream based, Tower may not be a good fit.
 
 ## Status
 
-Currently, `tower 0.3` is released on crates. We are currently working on cleaning
-up the codebase and adding more documentation. You can follow our progress in
-this [issue](https://github.com/tower-rs/tower/issues/431).
+Currently, `tower 0.4` is released on crates.io.
 
 ## License
 

--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+# 0.4.0 (January 7, 2021)
+
+This is a major breaking release including a large number of changes. In
+particular, this release updates `tower` to depend on Tokio 1.0, and moves all
+middleware into the `tower` crate. In addition, Tower 0.4 reworks several
+middleware APIs, as well as introducing new ones. 
+
+This release does *not* change the core `Service` or `Layer` traits, so `tower`
+0.4 still depends on `tower-service` 0.3 and `tower-layer` 0.3. This means that
+`tower` 0.4 is still compatible with libraries that depend on those crates.
+
 ### Added
 
 - **make**: Added `MakeService::into_service` and `MakeService::as_service` for

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tower-rs/tower"
 homepage = "https://github.com/tower-rs/tower"
-documentation = "https://docs.rs/tower/0.3.1"
+documentation = "https://docs.rs/tower/0.4.0"
 description = """
 Tower is a library of modular and reusable components for building robust
 clients and servers.

--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tower/0.3.1")]
+#![doc(html_root_url = "https://docs.rs/tower/0.4.0")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
This branch updates the changelogs and version numbers for Tower 0.4.