### PR TITLE
Rename `ServiceExt::ready_and` to `ServiceExt::ready`

### DIFF
--- a/tower/src/buffer/mod.rs
+++ b/tower/src/buffer/mod.rs
@@ -27,7 +27,7 @@
 //!         let mut svc = svc.clone();
 //!         tokio::spawn(async move {
 //!             for i in 0usize.. {
-//!                 svc.ready_and().await.expect("service crashed").call(i).await;
+//!                 svc.ready().await.expect("service crashed").call(i).await;
 //!             }
 //!         });
 //!     }

--- a/tower/src/load/mod.rs
+++ b/tower/src/load/mod.rs
@@ -47,9 +47,9 @@
 //!     S2: Load<Metric = S1::Metric> + Service<R, Response = S1::Response, Error = S1::Error>
 //! {
 //!     if svc1.load() < svc2.load() {
-//!         svc1.ready_and().await?.call(request).await
+//!         svc1.ready().await?.call(request).await
 //!     } else {
-//!         svc2.ready_and().await?.call(request).await
+//!         svc2.ready().await?.call(request).await
 //!     }
 //! }
 //! ```

--- a/tower/src/steer/mod.rs
+++ b/tower/src/steer/mod.rs
@@ -56,12 +56,12 @@
 //!
 //! // This request will get sent to `root`
 //! let req = Request::get("/").body(String::new()).unwrap();
-//! let res = svc.ready_and().await?.call(req).await?;
+//! let res = svc.ready().await?.call(req).await?;
 //! assert_eq!(res.into_body(), "Hello, World!");
 //!
 //! // This request will get sent to `not_found`
 //! let req = Request::get("/does/not/exist").body(String::new()).unwrap();
-//! let res = svc.ready_and().await?.call(req).await?;
+//! let res = svc.ready().await?.call(req).await?;
 //! assert_eq!(res.status(), StatusCode::NOT_FOUND);
 //! assert_eq!(res.into_body(), "");
 //! #

--- a/tower/src/util/future_service.rs
+++ b/tower/src/util/future_service.rs
@@ -31,7 +31,7 @@ use tower_service::Service;
 ///
 /// // Now, when we wait for the service to become ready, it will
 /// // drive the future to completion internally.
-/// let svc = svc.ready_and().await.unwrap();
+/// let svc = svc.ready().await.unwrap();
 /// let res = svc.call(()).await.unwrap();
 /// # };
 /// # }
