### PR TITLE
Multiplex middleware

### DIFF
--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -35,6 +35,7 @@ full = [
   "load",
   "load-shed",
   "make",
+  "multiplex",
   "ready-cache",
   "reconnect",
   "retry",
@@ -43,7 +44,6 @@ full = [
   "timeout",
   "util",
 ]
-log = ["tracing/log"]
 balance = ["discover", "load", "ready-cache", "make", "rand", "slab", "tokio-stream"]
 buffer = ["tokio/sync", "tokio/rt", "tokio-util", "tracing"]
 discover = []
@@ -52,7 +52,9 @@ hedge = ["util", "filter", "futures-util", "hdrhistogram", "tokio/time", "tracin
 limit = ["tokio/time", "tokio/sync", "tokio-util", "tracing"]
 load = ["tokio/time", "tracing"]
 load-shed = []
+log = ["tracing/log"]
 make = ["tokio/io-std", "futures-util"]
+multiplex = ["util"]
 ready-cache = ["futures-util", "indexmap", "tokio/sync", "tracing"]
 reconnect = ["make", "tokio/io-std", "tracing"]
 retry = ["tokio/time"]

--- a/tower/src/builder/mod.rs
+++ b/tower/src/builder/mod.rs
@@ -429,6 +429,7 @@ impl<L> ServiceBuilder<L> {
         self.layer(crate::util::ThenLayer::new(f))
     }
 
+    /// TODO(david): docs
     #[cfg(feature = "multiplex")]
     #[cfg_attr(docsrs, doc(cfg(feature = "multiplex")))]
     pub fn multiplex<A, P>(

--- a/tower/src/builder/mod.rs
+++ b/tower/src/builder/mod.rs
@@ -429,6 +429,16 @@ impl<L> ServiceBuilder<L> {
         self.layer(crate::util::ThenLayer::new(f))
     }
 
+    #[cfg(feature = "multiplex")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "multiplex")))]
+    pub fn multiplex<A, P>(
+        self,
+        first: A,
+        picker: P,
+    ) -> ServiceBuilder<Stack<crate::multiplex::MultiplexLayer<A, P>, L>> {
+        self.layer(crate::multiplex::MultiplexLayer::new(first, picker))
+    }
+
     /// Returns the underlying `Layer` implementation.
     pub fn into_inner(self) -> L {
         self.layer

--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -180,6 +180,9 @@ pub mod load_shed;
 #[cfg(feature = "make")]
 #[cfg_attr(docsrs, doc(cfg(feature = "make")))]
 pub mod make;
+#[cfg(feature = "multiplex")]
+#[cfg_attr(docsrs, doc(cfg(feature = "multiplex")))]
+pub mod multiplex;
 #[cfg(feature = "ready-cache")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ready-cache")))]
 pub mod ready_cache;

--- a/tower/src/macros.rs
+++ b/tower/src/macros.rs
@@ -2,7 +2,8 @@
     feature = "util",
     feature = "spawn-ready",
     feature = "filter",
-    feature = "make"
+    feature = "make",
+    feature = "multiplex",
 ))]
 macro_rules! opaque_future {
     ($(#[$m:meta])* pub type $name:ident<$($param:ident),+> = $actual:ty;) => {

--- a/tower/src/multiplex/layer.rs
+++ b/tower/src/multiplex/layer.rs
@@ -1,0 +1,28 @@
+use super::Multiplex;
+use tower_layer::Layer;
+
+/// TODO(david): docs
+#[derive(Debug, Clone, Copy)]
+pub struct MultiplexLayer<A, P> {
+    first: A,
+    picker: P,
+}
+
+impl<A, P> MultiplexLayer<A, P> {
+    /// TODO(david): docs
+    pub fn new(first: A, picker: P) -> Self {
+        Self { picker, first }
+    }
+}
+
+impl<P, A, B> Layer<B> for MultiplexLayer<A, P>
+where
+    P: Clone,
+    A: Clone,
+{
+    type Service = Multiplex<A, B, P>;
+
+    fn layer(&self, inner: B) -> Self::Service {
+        Multiplex::new(self.first.clone(), inner, self.picker.clone())
+    }
+}

--- a/tower/src/multiplex/mod.rs
+++ b/tower/src/multiplex/mod.rs
@@ -111,12 +111,15 @@ where
             "Multiplex must wait for all services to be ready. Did you forget to call poll_ready()?",
         );
 
-        self.first_ready = false;
-        self.second_ready = false;
-
         let future = match self.picker.pick(&mut req) {
-            Pick::First => Either::A(self.first.call(req)),
-            Pick::Second => Either::B(self.second.call(req)),
+            Pick::First => {
+                self.first_ready = false;
+                Either::A(self.first.call(req))
+            }
+            Pick::Second => {
+                self.second_ready = false;
+                Either::B(self.second.call(req))
+            }
         };
 
         ResponseFuture { inner: future }

--- a/tower/src/multiplex/mod.rs
+++ b/tower/src/multiplex/mod.rs
@@ -1,12 +1,14 @@
 //! TODO(david): docs
 
 mod layer;
-mod picker;
 mod service;
 
+pub mod picker;
+
+#[doc(inline)]
 pub use self::{
     layer::MultiplexLayer,
-    picker::{Pick, Picker, not, And, Or},
+    picker::{Pick, Picker},
     service::{Multiplex, ResponseFuture},
 };
 

--- a/tower/src/multiplex/mod.rs
+++ b/tower/src/multiplex/mod.rs
@@ -6,7 +6,7 @@ mod service;
 
 pub use self::{
     layer::MultiplexLayer,
-    picker::{Pick, Picker},
+    picker::{Pick, Picker, not, And, Or},
     service::{Multiplex, ResponseFuture},
 };
 

--- a/tower/src/multiplex/mod.rs
+++ b/tower/src/multiplex/mod.rs
@@ -135,3 +135,61 @@ where
         self.project().inner.poll(cx)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{service_fn, Service, ServiceBuilder, ServiceExt};
+
+    #[tokio::test]
+    async fn basic() {
+        let mut svc = ServiceBuilder::new()
+            .multiplex(service_fn(one), pick_if(1))
+            .multiplex(service_fn(two), pick_if(2))
+            .multiplex(service_fn(three), pick_if(3))
+            .service(service_fn(bottom));
+
+        assert_eq!(svc.ready_and().await.unwrap().call(1).await.unwrap(), "one",);
+
+        assert_eq!(svc.ready_and().await.unwrap().call(2).await.unwrap(), "two",);
+
+        assert_eq!(
+            svc.ready_and().await.unwrap().call(3).await.unwrap(),
+            "three",
+        );
+
+        assert_eq!(
+            svc.ready_and().await.unwrap().call(4).await.unwrap(),
+            "bottom",
+        );
+    }
+
+    fn pick_if(n: i32) -> impl Picker<i32> + Clone {
+        move |req: &mut i32| {
+            if n == *req {
+                Pick::First
+            } else {
+                Pick::Second
+            }
+        }
+    }
+
+    async fn one(req: i32) -> Result<&'static str, BoxError> {
+        assert_eq!(req, 1);
+        Ok("one")
+    }
+
+    async fn two(req: i32) -> Result<&'static str, BoxError> {
+        assert_eq!(req, 2);
+        Ok("two")
+    }
+
+    async fn three(req: i32) -> Result<&'static str, BoxError> {
+        assert_eq!(req, 3);
+        Ok("three")
+    }
+
+    async fn bottom(_req: i32) -> Result<&'static str, BoxError> {
+        Ok("bottom")
+    }
+}

