### PR TITLE
chore: remove unnecessary `mut` and imports in tests

### DIFF
--- a/tower/tests/buffer/main.rs
+++ b/tower/tests/buffer/main.rs
@@ -348,7 +348,7 @@ async fn wakes_pending_waiters_on_failure() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn propagates_trace_spans() {
-    use tower::{util::ServiceExt, Service};
+    use tower::util::ServiceExt;
     use tracing::Instrument;
 
     let _t = support::trace_init();
@@ -356,7 +356,7 @@ async fn propagates_trace_spans() {
     let span = tracing::info_span!("my_span");
 
     let service = support::AssertSpanSvc::new(span.clone());
-    let (mut service, worker) = Buffer::pair(service, 5);
+    let (service, worker) = Buffer::pair(service, 5);
     let worker = tokio::spawn(worker);
 
     let result = tokio::spawn(service.oneshot(()).instrument(span));

--- a/tower/tests/spawn_ready/main.rs
+++ b/tower/tests/spawn_ready/main.rs
@@ -46,7 +46,7 @@ async fn when_inner_fails() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn propagates_trace_spans() {
-    use tower::{util::ServiceExt, Service};
+    use tower::util::ServiceExt;
     use tracing::Instrument;
 
     let _t = support::trace_init();
@@ -54,7 +54,7 @@ async fn propagates_trace_spans() {
     let span = tracing::info_span!("my_span");
 
     let service = support::AssertSpanSvc::new(span.clone());
-    let mut service = SpawnReady::new(service);
+    let service = SpawnReady::new(service);
     let result = tokio::spawn(service.oneshot(()).instrument(span));
 
     result.await.expect("service panicked").expect("failed");


### PR DESCRIPTION
I noticed some of these warnings were going off in #567; I figured that I should try to remove them.