### PR TITLE
util: Fix some doc comment typos

### DIFF
--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -97,7 +97,7 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
         CallAll::new(self, reqs)
     }
 
-    /// Executes a new future after this service's after this services future resolves. This does
+    /// Executes a new future after this service's future resolves. This does
     /// not alter the behaviour of the [`poll_ready`] method.
     ///
     /// This method can be used to change the [`Response`] type of the service

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -1,4 +1,4 @@
-//! Various utility types and functions that are generally with Tower.
+//! Various utility types and functions that are generally used with Tower.
 
 mod and_then;
 mod boxed;

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -102,7 +102,7 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     ///
     /// This method can be used to change the [`Response`] type of the service
     /// into a different type. You can use this method to chain along a computation once the
-    /// services response has been resolved.
+    /// service's response has been resolved.
     ///
     /// [`Response`]: crate::Service::Response
     /// [`poll_ready`]: crate::Service::poll_ready
@@ -171,7 +171,7 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// This method can be used to change the [`Response`] type of the service
     /// into a different type. It is similar to the [`Result::map`]
     /// method. You can use this method to chain along a computation once the
-    /// services response has been resolved.
+    /// service's response has been resolved.
     ///
     /// [`Response`]: crate::Service::Response
     /// [`poll_ready`]: crate::Service::poll_ready
@@ -234,7 +234,7 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
         MapResponse::new(self, f)
     }
 
-    /// Maps this services's error value to a different value. This does not
+    /// Maps this service's error value to a different value. This does not
     /// alter the behaviour of the [`poll_ready`] method.
     ///
     /// This method can be used to change the [`Error`] type of the service


### PR DESCRIPTION
* delete some repeated words in `and_then`'s doc comment
* fix some apostrophes
* add a missing word in the `tower::util` module comment