--- a/tower/src/multiplex/mod.rs
+++ b/tower/src/multiplex/mod.rs
@@ -1,0 +1,139 @@
+#![allow(missing_docs)]
+
+use crate::util::Either;
+use crate::BoxError;
+use futures_util::ready;
+use pin_project::pin_project;
+use std::task::{Context, Poll};
+use std::{future::Future, pin::Pin};
+use tower_layer::Layer;
+use tower_service::Service;
+
+#[derive(Debug, Clone, Copy)]
+pub struct MultiplexLayer<A, P> {
+    first: A,
+    picker: P,
+}
+
+impl<A, P> MultiplexLayer<A, P> {
+    pub fn new(first: A, picker: P) -> Self {
+        Self { picker, first }
+    }
+}
+
+impl<P, A, B> Layer<B> for MultiplexLayer<A, P>
+where
+    P: Clone,
+    A: Clone,
+{
+    type Service = Multiplex<A, B, P>;
+
+    fn layer(&self, inner: B) -> Self::Service {
+        Multiplex::new(self.first.clone(), inner, self.picker.clone())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Multiplex<A, B, P> {
+    picker: P,
+    first: A,
+    first_ready: bool,
+    second: B,
+    second_ready: bool,
+}
+
+impl<A, B, P> Multiplex<A, B, P> {
+    pub fn new(first: A, second: B, picker: P) -> Self {
+        Self {
+            picker,
+            first,
+            first_ready: false,
+            second,
+            second_ready: false,
+        }
+    }
+}
+
+pub trait Picker<R: ?Sized> {
+    fn pick(&mut self, req: &R) -> Pick;
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum Pick {
+    First,
+    Second,
+}
+
+impl<F, T> Picker<T> for F
+where
+    F: FnMut(&T) -> Pick,
+{
+    fn pick(&mut self, req: &T) -> Pick {
+        self(req)
+    }
+}
+
+impl<R, P, A, B> Service<R> for Multiplex<A, B, P>
+where
+    P: Picker<R>,
+    A: Service<R>,
+    A::Error: Into<BoxError>,
+    B: Service<R, Response = A::Response>,
+    B::Error: Into<BoxError>,
+{
+    type Response = A::Response;
+    type Error = BoxError;
+    type Future = ResponseFuture<A::Future, B::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        if !self.first_ready {
+            ready!(self.first.poll_ready(cx).map_err(Into::into)?);
+            self.first_ready = true;
+        }
+
+        if !self.second_ready {
+            ready!(self.second.poll_ready(cx).map_err(Into::into)?);
+            self.second_ready = true;
+        }
+
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
+        assert!(
+            self.first_ready && self.second_ready,
+            "Multiplex must wait for all services to be ready. Did you forget to call poll_ready()?",
+        );
+
+        self.first_ready = false;
+        self.second_ready = false;
+
+        let future = match self.picker.pick(&req) {
+            Pick::First => Either::A(self.first.call(req)),
+            Pick::Second => Either::B(self.second.call(req)),
+        };
+
+        ResponseFuture { inner: future }
+    }
+}
+
+#[pin_project]
+#[derive(Debug)]
+pub struct ResponseFuture<AF, BF> {
+    #[pin]
+    inner: Either<AF, BF>,
+}
+
+impl<AFut, AErr, BFut, BErr, Res> Future for ResponseFuture<AFut, BFut>
+where
+    AFut: Future<Output = Result<Res, AErr>>,
+    BFut: Future<Output = Result<Res, BErr>>,
+    AErr: Into<BoxError>,
+    BErr: Into<BoxError>,
+{
+    type Output = Result<Res, BoxError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().inner.poll(cx)
+    }
+}

--- a/tower/src/multiplex/mod.rs
+++ b/tower/src/multiplex/mod.rs
@@ -1,3 +1,5 @@
+// TODO(david): docs
+
 use crate::util::Either;
 use crate::BoxError;
 use futures_util::ready;
@@ -50,10 +52,16 @@ impl<A, B, P> Multiplex<A, B, P> {
             second_ready: false,
         }
     }
