### PR TITLE
builder: Add type check utility methods

### DIFF
--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **builder**: Add `ServiceBuilder::check_service` to check the request,
+    response, and error types of the output service.
+- **builder**: Add `ServiceBuilder::check_service_clone` to check the output
+    service can be cloned.
 
 # 0.4.6 (February 26, 2021)
 


### PR DESCRIPTION
At Embark I've been building an HTTP client with about 10 middlewares applied. That sometimes produces some otherworldly type errors that can be hard to debug.

I remember seeing "type check" methods in [linkerd-proxy](https://github.com/linkerd/linkerd2-proxy/blob/main/linkerd/app/core/src/svc.rs) which I have found quite useful for debugging errors in large `ServiceBuilder` stacks.

I've been thinking it makes sense to have something like that in tower.