### PR TITLE
Add clone impls to layers

### DIFF
--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **util**: Implement `Layer` for `Either<A, B>`.
+- **util**: Implement `Clone` for `FilterLayer`.
 
 # 0.4.3 (January 13, 2021)
 

--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **util**: Implement `Layer` for `Either<A, B>`.
 - **util**: Implement `Clone` for `FilterLayer`.
 - **timeout**: Implement `Clone` for `TimeoutLayer`.
+- **limit**: Implement `Clone` for `RateLimitLayer`.
 
 # 0.4.3 (January 13, 2021)
 

--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **util**: Implement `Layer` for `Either<A, B>`.
 - **util**: Implement `Clone` for `FilterLayer`.
+- **timeout**: Implement `Clone` for `TimeoutLayer`.
 
 # 0.4.3 (January 13, 2021)
 

--- a/tower/src/filter/layer.rs
+++ b/tower/src/filter/layer.rs
@@ -9,7 +9,7 @@ use tower_layer::Layer;
 /// [predicate]: crate::filter::Predicate
 /// [`Layer`]: crate::Layer
 /// [`Filter`]: crate::filter::Filter
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FilterLayer<U> {
     predicate: U,
 }

--- a/tower/src/limit/rate/layer.rs
+++ b/tower/src/limit/rate/layer.rs
@@ -4,7 +4,7 @@ use tower_layer::Layer;
 
 /// Enforces a rate limit on the number of requests the underlying
 /// service can handle over a period of time.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RateLimitLayer {
     rate: Rate,
 }

--- a/tower/src/timeout/layer.rs
+++ b/tower/src/timeout/layer.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use tower_layer::Layer;
 
 /// Applies a timeout to requests via the supplied inner service.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TimeoutLayer {
     timeout: Duration,
 }


### PR DESCRIPTION
I ran into a missing `Clone` impl for `TimeoutLayer` today. Figure I would add that and look for other layers that probably should impl `Clone`.

Not sure if these were oversights or if there were reasons for not implementing `Clone`.