### PR TITLE
tower: prepare to release 0.4.1

### DIFF
--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Updated `tower-layer` to 0.3.1 to fix broken re-exports.
+
 # 0.4.0 (January 7, 2021)
 
 This is a major breaking release including a large number of changes. In

--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 0.4.1 (January 7, 2021)
+
+### Fixed
+
+- Updated `tower-layer` to 0.3.1 to fix broken re-exports.
 # 0.4.0 (January 7, 2021)
 
 This is a major breaking release including a large number of changes. In

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -8,13 +8,13 @@ name = "tower"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "vX.X.X" git tag.
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tower-rs/tower"
 homepage = "https://github.com/tower-rs/tower"
-documentation = "https://docs.rs/tower/0.4.0"
+documentation = "https://docs.rs/tower/0.4.1"
 description = """
 Tower is a library of modular and reusable components for building robust
 clients and servers.
@@ -46,7 +46,7 @@ util = ["futures-util"]
 [dependencies]
 futures-core = "0.3"
 pin-project = "1"
-tower-layer = { version = "0.3", path = "../tower-layer" }
+tower-layer = { version = "0.3.1", path = "../tower-layer" }
 tower-service = { version = "0.3" }
 tracing = "0.1.2"
 

--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tower/0.4.0")]
+#![doc(html_root_url = "https://docs.rs/tower/0.4.1")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
This branch updates the tower-layer dependency to 0.3.1 and prepares a
new release of `tower`. This should fix the broken re-exports of
`layer_fn` and get us a successful docs.rs build.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>