### PR TITLE
chore: add explicit feature flag for tower-balance example

### DIFF
--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -96,3 +96,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]
 features = ["full"]
+
+[[example]]
+name = "tower-balance"
+path = "examples/tower-balance.rs"
+required-features = ["full"]


### PR DESCRIPTION
Currently running example without any additional params causes error:
```
> cargo run --example tower-balance 

   Compiling tower v0.4.6 (/Users/michal/proj/rust/tower/tower)
error[E0432]: unresolved import `tower::balance`
  --> tower/examples/tower-balance.rs:15:5
   |
15 | use tower::balance as lb;
   |     ^^^^^^^^^^^^^^^^^^^^ no `balance` in the root

error[E0433]: failed to resolve: could not find `limit` in `tower`
  --> tower/examples/tower-balance.rs:17:12
   |
17 | use tower::limit::concurrency::ConcurrencyLimit;
   |            ^^^^^ could not find `limit` in `tower`

error[E0432]: unresolved import `tower::discover`
  --> tower/examples/tower-balance.rs:16:12
   |
16 | use tower::discover::{Change, Discover};
   |            ^^^^^^^^ could not find `discover` in `tower`

error[E0432]: unresolved import `tower::load`
  --> tower/examples/tower-balance.rs:18:5
   |
18 | use tower::load;
   |     ^^^^^^^^^^^ no `load` in the root

error[E0432]: unresolved import `tower::util`
  --> tower/examples/tower-balance.rs:19:12
   |
19 | use tower::util::ServiceExt;
   |            ^^^^ could not find `util` in `tower`

error[E0433]: failed to resolve: use of undeclared crate or module `futures_util`
 --> tower/examples/tower-balance.rs:4:5
  |
4 | use futures_util::{stream, stream::StreamExt, stream::TryStreamExt};
  |     ^^^^^^^^^^^^ use of undeclared crate or module `futures_util`

error[E0432]: unresolved import `futures_util`
 --> tower/examples/tower-balance.rs:4:5
  |
4 | use futures_util::{stream, stream::StreamExt, stream::TryStreamExt};
  |     ^^^^^^^^^^^^ use of undeclared crate or module `futures_util`

error[E0432]: unresolved import `rand`
 --> tower/examples/tower-balance.rs:7:12
  |
7 | use rand::{self, Rng};
  |            ^^^^ no external crate `rand`

error[E0433]: failed to resolve: use of undeclared type `ConcurrencyLimit`
   --> tower/examples/tower-balance.rs:127:28
    |
127 |                 (instance, ConcurrencyLimit::new(svc, ENDPOINT_CAPACITY))
    |                            ^^^^^^^^^^^^^^^^ use of undeclared type `ConcurrencyLimit`

error[E0433]: failed to resolve: use of undeclared type `ConcurrencyLimit`
   --> tower/examples/tower-balance.rs:146:19
    |
146 |     let service = ConcurrencyLimit::new(lb, CONCURRENCY);
    |                   ^^^^^^^^^^^^^^^^ use of undeclared type `ConcurrencyLimit`

error[E0412]: cannot find type `ConcurrencyLimit` in this scope
   --> tower/examples/tower-balance.rs:104:15
    |
104 |     Service = ConcurrencyLimit<
    |               ^^^^^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find function `service_fn` in crate `tower`
   --> tower/examples/tower-balance.rs:113:34
    |
113 |                 let svc = tower::service_fn(move |_| {
    |                                  ^^^^^^^^^^ not found in `tower`

error: aborting due to 12 previous errors
```

Passing explicit flag works fine:
```
> cargo run --features="full" --example tower-balance
```

After change more meaningful error message is shown in case of missing flag:
```
cargo run --example tower-balance
error: target `tower-balance` in package `tower` requires the features: `full`
Consider enabling them by passing, e.g., `--features="full"`
```