+
+    // TODO(david): accessors for `first` and `second`
 }
 
 pub trait Picker<R: ?Sized> {
+    // `&mut R` so we can insert into request extensions while picking a service. Useful for
+    // parsing the URI
     fn pick(&mut self, req: &mut R) -> Pick;
+
+    // TODO(david): add `and` and `or` methods for composing pickers
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/tower/src/multiplex/mod.rs
+++ b/tower/src/multiplex/mod.rs
@@ -1,156 +1,19 @@
-// TODO(david): docs
+//! TODO(david): docs
 
-use crate::util::Either;
-use crate::BoxError;
-use futures_util::ready;
-use pin_project::pin_project;
-use std::task::{Context, Poll};
-use std::{future::Future, pin::Pin};
-use tower_layer::Layer;
-use tower_service::Service;
+mod layer;
+mod picker;
+mod service;
 
-#[derive(Debug, Clone, Copy)]
-pub struct MultiplexLayer<A, P> {
-    first: A,
-    picker: P,
-}
-
-impl<A, P> MultiplexLayer<A, P> {
-    pub fn new(first: A, picker: P) -> Self {
-        Self { picker, first }
-    }
-}
-
-impl<P, A, B> Layer<B> for MultiplexLayer<A, P>
-where
-    P: Clone,
-    A: Clone,
-{
-    type Service = Multiplex<A, B, P>;
-
-    fn layer(&self, inner: B) -> Self::Service {
-        Multiplex::new(self.first.clone(), inner, self.picker.clone())
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct Multiplex<A, B, P> {
-    picker: P,
-    first: A,
-    first_ready: bool,
-    second: B,
-    second_ready: bool,
-}
-
-impl<A, B, P> Multiplex<A, B, P> {
-    pub fn new(first: A, second: B, picker: P) -> Self {
-        Self {
-            picker,
-            first,
-            first_ready: false,
-            second,
-            second_ready: false,
-        }
-    }
-
-    // TODO(david): accessors for `first` and `second`
-}
-
-pub trait Picker<R: ?Sized> {
-    // `&mut R` so we can insert into request extensions while picking a service. Useful for
-    // parsing the URI
-    fn pick(&mut self, req: &mut R) -> Pick;
-
-    // TODO(david): add `and` and `or` methods for composing pickers
-}
-
-#[derive(Debug, Copy, Clone)]
-pub enum Pick {
-    First,
-    Second,
-}
-
-impl<F, T> Picker<T> for F
-where
-    F: FnMut(&mut T) -> Pick,
-{
-    fn pick(&mut self, req: &mut T) -> Pick {
-        self(req)
-    }
-}
-
-impl<R, P, A, B> Service<R> for Multiplex<A, B, P>
-where
-    P: Picker<R>,
-    A: Service<R>,
-    A::Error: Into<BoxError>,
-    B: Service<R, Response = A::Response>,
-    B::Error: Into<BoxError>,
-{
-    type Response = A::Response;
-    type Error = BoxError;
-    type Future = ResponseFuture<A::Future, B::Future>;
-
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        if !self.first_ready {
-            ready!(self.first.poll_ready(cx).map_err(Into::into)?);
-            self.first_ready = true;
-        }
-
-        if !self.second_ready {
-            ready!(self.second.poll_ready(cx).map_err(Into::into)?);
-            self.second_ready = true;
-        }
-
-        Poll::Ready(Ok(()))
-    }
-
-    fn call(&mut self, mut req: R) -> Self::Future {
-        assert!(
-            self.first_ready && self.second_ready,
-            "Multiplex must wait for all services to be ready. Did you forget to call poll_ready()?",
-        );
-
-        let future = match self.picker.pick(&mut req) {
-            Pick::First => {
-                self.first_ready = false;
-                Either::A(self.first.call(req))
-            }
-            Pick::Second => {
-                self.second_ready = false;
-                Either::B(self.second.call(req))
-            }
-        };
-
-        ResponseFuture { inner: future }
-    }
-}
-
-#[pin_project]
-#[derive(Debug)]
-pub struct ResponseFuture<AF, BF> {
-    #[pin]
-    inner: Either<AF, BF>,
-}
-
-impl<AFut, AErr, BFut, BErr, Res> Future for ResponseFuture<AFut, BFut>
-where
-    AFut: Future<Output = Result<Res, AErr>>,
-    BFut: Future<Output = Result<Res, BErr>>,
-    AErr: Into<BoxError>,
-    BErr: Into<BoxError>,
-{
-    type Output = Result<Res, BoxError>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.project().inner.poll(cx)
-    }
-}
+pub use self::{
+    layer::MultiplexLayer,
+    picker::{Pick, Picker},
+    service::{Multiplex, ResponseFuture},
+};
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{service_fn, Service, ServiceBuilder, ServiceExt};
+    use crate::{service_fn, BoxError, Service, ServiceBuilder, ServiceExt};
 
     #[tokio::test]
     async fn basic() {

--- a/tower/src/multiplex/picker.rs
+++ b/tower/src/multiplex/picker.rs
@@ -1,0 +1,98 @@
+/// TODO(david): docs
+pub trait Picker<R: ?Sized> {
+    // `&mut R` so we can insert into request extensions while picking a service. Useful for
+    // parsing the URI
+    /// TODO(david): docs
+    fn pick(&mut self, req: &mut R) -> Pick;
+
+    /// Combine two `Picker`s into one. Will return `Pick::First` if _both_ returns `Pick::First`,
+    /// otherwise `Pick::Second`.
+    fn and<P>(self, next: P) -> And<Self, P>
+    where
+        Self: Sized,
+        P: Picker<R>,
+    {
+        And {
+            left: self,
+            right: next,
+        }
+    }
+
+    /// Combine two `Picker`s into one. Will return `Pick::First` if _either_ returns `Pick::First`,
+    /// otherwise `Pick::Second`.
+    fn or<P>(self, next: P) -> Or<Self, P>
+    where
+        Self: Sized,
+        P: Picker<R>,
+    {
+        Or {
+            left: self,
+            right: next,
+        }
+    }
+}
+
+impl<F, T> Picker<T> for F
+where
+    F: FnMut(&mut T) -> Pick,
+{
+    fn pick(&mut self, req: &mut T) -> Pick {
+        self(req)
+    }
+}
+
+/// TODO(david): docs
+#[derive(Debug, Copy, Clone)]
+pub enum Pick {
+    /// TODO(david): docs
+    First,
+    /// TODO(david): docs
+    Second,
+}
+
+/// TODO(david): docs
+#[derive(Debug, Copy, Clone)]
+pub struct And<A, B> {
+    left: A,
+    right: B,
+}
+
+impl<R, A, B> Picker<R> for And<A, B>
+where
+    A: Picker<R>,
+    B: Picker<R>,
+{
+    fn pick(&mut self, req: &mut R) -> Pick {
+        let left_pick = self.left.pick(req);
+        let right_pick = self.right.pick(req);
+
+        if let (Pick::First, Pick::First) = (left_pick, right_pick) {
+            Pick::First
+        } else {
+            Pick::Second
+        }
+    }
+}
+
+/// TODO(david): docs
+#[derive(Debug, Copy, Clone)]
+pub struct Or<A, B> {
+    left: A,
+    right: B,
+}
+
+impl<R, A, B> Picker<R> for Or<A, B>
+where
+    A: Picker<R>,
+    B: Picker<R>,
+{
+    fn pick(&mut self, req: &mut R) -> Pick {
+        let left_pick = self.left.pick(req);
+        let right_pick = self.right.pick(req);
+
+        match (left_pick, right_pick) {
+            (Pick::First, _) | (_, Pick::First) => Pick::First,
+            _ => Pick::Second,
+        }
+    }
+}

--- a/tower/src/multiplex/picker.rs
+++ b/tower/src/multiplex/picker.rs
@@ -96,3 +96,24 @@ where
         }
     }
 }
