### PR TITLE
util: impl `Clone` for `AndThen`, `MapRequest` and `MapErr` layers

### DIFF
--- a/tower/src/util/and_then.rs
+++ b/tower/src/util/and_then.rs
@@ -47,7 +47,7 @@ where
 /// A [`Layer`] that produces a [`AndThen`] service.
 ///
 /// [`Layer`]: tower_layer::Layer
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct AndThenLayer<F> {
     f: F,
 }

--- a/tower/src/util/map_err.rs
+++ b/tower/src/util/map_err.rs
@@ -15,7 +15,7 @@ pub struct MapErr<S, F> {
 /// A [`Layer`] that produces a [`MapErr`] service.
 ///
 /// [`Layer`]: tower_layer::Layer
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MapErrLayer<F> {
     f: F,
 }

--- a/tower/src/util/map_request.rs
+++ b/tower/src/util/map_request.rs
@@ -41,7 +41,7 @@ where
 /// A [`Layer`] that produces a [`MapRequest`] service.
 ///
 /// [`Layer`]: tower_layer::Layer
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MapRequestLayer<F> {
     f: F,
 }


### PR DESCRIPTION
The `Layer` types for `AndThen`, `MapRequest`, and `MapErr` middleware
were missing `Clone` impls, which the `MapResponse`, `MapResult`, and
`Then` middleware's layer types *do* have. These layers should all be
`Clone` when the function is `Clone`.

I've added `derive(Clone)` to all these layer types.