### PR TITLE
chore: add `--all-features` and `--cfg docsrs` to `cargo doc` CI workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --workspace --no-deps
+          args: --workspace --no-deps --all-features
       - name: Deploy documentation
         if: success()
         uses: crazy-max/ghaction-github-pages@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           command: doc
           args: --workspace --no-deps --all-features
+          # Tower uses nightly-only RustDoc features
+          toolchain: nightly
+          env:
+            RUSTDOCFLAGS: --cfg docsrs
       - name: Deploy documentation
         if: success()
         uses: crazy-max/ghaction-github-pages@v1


### PR DESCRIPTION
Tower's docs builds are currently failing on `master` because of broken
docs links. These links are broken because they reference modules that
are feature flagged and disabled by default.

In order to build docs successfully, we should build with
`--all-features`. This also means we'll actually build docs for feature
flagged modules --- because we weren't doing that previously, we
actually weren't building most of the docs on CI.

Additionally, I've changed the docs build workflow to build on nightly and
to set `RUSTDOCFLAGS="--cfg docsrs"` so that we can use `doc(cfg)`
attributes when building the Git API docs.