### PR TITLE
chore: converts rest doc-links to intra-doc links

### DIFF
--- a/tower-layer/src/lib.rs
+++ b/tower-layer/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! A middleware implements the [`Layer`] and [`Service`] trait.
 //!
-//! [`Service`]: ../tower/trait.Service.html
+//! [`Service`]: https://docs.rs/tower/trait.Service.html
 
 mod identity;
 mod layer_fn;
@@ -90,7 +90,7 @@ pub use self::{
 /// is also decoupled from client or server concerns. In other words, the same
 /// log middleware could be used in either a client or a server.
 ///
-/// [`Service`]: ../tower/trait.Service.html
+/// [`Service`]: https://docs.rs/tower/trait.Service.html
 pub trait Layer<S> {
     /// The wrapped service
     type Service;

--- a/tower/src/balance/p2c/service.rs
+++ b/tower/src/balance/p2c/service.rs
@@ -27,7 +27,7 @@ use tracing::{debug, trace};
 /// `&mut self`. You can achieve this easily by wrapping your [`Discover`] in [`Box::pin`] before you
 /// construct the [`Balance`] instance. For more details, see [#319].
 ///
-/// [`Box::pin`]: https://doc.rust-lang.org/std/boxed/struct.Box.html#method.pin
+/// [`Box::pin`]: std::boxed::Box::pin()
 /// [#319]: https://github.com/tower-rs/tower/issues/319
 pub struct Balance<D, Req>
 where

--- a/tower/src/balance/pool/mod.rs
+++ b/tower/src/balance/pool/mod.rs
@@ -168,7 +168,7 @@ where
 }
 
 /// A [builder] that lets you configure how a [`Pool`] determines whether the underlying service is
-/// loaded or not. See the [module-level documentation](index.html) and the builder's methods for
+/// loaded or not. See the [module-level documentation](self) and the builder's methods for
 /// details.
 ///
 ///  [builder]: https://rust-lang-nursery.github.io/api-guidelines/type-safety.html#builders-enable-construction-of-complex-values-c-builder
@@ -201,7 +201,7 @@ impl Builder {
         Self::default()
     }
 
-    /// When the estimated load (see the [module-level docs](index.html)) drops below this
+    /// When the estimated load (see the [module-level docs](self)) drops below this
     /// threshold, and there are at least two services active, a service is removed.
     ///
     /// The default value is 0.01. That is, when one in every 100 `poll_ready` calls return
@@ -211,7 +211,7 @@ impl Builder {
         self
     }
 
-    /// When the estimated load (see the [module-level docs](index.html)) exceeds this
+    /// When the estimated load (see the [module-level docs](self)) exceeds this
     /// threshold, and no service is currently in the process of being added, a new service is
     /// scheduled to be added to the underlying [`Balance`].
     ///

--- a/tower/src/reconnect/mod.rs
+++ b/tower/src/reconnect/mod.rs
@@ -9,8 +9,8 @@
 //! call the service again even if the inner `MakeService` was unable to
 //! connect on the last call.
 //!
-//! [`MakeService`]: ../make/trait.MakeService.html
-//! [`Service`]: ../trait.Service.html
+//! [`MakeService`]: crate::make::MakeService
+//! [`Service`]: crate::Service
 
 mod future;
 


### PR DESCRIPTION
This PR simply converts the rest doc-links to intra-doc links.