### PR TITLE
tower: prepare to release 0.4.7

### DIFF
--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -6,10 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+# 0.4.7 (April 27, 2021)
+
+### Added
+
 - **builder**: Add `ServiceBuilder::check_service` to check the request,
-    response, and error types of the output service.
+    response, and error types of the output service. ([#576])
 - **builder**: Add `ServiceBuilder::check_service_clone` to check the output
-    service can be cloned.
+    service can be cloned. ([#576])
+
+### Fixed
+
+- **spawn_ready**: Abort spawned background tasks when the `SpawnReady` service
+  is dropped, fixing a potential task/resource leak (#[581])
+- Fixed broken documentation links ([#578])
+
+[#576]: https://github.com/tower-rs/tower/pull/576
+[#578]: https://github.com/tower-rs/tower/pull/578
+[#581]: https://github.com/tower-rs/tower/pull/581
 
 # 0.4.6 (February 26, 2021)
 

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -8,13 +8,13 @@ name = "tower"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "vX.X.X" git tag.
-version = "0.4.6"
+version = "0.4.7"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tower-rs/tower"
 homepage = "https://github.com/tower-rs/tower"
-documentation = "https://docs.rs/tower/0.4.6"
+documentation = "https://docs.rs/tower/0.4.7"
 description = """
 Tower is a library of modular and reusable components for building robust
 clients and servers.

--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tower/0.4.6")]
+#![doc(html_root_url = "https://docs.rs/tower/0.4.7")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
# 0.4.7 (April 27, 2021)

### Added

- **builder**: Add `ServiceBuilder::check_service` to check the request,
    response, and error types of the output service. ([#576])
- **builder**: Add `ServiceBuilder::check_service_clone` to check the
  output service can be cloned. ([#576])

### Fixed

- **spawn_ready**: Abort spawned background tasks when the `SpawnReady`
  service is dropped, fixing a potential task/resource leak (#[581])
- Fixed broken documentation links ([#578])

[#576]: https://github.com/tower-rs/tower/pull/576
[#578]: https://github.com/tower-rs/tower/pull/578
[#581]: https://github.com/tower-rs/tower/pull/581