@@ -87,7 +87,7 @@ impl<F, S> FutureService<F, S> {
     ///
     /// // Now, when we wait for the service to become ready, it will
     /// // drive the future to completion internally.
-    /// let svc = svc.ready_and().await.unwrap();
+    /// let svc = svc.ready().await.unwrap();
     /// let res = svc.call(()).await.unwrap();
     /// # };
     /// # }
@@ -188,7 +188,7 @@ mod tests {
             "FutureService { state: State::Future(<futures_util::future::ready::Ready<core::result::Result<tower::util::future_service::tests::DebugService, core::convert::Infallible>>>) }"
         );
 
-        pending_svc.ready_and().await.unwrap();
+        pending_svc.ready().await.unwrap();
 
         assert_eq!(
             format!("{:?}", pending_svc),

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -30,7 +30,7 @@ pub use self::{
     map_result::{MapResult, MapResultLayer},
     oneshot::Oneshot,
     optional::Optional,
-    ready::{ReadyAnd, ReadyOneshot},
+    ready::{Ready, ReadyOneshot},
     service_fn::{service_fn, ServiceFn},
     then::{Then, ThenLayer},
 };
@@ -61,11 +61,11 @@ pub mod future {
 /// adapters
 pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// Yields a mutable reference to the service when it is ready to accept a request.
-    fn ready_and(&mut self) -> ReadyAnd<'_, Self, Request>
+    fn ready(&mut self) -> Ready<'_, Self, Request>
     where
         Self: Sized,
     {
-        ReadyAnd::new(self)
+        Ready::new(self)
     }
 
     /// Yields the service when it is ready to accept a request.
@@ -222,7 +222,7 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// // Call the new service
     /// let id = 13;
     /// let name = new_service
-    ///     .ready_and()
+    ///     .ready()
     ///     .await?
     ///     .call(id)
     ///     .await?;
@@ -289,7 +289,7 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// // Call the new service
     /// let id = 13;
     /// let code = new_service
-    ///     .ready_and()
+    ///     .ready()
     ///     .await?
     ///     .call(id)
     ///     .await
@@ -390,7 +390,7 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// // Call the new service
     /// let id = 13;
     /// let name = new_service
-    ///     .ready_and()
+    ///     .ready()
     ///     .await?
     ///     .call(id)
     ///     .await?;
@@ -460,7 +460,7 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// // Call the new service
     /// let id = 13;
     /// let record = new_service
-    ///     .ready_and()
+    ///     .ready()
     ///     .await?
     ///     .call(id)
     ///     .await?;
@@ -511,7 +511,7 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// // Call the new service
     /// let id = 13;
     /// let response = new_service
-    ///     .ready_and()
+    ///     .ready()
     ///     .await?
     ///     .call(id)
     ///     .await;
@@ -579,7 +579,7 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// // Call the new service
     /// let id = 13;
     /// let response = new_service
-    ///     .ready_and()
+    ///     .ready()
     ///     .await?
     ///     .call(id)
     ///     .await;
@@ -648,7 +648,7 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// // Call the new service
     /// let id = "13";
     /// let response = new_service
-    ///     .ready_and()
+    ///     .ready()
     ///     .await?
     ///     .call(id)
     ///     .await;
@@ -735,7 +735,7 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// let id = 13;
     /// # let id: u32 = id;
     /// let response = new_service
-    ///     .ready_and()
+    ///     .ready()
     ///     .await?
     ///     .call(id)
     ///     .await;
@@ -837,7 +837,7 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// // Call the new service
     /// let id = 13;
     /// let record = new_service
-    ///     .ready_and()
+    ///     .ready()
     ///     .await?
     ///     .call(id)
     ///     .await?;
@@ -915,7 +915,7 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// // Call the new service
     /// let id = 13;
     /// let record = new_service
-    ///     .ready_and()
+    ///     .ready()
     ///     .await?
     ///     .call(id)
     ///     .await?;

--- a/tower/src/util/ready.rs
+++ b/tower/src/util/ready.rs
@@ -64,15 +64,15 @@ where
 
 /// A future that yields a mutable reference to the service when it is ready to accept a request.
 ///
-/// [`ReadyAnd`] values are produced by [`ServiceExt::ready_and`].
+/// [`Ready`] values are produced by [`ServiceExt::ready`].
 ///
-/// [`ServiceExt::ready_and`]: crate::util::ServiceExt::ready_and
-pub struct ReadyAnd<'a, T, Request>(ReadyOneshot<&'a mut T, Request>);
+/// [`ServiceExt::ready`]: crate::util::ServiceExt::ready
+pub struct Ready<'a, T, Request>(ReadyOneshot<&'a mut T, Request>);
 
 // Safety: This is safe for the same reason that the impl for ReadyOneshot is safe.
-impl<'a, T, Request> Unpin for ReadyAnd<'a, T, Request> {}
+impl<'a, T, Request> Unpin for Ready<'a, T, Request> {}
 
-impl<'a, T, Request> ReadyAnd<'a, T, Request>
+impl<'a, T, Request> Ready<'a, T, Request>
 where
     T: Service<Request>,
 {
@@ -82,7 +82,7 @@ where
     }
 }
 
-impl<'a, T, Request> Future for ReadyAnd<'a, T, Request>
+impl<'a, T, Request> Future for Ready<'a, T, Request>
 where
     T: Service<Request>,
 {
@@ -93,11 +93,11 @@ where
     }
 }
 
-impl<'a, T, Request> fmt::Debug for ReadyAnd<'a, T, Request>
+impl<'a, T, Request> fmt::Debug for Ready<'a, T, Request>
 where
     T: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_tuple("ReadyAnd").field(&self.0).finish()
+        f.debug_tuple("Ready").field(&self.0).finish()
     }
 }

--- a/tower/tests/builder.rs
+++ b/tower/tests/builder.rs
@@ -28,7 +28,7 @@ async fn builder_service() {
     // allow a request through
     handle.allow(1);
 
-    let fut = client.ready_and().await.unwrap().call("hello");
+    let fut = client.ready().await.unwrap().call("hello");
     assert_request_eq!(handle, true).send_response("world");
     assert_eq!(fut.await.unwrap(), true);
 }


### PR DESCRIPTION
This PR renames:
- `ServiceExt::ready_and` to `ServiceExt::ready`
- the `ReadyAnd` future to `Ready`
-  the associated documentation to refer to `ServiceExt::ready` and `ReadyAnd`.

My recollection of the original conversation surrounding the introduction of the `ServiceExt::ready_and` combinator in https://github.com/tower-rs/tower/pull/427 was that it was meant to be a temporary workaround for the unchainable `ServiceExt::ready` combinator until the next breaking release of the Tower crate. The unchainable `ServiceExt::ready` combinator was removed, but `ServiceExt::ready_and` was not renamed. I believe, but am not 100% sure, that this was an oversight. 

I also recognize that this PR might have a large impact. To reduce the impact, I'd be happy to modify this PR to introduce `ServiceExt::ready` and deprecate `ServiceExt::ready_and`.