### PR TITLE
Retry Policy POC

### DIFF
--- a/tower/src/retry/mod.rs
+++ b/tower/src/retry/mod.rs
@@ -4,9 +4,11 @@ pub mod budget;
 pub mod future;
 mod layer;
 mod policy;
+mod policyv2;
 
 pub use self::layer::RetryLayer;
 pub use self::policy::Policy;
+pub use self::policyv2::PolicyV2;
 
 use self::future::ResponseFuture;
 use pin_project::pin_project;
@@ -50,7 +52,7 @@ impl<P, S> Retry<P, S> {
 
 impl<P, S, Request> Service<Request> for Retry<P, S>
 where
-    P: Policy<Request, S::Response, S::Error> + Clone,
+    P: PolicyV2<Request, S::Response, S::Error> + Clone,
     S: Service<Request> + Clone,
 {
     type Response = S::Response;

--- a/tower/src/retry/policyv2.rs
+++ b/tower/src/retry/policyv2.rs
@@ -1,0 +1,42 @@
+use std::future::Future;
+use crate::retry::Policy;
+
+/// TODO docs
+pub trait PolicyV2<Req, Res, E>: Sized {
+    /// The [`Future`] type returned by [`Policy::retry`].
+    type Future: Future<Output = Self>;
+
+    /// Check the policy if a certain request should be retried.
+    ///
+    /// This method is passed a reference to the original request, and either
+    /// the [`Service::Response`] or [`Service::Error`] from the inner service.
+    ///
+    /// If the request should **not** be retried, return `None`.
+    ///
+    /// If the request *should* be retried, return `Some` future of a new
+    /// policy that would apply for the next request attempt.
+    ///
+    /// [`Service::Response`]: crate::Service::Response
+    /// [`Service::Error`]: crate::Service::Error
+    fn retry(&self, req: &Req, result: Result<Res, E>) -> Result<Result<Res, E>, Self::Future>;
+
+    /// Tries to clone a request before being passed to the inner service.
+    ///
+    /// If the request cannot be cloned, return [`None`].
+    fn clone_request(&self, req: &Req) -> Option<Req>;
+}
+
+impl<T, Req, Res, E> PolicyV2<Req, Res, E> for T where T: Policy<Req, Res, E> {
+    type Future = T::Future;
+
+    fn retry(&self, req: &Req, result: Result<Res, E>) -> Result<Result<Res, E>, Self::Future> {
+        match Policy::<Req, Res, E>::retry(self, req, result.as_ref()) {
+            Some(fut) => Err(fut),
+            None => Ok(result)
+        }
+    }
+
+    fn clone_request(&self, req: &Req) -> Option<Req> {
+        Policy::<Req, Res, E>::clone_request(self, req)
+    }
+}


### PR DESCRIPTION
POC for a retry policy that allows the policy to modify the response if it chooses not to retry. It also includes a blanket implementation to the old trait this change can be backwards compatible.