### PR TITLE
Re-export `layer_fn` and `LayerFn` from tower

### DIFF
--- a/tower/src/layer.rs
+++ b/tower/src/layer.rs
@@ -1,6 +1,6 @@
 //! A collection of `Layer` based tower services
 
-pub use tower_layer::Layer;
+pub use tower_layer::{layer_fn, Layer, LayerFn};
 
 /// `util` exports an Identity Layer and Chain, a mechanism for chaining them.
 pub mod util {


### PR DESCRIPTION
I guess it makes sense to re-export `layer_fn` and `LayerFn` from tower otherwise users have to depend on `tower_layer`. Actually thought we already had this but guess not 🤷 