### PR TITLE
buffer: Add `Buffer::try_into_inner` for recovering inner service

### DIFF
--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     response, and error types of the output service.
 - **builder**: Add `ServiceBuilder::check_service_clone` to check the output
     service can be cloned.
+- **buffer**: Add `Buffer::try_into_inner` for recovering inner service
 
 # 0.4.6 (February 26, 2021)
 

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -45,7 +45,7 @@ full = [
 ]
 log = ["tracing/log"]
 balance = ["discover", "load", "ready-cache", "make", "rand", "slab", "tokio-stream"]
-buffer = ["tokio/sync", "tokio/rt", "tokio-util", "tracing"]
+buffer = ["tokio/sync", "tokio/rt", "tokio-util", "tracing", "parking_lot"]
 discover = []
 filter = ["futures-util"]
 hedge = ["util", "filter", "futures-util", "hdrhistogram", "tokio/time", "tracing"]
@@ -70,6 +70,7 @@ tower-service = { version = "0.3" }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
 hdrhistogram = { version = "6.0", optional = true }
 indexmap = { version = "1.0.2", optional = true }
+parking_lot = { version = "0.11.1", optional = true }
 rand = { version = "0.8", features = ["small_rng"], optional = true }
 slab = { version = "0.4", optional = true }
 tokio = { version = "1", optional = true, features = ["sync"] }

--- a/tower/src/buffer/error.rs
+++ b/tower/src/buffer/error.rs
@@ -17,6 +17,12 @@ pub struct Closed {
     _p: (),
 }
 
+/// An error produced by calling a [`Buffer`] who's worker's service has been extraced
+/// with [`Buffer::try_into_inner`].
+pub struct ServiceExtractedFromWorker {
+    _p: (),
+}
+
 // ===== impl ServiceError =====
 
 impl ServiceError {
@@ -66,3 +72,25 @@ impl fmt::Display for Closed {
 }
 
 impl std::error::Error for Closed {}
+
+// ===== impl ServiceExtractedFromWorker =====
+
+impl ServiceExtractedFromWorker {
+    pub(crate) fn new() -> Self {
+        ServiceExtractedFromWorker { _p: () }
+    }
+}
+
+impl fmt::Debug for ServiceExtractedFromWorker {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_tuple("ServiceExtractedFromWorker").finish()
+    }
+}
+
+impl fmt::Display for ServiceExtractedFromWorker {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("buffer's worker service has been extracted")
+    }
+}
+
+impl std::error::Error for ServiceExtractedFromWorker {}

--- a/tower/src/buffer/message.rs
+++ b/tower/src/buffer/message.rs
@@ -4,7 +4,7 @@ use tokio::sync::{oneshot, OwnedSemaphorePermit};
 /// Message sent over buffer
 #[derive(Debug)]
 pub(crate) struct Message<Request, Fut> {
-    pub(crate) request: Request,
+    pub(crate) request: Option<Request>,
     pub(crate) tx: Tx<Fut>,
     pub(crate) span: tracing::Span,
     pub(super) _permit: OwnedSemaphorePermit,


### PR DESCRIPTION
This is a possible solution to #111. The idea is to share the service itself between `Buffer` and `Worker` using an `Arc<Mutex<Option<T>>>`. `Buffer::try_into_inner` then `take`s the inner value if its there.

After extracting the inner service all requests will fail with `ServiceExtractedFromWorker`.

I would like some input on this 😊 

- Is this even a feature we want to provide? #111 is quite old has hasn't seen much activity. `Buffer` is currently an odd one in that it doesn't currently have an `into_inner`. Most other middlewares have that.
- Would this implementation work? I imagine the `Arc<Mutex<_>>` would add a small amount of overhead. I haven't benchmarked the before/after.

cc @jonhoo

---

Fixes #111