+
+/// TODO(david): docs
+pub fn not<P>(picker: P) -> Not<P> {
+    Not(picker)
+}
+
+/// TODO(david): docs
+#[derive(Debug, Copy, Clone)]
+pub struct Not<P>(P);
+
+impl<P, R> Picker<R> for Not<P>
+where
+    P: Picker<R>,
+{
+    fn pick(&mut self, req: &mut R) -> Pick {
+        match self.0.pick(req) {
+            Pick::First => Pick::Second,
+            Pick::Second => Pick::First,
+        }
+    }
+}

--- a/tower/src/multiplex/picker.rs
+++ b/tower/src/multiplex/picker.rs
@@ -1,3 +1,5 @@
+//! TODO(david): docs
+
 /// TODO(david): docs
 pub trait Picker<R: ?Sized> {
     // `&mut R` so we can insert into request extensions while picking a service. Useful for
@@ -114,6 +116,28 @@ where
         match self.0.pick(req) {
             Pick::First => Pick::Second,
             Pick::Second => Pick::First,
+        }
+    }
+}
+
+/// TODO(david): docs
+pub fn from_bool_fn<F>(f: F) -> FromBoolFn<F> {
+    FromBoolFn(f)
+}
+
+/// TODO(david): docs
+#[derive(Debug, Copy, Clone)]
+pub struct FromBoolFn<F>(F);
+
+impl<R, F> Picker<R> for FromBoolFn<F>
+where
+    F: FnMut(&mut R) -> bool,
+{
+    fn pick(&mut self, req: &mut R) -> Pick {
+        if (self.0)(req) {
+            Pick::First
+        } else {
+            Pick::Second
         }
     }
 }

