### PR TITLE
builder: Add `ServiceBuilder::service_fn`

### DIFF
--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **builder**: Add `ServiceBuilder::map_future` for transforming the futures produced
   by a service.
+- **builder**: Add `ServiceBuilder::service_fn` for applying `Layer` to an
+  async function using `util::service_fn`.
 
 # 0.4.5 (February 10, 2021)
 

--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **builder**: Add `ServiceBuilder::map_future` for transforming the futures produced
   by a service.
-- **builder**: Add `ServiceBuilder::service_fn` for applying `Layer` to an
+- **builder**: Add `ServiceBuilder::service_fn` for applying `Layer`s to an
   async function using `util::service_fn`.
 
 # 0.4.5 (February 10, 2021)

--- a/tower/src/builder/mod.rs
+++ b/tower/src/builder/mod.rs
@@ -459,6 +459,22 @@ impl<L> ServiceBuilder<L> {
     {
         self.layer.layer(service)
     }
+
+    /// Wrap the async function `F` with the middleware provided by this [`ServiceBuilder`]'s
+    /// [`Layer`]'s, returning a new [`Service`].
+    ///
+    /// This is a convenience for doing `.service(service_fn(handler_function))`.
+    ///
+    /// [`Layer`]: crate::Layer
+    /// [`Service`]: crate::Service
+    #[cfg(feature = "util")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "util")))]
+    pub fn service_fn<F>(self, f: F) -> L::Service
+    where
+        L: Layer<crate::util::ServiceFn<F>>,
+    {
+        self.service(crate::util::service_fn(f))
+    }
 }
 
 impl<L: fmt::Debug> fmt::Debug for ServiceBuilder<L> {

--- a/tower/src/builder/mod.rs
+++ b/tower/src/builder/mod.rs
@@ -474,20 +474,22 @@ impl<L> ServiceBuilder<L> {
     ///
     /// This is a convenience method which is equivalent to calling
     /// [`ServiceBuilder::service`] with a [`service_fn`], like this:
+    ///
     /// ```rust
-    /// # use tower::{ServiceBuilder, ServiceFn};
+    /// # use tower::{ServiceBuilder, service_fn};
     /// # async fn handler_fn(_: ()) -> Result<(), ()> { Ok(()) }
     /// # let _ = {
     /// ServiceBuilder::new()
     ///     // ...
     ///     .service(service_fn(handler_fn))
     /// # };
+    /// ```
     ///
     /// # Example
     ///
     /// ```rust
     /// use std::time::Duration;
-    /// use tower::{ServiceBuilder, ServiceExt, BoxError};
+    /// use tower::{ServiceBuilder, ServiceExt, BoxError, service_fn};
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), BoxError> {

--- a/tower/src/builder/mod.rs
+++ b/tower/src/builder/mod.rs
@@ -461,9 +461,18 @@ impl<L> ServiceBuilder<L> {
     }
 
     /// Wrap the async function `F` with the middleware provided by this [`ServiceBuilder`]'s
-    /// [`Layer`]'s, returning a new [`Service`].
+    /// [`Layer`]s, returning a new [`Service`].
     ///
-    /// This is a convenience for doing [`.service(service_fn(handler_function))`][`service_fn`].
+    /// This is a convenience method which is equivalent to calling
+    /// [`ServiceBuilder::service`] with a [`service_fn`], like this:
+    /// ```rust
+    /// # use tower::{ServiceBuilder, ServiceFn};
+    /// # async fn handler_fn(_: ()) -> Result<(), ()> { Ok(()) }
+    /// # let _ = {
+    /// ServiceBuilder::new()
+    ///     // ...
+    ///     .service(service_fn(handler_fn))
+    /// # };
     ///
     /// # Example
     ///

--- a/tower/src/builder/mod.rs
+++ b/tower/src/builder/mod.rs
@@ -463,10 +463,35 @@ impl<L> ServiceBuilder<L> {
     /// Wrap the async function `F` with the middleware provided by this [`ServiceBuilder`]'s
     /// [`Layer`]'s, returning a new [`Service`].
     ///
-    /// This is a convenience for doing `.service(service_fn(handler_function))`.
+    /// This is a convenience for doing [`.service(service_fn(handler_function))`][`service_fn`].
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use std::time::Duration;
+    /// use tower::{ServiceBuilder, ServiceExt, BoxError};
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), BoxError> {
+    /// async fn handle(request: &'static str) -> Result<&'static str, BoxError> {
+    ///    Ok(request)
+    /// }
+    ///
+    /// let svc = ServiceBuilder::new()
+    ///     .buffer(1024)
+    ///     .timeout(Duration::from_secs(10))
+    ///     .service_fn(handle);
+    ///
+    /// let response = svc.oneshot("foo").await?;
+    ///
+    /// assert_eq!(response, "foo");
+    /// # Ok(())
+    /// # }
+    /// ```
     ///
     /// [`Layer`]: crate::Layer
     /// [`Service`]: crate::Service
+    /// [`service_fn`]: crate::service_fn
     #[cfg(feature = "util")]
     #[cfg_attr(docsrs, doc(cfg(feature = "util")))]
     pub fn service_fn<F>(self, f: F) -> L::Service


### PR DESCRIPTION
A small convenience for doing `.service(service_fn(handler_function))`.