### PR TITLE
util: Add `ServiceExt::map_future`

### DIFF
--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **util**: Add `ServiceExt::map_future`. ([#542])
+
+[#542]: https://github.com/tower-rs/tower/pull/542
+
 # 0.4.4 (January 20, 2021)
 
 ### Added

--- a/tower/src/util/map_future.rs
+++ b/tower/src/util/map_future.rs
@@ -1,0 +1,57 @@
+use std::{
+    future::Future,
+    task::{Context, Poll},
+};
+use tower_layer::Layer;
+use tower_service::Service;
+
+pub struct MapFuture<S, F> {
+    inner: S,
+    f: F,
+}
+
+#[derive(Debug, Clone)]
+pub struct MapFutureLayer<F> {
+    f: F,
+}
+
+impl<S, F> MapFuture<S, F> {
+    pub fn new(inner: S, f: F) -> Self {
+        Self { inner, f }
+    }
+
+    pub fn layer(f: F) -> MapFutureLayer<F> {
+        MapFutureLayer { f }
+    }
+}
+
+impl<R, S, F, T, E, Fut> Service<R> for MapFuture<S, F>
+where
+    S: Service<R>,
+    F: FnMut(S::Future) -> Fut,
+    E: From<S::Error>,
+    Fut: Future<Output = Result<T, E>>,
+{
+    type Response = T;
+    type Error = E;
+    type Future = Fut;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(From::from)
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
+        (self.f)(self.inner.call(req))
+    }
+}
+
+impl<S, F> Layer<S> for MapFuture<S, F>
+where
+    F: Clone,
+{
+    type Service = MapFuture<S, F>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        MapFuture::new(inner, self.f.clone())
+    }
+}

--- a/tower/src/util/map_future.rs
+++ b/tower/src/util/map_future.rs
@@ -81,7 +81,7 @@ where
 /// A [`Layer`] that produces a [`MapFuture`] service.
 ///
 /// [`Layer`]: tower_layer::Layer
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct MapFutureLayer<F> {
     f: F,
 }
@@ -101,5 +101,13 @@ where
 
     fn layer(&self, inner: S) -> Self::Service {
         MapFuture::new(inner, self.f.clone())
+    }
+}
+
+impl<F> fmt::Debug for MapFutureLayer<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MapFutureLayer")
+            .field("f", &format_args!("{}", std::any::type_name::<F>()))
+            .finish()
     }
 }

--- a/tower/src/util/map_future.rs
+++ b/tower/src/util/map_future.rs
@@ -73,7 +73,7 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MapFuture")
             .field("inner", &self.inner)
-            .field("f", &format_args!("<{}>", std::any::type_name::<F>()))
+            .field("f", &format_args!("{}", std::any::type_name::<F>()))
             .finish()
     }
 }

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -24,10 +24,10 @@ pub use self::{
     either::Either,
     future_service::{future_service, FutureService},
     map_err::{MapErr, MapErrLayer},
+    map_future::MapFuture,
     map_request::{MapRequest, MapRequestLayer},
     map_response::{MapResponse, MapResponseLayer},
     map_result::{MapResult, MapResultLayer},
-    map_future::MapFuture,
     oneshot::Oneshot,
     optional::Optional,
     ready::{ReadyAnd, ReadyOneshot},
@@ -862,9 +862,12 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
         Then::new(self, f)
     }
 
-    fn map_future<F, Fut>(self, f: F) -> MapFuture<Self, F>
+    fn map_future<F, Fut, Response, Error>(self, f: F) -> MapFuture<Self, F>
     where
         Self: Sized,
+        F: FnMut(Self::Future) -> Fut,
+        Error: From<Self::Error>,
+        Fut: Future<Output = Result<Response, Error>>,
     {
         MapFuture::new(self, f)
     }

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -11,6 +11,7 @@ mod map_request;
 mod map_response;
 mod map_result;
 
+mod map_future;
 mod oneshot;
 mod optional;
 mod ready;
@@ -26,6 +27,7 @@ pub use self::{
     map_request::{MapRequest, MapRequestLayer},
     map_response::{MapResponse, MapResponseLayer},
     map_result::{MapResult, MapResultLayer},
+    map_future::MapFuture,
     oneshot::Oneshot,
     optional::Optional,
     ready::{ReadyAnd, ReadyOneshot},
@@ -858,6 +860,13 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
         Fut: Future<Output = Result<Response, Error>>,
     {
         Then::new(self, f)
+    }
+
+    fn map_future<F, Fut>(self, f: F) -> MapFuture<Self, F>
+    where
+        Self: Sized,
+    {
+        MapFuture::new(self, f)
     }
 }
 


### PR DESCRIPTION
I ran into a thing today where I wanted to write a middleware that wraps
all futures produced by a service in a `tracing::Span`. So something
like `self.inner.call(req).instrument(span)`.

Afaik all the combinators we have today receive the value produced by
the future and not the future itself. At that point its too late to call
`.instrument`. So I thought this made sense to add a combinator for.

If you agree I'll go write some docs and clean things up.