### PR TITLE
Allow reusable concurrency limit via GlobalConcurrencyLimit

### DIFF
--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **builder**: Add `ServiceBuilder::map_result` analogous to
   `ServiceExt::map_result`.
+- **limit**: Add `GlobalConcurrencyLimitLayer` allowing to reuse concurrency
+  limit across multiple services ([#574])
 
 # 0.4.7 (April 27, 2021)
 

--- a/tower/src/limit/concurrency/layer.rs
+++ b/tower/src/limit/concurrency/layer.rs
@@ -28,10 +28,12 @@ impl<S> Layer<S> for ConcurrencyLimitLayer {
 
 /// Enforces a limit on the concurrent number of requests the underlying
 /// service can handle.
+///
 /// Unlike [`ConcurrencyLimitLayer`], which enforces a per-service concurrency
 /// limit, this layer accepts a owned semaphore (`Arc<Semaphore>`) which can be
 /// shared across multiple services.
-/// Cloning it will not create a new semaphore.
+///
+/// Cloning this layer will not create a new semaphore.
 #[derive(Debug, Clone)]
 pub struct GlobalConcurrencyLimitLayer {
     semaphore: Arc<Semaphore>,

--- a/tower/src/limit/concurrency/layer.rs
+++ b/tower/src/limit/concurrency/layer.rs
@@ -1,4 +1,7 @@
+use std::sync::Arc;
+
 use super::ConcurrencyLimit;
+use tokio::sync::Semaphore;
 use tower_layer::Layer;
 
 /// Enforces a limit on the concurrent number of requests the underlying
@@ -20,5 +23,29 @@ impl<S> Layer<S> for ConcurrencyLimitLayer {
 
     fn layer(&self, service: S) -> Self::Service {
         ConcurrencyLimit::new(service, self.max)
+    }
+}
+
+/// Enforces a limit on the concurrent number of requests the underlying
+/// service can handle.
+/// This variant accepts a owned semaphore (`Arc<Semaphore>`) which can
+/// be reused across services.
+#[derive(Debug, Clone)]
+pub struct GlobalConcurrencyLimitLayer {
+    semaphore: Arc<Semaphore>,
+}
+
+impl GlobalConcurrencyLimitLayer {
+    /// Create a new global concurrency limit layer.
+    pub fn new(semaphore: Arc<Semaphore>) -> Self {
+        GlobalConcurrencyLimitLayer { semaphore }
+    }
+}
+
+impl<S> Layer<S> for GlobalConcurrencyLimitLayer {
+    type Service = ConcurrencyLimit<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        ConcurrencyLimit::new_owned(service, self.semaphore.clone())
     }
 }

--- a/tower/src/limit/concurrency/layer.rs
+++ b/tower/src/limit/concurrency/layer.rs
@@ -36,7 +36,7 @@ pub struct GlobalConcurrencyLimitLayer {
 }
 
 impl GlobalConcurrencyLimitLayer {
-    /// Create a new global concurrency limit layer.
+    /// Create a new `GlobalConcurrencyLimitLayer`.
     pub fn new(semaphore: Arc<Semaphore>) -> Self {
         GlobalConcurrencyLimitLayer { semaphore }
     }
@@ -46,6 +46,6 @@ impl<S> Layer<S> for GlobalConcurrencyLimitLayer {
     type Service = ConcurrencyLimit<S>;
 
     fn layer(&self, service: S) -> Self::Service {
-        ConcurrencyLimit::new_owned(service, self.semaphore.clone())
+        ConcurrencyLimit::new_shared(service, self.semaphore.clone())
     }
 }

--- a/tower/src/limit/concurrency/mod.rs
+++ b/tower/src/limit/concurrency/mod.rs
@@ -4,4 +4,7 @@ pub mod future;
 mod layer;
 mod service;
 
-pub use self::{layer::ConcurrencyLimitLayer, service::ConcurrencyLimit};
+pub use self::{
+    layer::{ConcurrencyLimitLayer, GlobalConcurrencyLimitLayer},
+    service::ConcurrencyLimit,
+};

--- a/tower/src/limit/concurrency/service.rs
+++ b/tower/src/limit/concurrency/service.rs
@@ -26,7 +26,7 @@ pub struct ConcurrencyLimit<T> {
 impl<T> ConcurrencyLimit<T> {
     /// Create a new concurrency limiter.
     pub fn new(inner: T, max: usize) -> Self {
-        Self::new_shared(inner, Arc::new(Semaphore::new(max)))
+        Self::with_semaphore(inner, Arc::new(Semaphore::new(max)))
     }
 
     /// Create a new concurrency limiter with a provided shared semaphore

--- a/tower/src/limit/concurrency/service.rs
+++ b/tower/src/limit/concurrency/service.rs
@@ -26,11 +26,11 @@ pub struct ConcurrencyLimit<T> {
 impl<T> ConcurrencyLimit<T> {
     /// Create a new concurrency limiter.
     pub fn new(inner: T, max: usize) -> Self {
-        Self::new_owned(inner, Arc::new(Semaphore::new(max)))
+        Self::new_shared(inner, Arc::new(Semaphore::new(max)))
     }
 
-    /// Create a new concurrency limiter with a provided owned semaphore
-    pub fn new_owned(inner: T, semaphore: Arc<Semaphore>) -> Self {
+    /// Create a new concurrency limiter with a provided shared semaphore
+    pub fn new_shared(inner: T, semaphore: Arc<Semaphore>) -> Self {
         ConcurrencyLimit {
             inner,
             semaphore: PollSemaphore::new(semaphore),

--- a/tower/src/limit/concurrency/service.rs
+++ b/tower/src/limit/concurrency/service.rs
@@ -26,9 +26,14 @@ pub struct ConcurrencyLimit<T> {
 impl<T> ConcurrencyLimit<T> {
     /// Create a new concurrency limiter.
     pub fn new(inner: T, max: usize) -> Self {
+        Self::new_owned(inner, Arc::new(Semaphore::new(max)))
+    }
+
+    /// Create a new concurrency limiter with a provided owned semaphore
+    pub fn new_owned(inner: T, semaphore: Arc<Semaphore>) -> Self {
         ConcurrencyLimit {
             inner,
-            semaphore: PollSemaphore::new(Arc::new(Semaphore::new(max))),
+            semaphore: PollSemaphore::new(semaphore),
             permit: None,
         }
     }

--- a/tower/src/limit/concurrency/service.rs
+++ b/tower/src/limit/concurrency/service.rs
@@ -30,7 +30,7 @@ impl<T> ConcurrencyLimit<T> {
     }
 
     /// Create a new concurrency limiter with a provided shared semaphore
-    pub fn new_shared(inner: T, semaphore: Arc<Semaphore>) -> Self {
+    pub fn with_semaphore(inner: T, semaphore: Arc<Semaphore>) -> Self {
         ConcurrencyLimit {
             inner,
             semaphore: PollSemaphore::new(semaphore),

--- a/tower/src/limit/mod.rs
+++ b/tower/src/limit/mod.rs
@@ -4,6 +4,6 @@ pub mod concurrency;
 pub mod rate;
 
 pub use self::{
-    concurrency::{ConcurrencyLimit, ConcurrencyLimitLayer},
+    concurrency::{ConcurrencyLimit, ConcurrencyLimitLayer, GlobalConcurrencyLimitLayer},
     rate::{RateLimit, RateLimitLayer},
 };


### PR DESCRIPTION
We've been needing this to share the same `Arc<Semaphore>` from multiple listeners.

Concretely, this allows us to have a shared "max connections" limit throughout all our listeners. It also allows us to reuse the same semaphore for all services for the same "app".

I've added a `ToOwnedSemaphore` trait and implemented it for `usize` and `Arc<Semaphore>`.

This is a breaking change for people explicitly creating a `ConcurrencyLimitLayer`. It now requires a type implementing `ToOwnedSemaphore` to be specified.