### PR TITLE
util: Implement `Layer` for `Either<A, B>`

### DIFF
--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+# Unreleased
+
+### Added
+- **util**: Implement `Layer` for `Either<A, B>`.
+
 # 0.4.3 (January 13, 2021)
 
 ### Added

--- a/tower/src/util/either.rs
+++ b/tower/src/util/either.rs
@@ -9,8 +9,8 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tower_service::Service;
 use tower_layer::Layer;
+use tower_service::Service;
 
 /// Combine two different service types into a single type.
 ///

--- a/tower/src/util/either.rs
+++ b/tower/src/util/either.rs
@@ -10,6 +10,7 @@ use std::{
     task::{Context, Poll},
 };
 use tower_service::Service;
+use tower_layer::Layer;
 
 /// Combine two different service types into a single type.
 ///
@@ -68,6 +69,21 @@ where
         match self.project() {
             EitherProj::A(fut) => Poll::Ready(Ok(ready!(fut.poll(cx)).map_err(Into::into)?)),
             EitherProj::B(fut) => Poll::Ready(Ok(ready!(fut.poll(cx)).map_err(Into::into)?)),
+        }
+    }
+}
+
+impl<S, A, B> Layer<S> for Either<A, B>
+where
+    A: Layer<S>,
+    B: Layer<S>,
+{
+    type Service = Either<A::Service, B::Service>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        match self {
+            Either::A(layer) => Either::A(layer.layer(inner)),
+            Either::B(layer) => Either::B(layer.layer(inner)),
         }
     }
 }


### PR DESCRIPTION
I ran into a use case for this today which meant I had to make my own `Either` type. I guess makes sense for Tower to provide this directly.

My use case was that I wanted to optionally apply some layer depending on some config. I had an `Option<T>` which I wanted to map into a `Either<LayerUsingT, Identity>` and then treat that as a `Layer` in a larger stack.