--- a/tower/src/multiplex/service.rs
+++ b/tower/src/multiplex/service.rs
@@ -1,0 +1,100 @@
+use super::{Pick, Picker};
+use crate::util::Either;
+use crate::BoxError;
+use futures_util::ready;
+use pin_project::pin_project;
+use std::task::{Context, Poll};
+use std::{future::Future, pin::Pin};
+use tower_service::Service;
+
+/// TODO(david): docs
+#[derive(Debug, Clone, Copy)]
+pub struct Multiplex<A, B, P> {
+    picker: P,
+    first: A,
+    first_ready: bool,
+    second: B,
+    second_ready: bool,
+}
+
+impl<A, B, P> Multiplex<A, B, P> {
+    /// TODO(david): docs
+    pub fn new(first: A, second: B, picker: P) -> Self {
+        Self {
+            picker,
+            first,
+            first_ready: false,
+            second,
+            second_ready: false,
+        }
+    }
+}
+
+impl<R, P, A, B> Service<R> for Multiplex<A, B, P>
+where
+    P: Picker<R>,
+    A: Service<R>,
+    A::Error: Into<BoxError>,
+    B: Service<R, Response = A::Response>,
+    B::Error: Into<BoxError>,
+{
+    type Response = A::Response;
+    type Error = BoxError;
+    type Future = ResponseFuture<A::Future, B::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        if !self.first_ready {
+            ready!(self.first.poll_ready(cx).map_err(Into::into)?);
+            self.first_ready = true;
+        }
+
+        if !self.second_ready {
+            ready!(self.second.poll_ready(cx).map_err(Into::into)?);
+            self.second_ready = true;
+        }
+
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, mut req: R) -> Self::Future {
+        assert!(
+            self.first_ready && self.second_ready,
+            "Multiplex must wait for all services to be ready. Did you forget to call poll_ready()?",
+        );
+
+        let future = match self.picker.pick(&mut req) {
+            Pick::First => {
+                self.first_ready = false;
+                Either::A(self.first.call(req))
+            }
+            Pick::Second => {
+                self.second_ready = false;
+                Either::B(self.second.call(req))
+            }
+        };
+
+        ResponseFuture { inner: future }
+    }
+}
+
+/// TODO(david): docs
+#[pin_project]
+#[derive(Debug)]
+pub struct ResponseFuture<AF, BF> {
+    #[pin]
+    inner: Either<AF, BF>,
+}
+
+impl<AFut, AErr, BFut, BErr, Res> Future for ResponseFuture<AFut, BFut>
+where
+    AFut: Future<Output = Result<Res, AErr>>,
+    BFut: Future<Output = Result<Res, BErr>>,
+    AErr: Into<BoxError>,
+    BErr: Into<BoxError>,
+{
+    type Output = Result<Res, BoxError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().inner.poll(cx)
+    }
+}


