### PR TITLE
util: Add `BoxLayer`

### DIFF
--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **builder**: Add `ServiceBuilder::map_future` for transforming the futures produced
-  by a service.
+- **util**: Add `BoxLayer` for creating boxed `Layer` trait objects.
 
 # 0.4.5 (February 10, 2021)
 

--- a/tower/src/util/boxed/layer.rs
+++ b/tower/src/util/boxed/layer.rs
@@ -3,14 +3,20 @@ use std::{fmt, sync::Arc};
 use tower_layer::{layer_fn, Layer};
 use tower_service::Service;
 
-/// A boxed `Layer` trait object.
+/// A boxed [`Layer`] trait object.
 ///
-/// [`BoxLayer`] turns a layer into a trait object, allowing the output service to be dynamic.
+/// [`BoxLayer`] turns a layer into a trait object, allowing both the [`Layer`] itself
+/// and the output [`Service`] to be dynamic, while having consistent types.
+///
+/// This [`Layer`] produces [`BoxService`] instances erasing the type of the 
+/// [`Service`] produced by the wrapped [`Layer`].
 ///
 /// # Example
 ///
-/// `BoxLayer` can for example be useful to create layers dynamically that otherwise wouldn't have
-/// the same types.
+/// `BoxLayer` can, for example, be useful to create layers dynamically that otherwise wouldn't have
+/// the same types. In this example, we include a [`Timeout`] layer
+/// only if an environment variable is set. We can use `BoxLayer`
+/// to return a consistent type regardless of runtime configuration:
 ///
 /// ```
 /// use std::time::Duration;
@@ -40,6 +46,11 @@ use tower_service::Service;
 ///     }
 /// }
 /// ```
+///
+/// [`Layer`]: tower_layer::Layer
+/// [`Service`]: tower_service::Service
+/// [`BoxService`]: super::BoxService
+/// [`Timeout`]: crate::timeout
 pub struct BoxLayer<In, T, U, E> {
     boxed: Arc<dyn Layer<In, Service = BoxService<T, U, E>> + Send + Sync + 'static>,
 }

--- a/tower/src/util/boxed/layer.rs
+++ b/tower/src/util/boxed/layer.rs
@@ -1,0 +1,86 @@
+use crate::util::BoxService;
+use std::{fmt, sync::Arc};
+use tower_layer::{layer_fn, Layer};
+use tower_service::Service;
+
+/// A boxed `Layer` trait object.
+///
+/// [`BoxLayer`] turns a layer into a trait object, allowing the output service to be dynamic.
+///
+/// # Example
+///
+/// `BoxLayer` can for example be useful to create layers dynamically that otherwise wouldn't have
+/// the same types.
+///
+/// ```
+/// use std::time::Duration;
+/// use tower::{Service, ServiceBuilder, BoxError, util::BoxLayer};
+///
+/// fn common_layer<S, T>() -> BoxLayer<S, T, S::Response, BoxError>
+/// where
+///     S: Service<T> + Send + 'static,
+///     S::Future: Send + 'static,
+///     S::Error: Into<BoxError> + 'static,
+/// {
+///     let builder = ServiceBuilder::new()
+///         .concurrency_limit(100);
+///
+///     if std::env::var("SET_TIMEOUT").is_ok() {
+///         let layer = builder
+///             .timeout(Duration::from_secs(30))
+///             .into_inner();
+///
+///         BoxLayer::new(layer)
+///     } else {
+///         let layer = builder
+///             .map_err(Into::into)
+///             .into_inner();
+///
+///         BoxLayer::new(layer)
+///     }
+/// }
+/// ```
+pub struct BoxLayer<In, T, U, E> {
+    boxed: Arc<dyn Layer<In, Service = BoxService<T, U, E>> + Send + Sync + 'static>,
+}
+
+impl<In, T, U, E> BoxLayer<In, T, U, E> {
+    /// Create a new [`BoxLayer`].
+    pub fn new<L>(inner_layer: L) -> Self
+    where
+        L: Layer<In> + Send + Sync + 'static,
+        L::Service: Service<T, Response = U, Error = E> + Send + 'static,
+        <L::Service as Service<T>>::Future: Send + 'static,
+    {
+        let layer = layer_fn(move |inner: In| {
+            let out = inner_layer.layer(inner);
+            BoxService::new(out)
+        });
+
+        Self {
+            boxed: Arc::new(layer),
+        }
+    }
+}
+
+impl<In, T, U, E> Layer<In> for BoxLayer<In, T, U, E> {
+    type Service = BoxService<T, U, E>;
+
+    fn layer(&self, inner: In) -> Self::Service {
+        self.boxed.layer(inner)
+    }
+}
+
+impl<In, T, U, E> Clone for BoxLayer<In, T, U, E> {
+    fn clone(&self) -> Self {
+        Self {
+            boxed: Arc::clone(&self.boxed),
+        }
+    }
+}
+
+impl<In, T, U, E> fmt::Debug for BoxLayer<In, T, U, E> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("BoxLayer").finish()
+    }
+}

--- a/tower/src/util/boxed/layer.rs
+++ b/tower/src/util/boxed/layer.rs
@@ -8,7 +8,7 @@ use tower_service::Service;
 /// [`BoxLayer`] turns a layer into a trait object, allowing both the [`Layer`] itself
 /// and the output [`Service`] to be dynamic, while having consistent types.
 ///
-/// This [`Layer`] produces [`BoxService`] instances erasing the type of the 
+/// This [`Layer`] produces [`BoxService`] instances erasing the type of the
 /// [`Service`] produced by the wrapped [`Layer`].
 ///
 /// # Example

--- a/tower/src/util/boxed/mod.rs
+++ b/tower/src/util/boxed/mod.rs
@@ -32,8 +32,9 @@
 //! [`Service`]: crate::Service
 //! [`Rc`]: std::rc::Rc
 
+mod layer;
 mod sync;
 mod unsync;
 
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-pub use self::{sync::BoxService, unsync::UnsyncBoxService};
+pub use self::{layer::BoxLayer, sync::BoxService, unsync::UnsyncBoxService};

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -20,7 +20,7 @@ mod then;
 
 pub use self::{
     and_then::{AndThen, AndThenLayer},
-    boxed::{BoxService, UnsyncBoxService},
+    boxed::{BoxLayer, BoxService, UnsyncBoxService},
     either::Either,
     future_service::{future_service, FutureService},
     map_err::{MapErr, MapErrLayer},


### PR DESCRIPTION
I've run into a use case where I need to return a `Layer` with a complex type from a function. I previously used `impl Layer<S, Service = impl Service<...>>` but that impacted compile times quite significantly. Boxing the `Layer` fixed it. Thought it made sense to upstream.

The `Send + Sync + 'static` bounds on the inner `dyn Layer` were necessary to get it working with hyper.