### PR TITLE
util: add `layer` fns to middleware

### DIFF
--- a/tower/src/util/and_then.rs
+++ b/tower/src/util/and_then.rs
@@ -57,6 +57,15 @@ impl<S, F> AndThen<S, F> {
     pub fn new(inner: S, f: F) -> Self {
         AndThen { f, inner }
     }
+
+    /// Returns a new [`Layer`] that produces [`AndThen`] services.
+    ///
+    /// This is a convenience function that simply calls [`AndThenLayer::new`].
+    ///
+    /// [`Layer`]: tower_layer::Layer
+    pub fn layer(f: F) -> AndThenLayer<F> {
+        AndThenLayer { f }
+    }
 }
 
 impl<S, F, Request, Fut> Service<Request> for AndThen<S, F>

--- a/tower/src/util/map_err.rs
+++ b/tower/src/util/map_err.rs
@@ -12,7 +12,7 @@ pub struct MapErr<S, F> {
     f: F,
 }
 
-/// A [`Layer`] that produces a [`MapErr`] service.
+/// A [`Layer`] that produces [`MapErr`] services.
 ///
 /// [`Layer`]: tower_layer::Layer
 #[derive(Debug)]
@@ -31,6 +31,15 @@ impl<S, F> MapErr<S, F> {
     /// Creates a new [`MapErr`] service.
     pub fn new(inner: S, f: F) -> Self {
         MapErr { f, inner }
+    }
+
+    /// Returns a new [`Layer`] that produces [`MapErr`] services.
+    ///
+    /// This is a convenience function that simply calls [`MapErrLayer::new`].
+    ///
+    /// [`Layer`]: tower_layer::Layer
+    pub fn layer(f: F) -> MapErrLayer<F> {
+        MapErrLayer { f }
     }
 }
 

--- a/tower/src/util/map_request.rs
+++ b/tower/src/util/map_request.rs
@@ -16,6 +16,15 @@ impl<S, F> MapRequest<S, F> {
     pub fn new(inner: S, f: F) -> Self {
         MapRequest { inner, f }
     }
+
+    /// Returns a new [`Layer`] that produces [`MapRequest`] services.
+    ///
+    /// This is a convenience function that simply calls [`MapRequestLayer::new`].
+    ///
+    /// [`Layer`]: tower_layer::Layer
+    pub fn layer(f: F) -> MapRequestLayer<F> {
+        MapRequestLayer { f }
+    }
 }
 
 impl<S, F, R1, R2> Service<R1> for MapRequest<S, F>
@@ -38,7 +47,7 @@ where
     }
 }
 
-/// A [`Layer`] that produces a [`MapRequest`] service.
+/// A [`Layer`] that produces [`MapRequest`] services.
 ///
 /// [`Layer`]: tower_layer::Layer
 #[derive(Debug)]

--- a/tower/src/util/map_response.rs
+++ b/tower/src/util/map_response.rs
@@ -32,6 +32,15 @@ impl<S, F> MapResponse<S, F> {
     pub fn new(inner: S, f: F) -> Self {
         MapResponse { f, inner }
     }
+
+    /// Returns a new [`Layer`] that produces [`MapResponse`] services.
+    ///
+    /// This is a convenience function that simply calls [`MapResponseLayer::new`].
+    ///
+    /// [`Layer`]: tower_layer::Layer
+    pub fn layer(f: F) -> MapResponseLayer<F> {
+        MapResponseLayer { f }
+    }
 }
 
 impl<S, F, Request, Response> Service<Request> for MapResponse<S, F>

--- a/tower/src/util/map_result.rs
+++ b/tower/src/util/map_result.rs
@@ -32,6 +32,15 @@ impl<S, F> MapResult<S, F> {
     pub fn new(inner: S, f: F) -> Self {
         MapResult { f, inner }
     }
+
+    /// Returns a new [`Layer`] that produces [`MapResult`] services.
+    ///
+    /// This is a convenience function that simply calls [`MapResultLayer::new`].
+    ///
+    /// [`Layer`]: tower_layer::Layer
+    pub fn layer(f: F) -> MapResultLayer<F> {
+        MapResultLayer { f }
+    }
 }
 
 impl<S, F, Request, Response, Error> Service<Request> for MapResult<S, F>

--- a/tower/src/util/then.rs
+++ b/tower/src/util/then.rs
@@ -28,6 +28,15 @@ impl<S, F> Then<S, F> {
     pub fn new(inner: S, f: F) -> Self {
         Then { f, inner }
     }
+
+    /// Returns a new [`Layer`] that produces [`Then`] services.
+    ///
+    /// This is a convenience function that simply calls [`ThenLayer::new`].
+    ///
+    /// [`Layer`]: tower_layer::Layer
+    pub fn layer(f: F) -> ThenLayer<F> {
+        ThenLayer { f }
+    }
 }
 
 opaque_future! {


### PR DESCRIPTION
This branch adds `AndThen::layer`, `Then::layer`, `MapErr::layer`,
`MapRequest::layer`, `MapResponse::layer`, and `MapResult::layer`
associated functions that simply return each middleware's associated
layer type. This can be more convenient in some cases, since it avoids
having to import both the layer type and the middleware type.

Similar functions already exist for other middleware, such as
`BoxService`.