### PR TITLE
tower: prepare to release 0.4.8

### DIFF
--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -12,11 +12,12 @@ Nothing yet.
 # 0.4.8 (May 28, 2021)
 
 - **builder**: Add `ServiceBuilder::map_result` analogous to
-  `ServiceExt::map_result`.
-- **limit**: Add `GlobalConcurrencyLimitLayer` allowing to reuse concurrency
+  `ServiceExt::map_result` ([#583]) 
+- **limit**: Add `GlobalConcurrencyLimitLayer` to allow reusing a concurrency
   limit across multiple services ([#574])
 
 [#574]: https://github.com/tower-rs/tower/pull/574
+[#583]: https://github.com/tower-rs/tower/pull/583
 
 # 0.4.7 (April 27, 2021)
 

--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+Nothing yet.
+
+# 0.4.8 (May 28, 2021)
+
 - **builder**: Add `ServiceBuilder::map_result` analogous to
   `ServiceExt::map_result`.
 - **limit**: Add `GlobalConcurrencyLimitLayer` allowing to reuse concurrency
   limit across multiple services ([#574])
+
+[#574]: https://github.com/tower-rs/tower/pull/574
 
 # 0.4.7 (April 27, 2021)
 

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -8,13 +8,13 @@ name = "tower"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "vX.X.X" git tag.
-version = "0.4.7"
+version = "0.4.8"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tower-rs/tower"
 homepage = "https://github.com/tower-rs/tower"
-documentation = "https://docs.rs/tower/0.4.7"
+documentation = "https://docs.rs/tower/0.4.8"
 description = """
 Tower is a library of modular and reusable components for building robust
 clients and servers.

--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tower/0.4.7")]
+#![doc(html_root_url = "https://docs.rs/tower/0.4.8")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
# 0.4.8 (May 28, 2021)

- **builder**: Add `ServiceBuilder::map_result` analogous to
  `ServiceExt::map_result`.
- **limit**: Add `GlobalConcurrencyLimitLayer` allowing to reuse concurrency
  limit across multiple services ([#574])

[#574]: https://github.com/tower-rs/tower/pull/574