### PR TITLE
filter: add `get_ref`, `get_mut`, and `into_inner`

### DIFF
--- a/tower/src/filter/mod.rs
+++ b/tower/src/filter/mod.rs
@@ -80,6 +80,21 @@ impl<T, U> Filter<T, U> {
     {
         self.predicate.check(request)
     }
+
+    /// Get a reference to the inner service
+    pub fn get_ref(&self) -> &T {
+        &self.inner
+    }
+
+    /// Get a mutable reference to the inner service
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
+    /// Consume `self`, returning the inner service
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
 }
 
 impl<T, U, Request> Service<Request> for Filter<T, U>
@@ -126,6 +141,21 @@ impl<T, U> AsyncFilter<T, U> {
         U: AsyncPredicate<R>,
     {
         self.predicate.check(request).await
+    }
+
+    /// Get a reference to the inner service
+    pub fn get_ref(&self) -> &T {
+        &self.inner
+    }
+
+    /// Get a mutable reference to the inner service
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
+    /// Consume `self`, returning the inner service
+    pub fn into_inner(self) -> T {
+        self.inner
     }
 }
 


### PR DESCRIPTION
This branch adds methods to access the inner service of a `Filter` or an
`AsyncFilter`. These are identical to the similarly-named method
provided by many other middleware services.

Along with the changes in #521, this is also necessary to implement
filtered versions of foreign traits in downstream code. I probably
should've added this in that PR, but I wasn't thinking it through...