### PR TITLE
builder: Add `ServiceBuilder::map_future`

### DIFF
--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-None.
+- **builder**: Add `ServiceBuilder::map_future` for transforming the futures produced
+  by a service.
 
 # 0.4.5 (February 10, 2021)
 

--- a/tower/src/builder/mod.rs
+++ b/tower/src/builder/mod.rs
@@ -405,6 +405,18 @@ impl<L> ServiceBuilder<L> {
         self.layer(crate::util::MapErrLayer::new(f))
     }
 
+    /// Composes a function that transforms futures produced by the service.
+    ///
+    /// This wraps the inner service with an instance of the [`MapFutureLayer`] middleware.
+    ///
+    /// See the documentation for the [`map_future`] combinator for details.
+    ///
+    /// [`MapFutureLayer`]: crate::util::MapFutureLayer
+    /// [`map_future`]: crate::util::ServiceExt::map_future
+    pub fn map_future<F>(self, f: F) -> ServiceBuilder<Stack<crate::util::MapFutureLayer<F>, L>> {
+        self.layer(crate::util::MapFutureLayer::new(f))
+    }
+
     /// Apply a function after the service, regardless of whether the future
     /// succeeds or fails.
     ///

--- a/tower/src/builder/mod.rs
+++ b/tower/src/builder/mod.rs
@@ -413,6 +413,8 @@ impl<L> ServiceBuilder<L> {
     ///
     /// [`MapFutureLayer`]: crate::util::MapFutureLayer
     /// [`map_future`]: crate::util::ServiceExt::map_future
+    #[cfg(feature = "util")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "util")))]
     pub fn map_future<F>(self, f: F) -> ServiceBuilder<Stack<crate::util::MapFutureLayer<F>, L>> {
         self.layer(crate::util::MapFutureLayer::new(f))
     }


### PR DESCRIPTION
I forgot at add this one in #542. Think its nice to have for consistency.