### PR DESCRIPTION
This is a middleware that I've been thinking about for some time and I would like to hear what people think.

For tower-http I would like to provide some basic routing functionality. The goal isn't to compete with warp but to provide something for users who just want to route requests between a couple services.

That can in theory be done with `Steer` but I think it has a few limitations:

- The services must all be the same type.
- You cannot use `ServiceBuilder` to compose things. You have to build each service separately and then put them all in a `Vec`.
- Returning indexes into a `Vec` feels quite low level and error prone.

`Multiplex` serves a similar purpose but only dispatches to one of two services. It has a `P: Picker` that returns `Pick::First` or `Pick::Second` which is how we know which service to call.

This would allow you compose a service by doing something like this (where `method` and `path` are methods for building pickers that work on `Request<B>`):

```rust
ServiceBuilder::new()
    .layer(CompressionLayer::new()) // middleware applied to all lower services
    .multiplex(service_fn(root), method(Method::GET).and(path("/")))
    .multiplex(service_fn(users_index), method(Method::GET).and(path("/users")))
    .multiplex(service_fn(users_show), method(Method::GET).and(path("/users/:id")))
    .multiplex(service_fn(users_create), method(Method::POST).and(path("/users")))
    .service(service_fn(not_found));
```

The main downside to this API is that you have `O(n)` time to route a request, where `n` is the number of services. Getting to the bottom service requires checking all the ones above it. `Steer` doesn't have that limitation. However afaik warp works the same way since filters are built and composed individually, though I might be mistaking. In practice I don't think this would be a problem unless users have well beyond 100 leaf services.