### PR TITLE
Migrate to pin project lite

### DIFF
--- a/tower-layer/src/lib.rs
+++ b/tower-layer/src/lib.rs
@@ -5,7 +5,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![deny(broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 //! Layer traits and extensions.
 //!

--- a/tower-service/src/lib.rs
+++ b/tower-service/src/lib.rs
@@ -5,7 +5,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![deny(broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 //! Definition of the core `Service` trait to Tower
 //!

--- a/tower-test/Cargo.toml
+++ b/tower-test/Cargo.toml
@@ -27,7 +27,7 @@ tokio = { version = "1.0", features = ["sync"] }
 tokio-test = "0.4"
 tower-layer = { version = "0.3", path = "../tower-layer" }
 tower-service = { version = "0.3" }
-pin-project = "1"
+pin-project-lite = "0.2"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros"] }

--- a/tower-test/src/lib.rs
+++ b/tower-test/src/lib.rs
@@ -6,7 +6,7 @@
     unreachable_pub
 )]
 #![allow(elided_lifetimes_in_paths)]
-#![deny(broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 //! Mock `Service` that can be used in tests.
 

--- a/tower-test/src/mock/future.rs
+++ b/tower-test/src/mock/future.rs
@@ -2,7 +2,7 @@
 
 use crate::mock::error::{self, Error};
 use futures_util::ready;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use tokio::sync::oneshot;
 
 use std::{
@@ -11,12 +11,13 @@ use std::{
     task::{Context, Poll},
 };
 
-/// Future of the `Mock` response.
-#[pin_project]
-#[derive(Debug)]
-pub struct ResponseFuture<T> {
-    #[pin]
-    rx: Option<Rx<T>>,
+pin_project! {
+    /// Future of the `Mock` response.
+    #[derive(Debug)]
+    pub struct ResponseFuture<T> {
+        #[pin]
+        rx: Option<Rx<T>>,
+    }
 }
 
 type Rx<T> = oneshot::Receiver<Result<T, Error>>;

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -76,6 +76,7 @@ tokio = { version = "1", optional = true, features = ["sync"] }
 tokio-stream = { version = "0.1.0", optional = true }
 tokio-util = { version = "0.6.3", default-features = false, optional = true }
 tracing = { version = "0.1.2", optional = true }
+pin-project-lite = "0.2.7"
 
 [dev-dependencies]
 futures = "0.3"

--- a/tower/examples/tower-balance.rs
+++ b/tower/examples/tower-balance.rs
@@ -3,7 +3,7 @@
 use futures_core::{Stream, TryStream};
 use futures_util::{stream, stream::StreamExt, stream::TryStreamExt};
 use hdrhistogram::Histogram;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use rand::{self, Rng};
 use std::hash::Hash;
 use std::time::Duration;
@@ -78,8 +78,17 @@ type Error = Box<dyn std::error::Error + Send + Sync>;
 
 type Key = usize;
 
-#[pin_project]
-struct Disco<S>(Vec<(Key, S)>);
+pin_project! {
+    struct Disco<S> {
+        services: Vec<(Key, S)>
+    }
+}
+
+impl<S> Disco<S> {
+    fn new(services: Vec<(Key, S)>) -> Self {
+        Self { services }
+    }
+}
 
 impl<S> Stream for Disco<S>
 where
@@ -88,7 +97,7 @@ where
     type Item = Result<Change<Key, S>, Error>;
 
     fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        match self.project().0.pop() {
+        match self.project().services.pop() {
             Some((k, service)) => Poll::Ready(Some(Ok(Change::Insert(k, service)))),
             None => {
                 // there may be more later
@@ -105,7 +114,7 @@ fn gen_disco() -> impl Discover<
         impl Service<Req, Response = Rsp, Error = Error, Future = impl Send> + Send,
     >,
 > + Send {
-    Disco(
+    Disco::new(
         MAX_ENDPOINT_LATENCIES
             .iter()
             .enumerate()

--- a/tower/src/balance/p2c/make.rs
+++ b/tower/src/balance/p2c/make.rs
@@ -1,7 +1,7 @@
 use super::Balance;
 use crate::discover::Discover;
 use futures_core::ready;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::hash::Hash;
 use std::marker::PhantomData;
 use std::{
@@ -29,15 +29,16 @@ pub struct MakeBalance<S, Req> {
     _marker: PhantomData<fn(Req)>,
 }
 
-/// A [`Balance`] in the making.
-///
-/// [`Balance`]: crate::balance::p2c::Balance
-#[pin_project]
-#[derive(Debug)]
-pub struct MakeFuture<F, Req> {
-    #[pin]
-    inner: F,
-    _marker: PhantomData<fn(Req)>,
+pin_project! {
+    /// A [`Balance`] in the making.
+    ///
+    /// [`Balance`]: crate::balance::p2c::Balance
+    #[derive(Debug)]
+    pub struct MakeFuture<F, Req> {
+        #[pin]
+        inner: F,
+        _marker: PhantomData<fn(Req)>,
+    }
 }
 
 impl<S, Req> MakeBalance<S, Req> {

--- a/tower/src/balance/p2c/service.rs
+++ b/tower/src/balance/p2c/service.rs
@@ -4,7 +4,7 @@ use crate::load::Load;
 use crate::ready_cache::{error::Failed, ReadyCache};
 use futures_core::ready;
 use futures_util::future::{self, TryFutureExt};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -59,18 +59,19 @@ where
     }
 }
 
-/// A Future that becomes satisfied when an `S`-typed service is ready.
-///
-/// May fail due to cancelation, i.e., if [`Discover`] removes the service from the service set.
-#[pin_project]
-#[derive(Debug)]
-struct UnreadyService<K, S, Req> {
-    key: Option<K>,
-    #[pin]
-    cancel: oneshot::Receiver<()>,
-    service: Option<S>,
+pin_project! {
+    /// A Future that becomes satisfied when an `S`-typed service is ready.
+    ///
+    /// May fail due to cancelation, i.e., if [`Discover`] removes the service from the service set.
+    #[derive(Debug)]
+    struct UnreadyService<K, S, Req> {
+        key: Option<K>,
+        #[pin]
+        cancel: oneshot::Receiver<()>,
+        service: Option<S>,
 
-    _req: PhantomData<Req>,
+        _req: PhantomData<Req>,
+    }
 }
 
 enum Error<E> {

--- a/tower/src/balance/pool/mod.rs
+++ b/tower/src/balance/pool/mod.rs
@@ -19,7 +19,7 @@ use crate::discover::Change;
 use crate::load::Load;
 use crate::make::MakeService;
 use futures_core::{ready, Stream};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use slab::Slab;
 use std::{
     fmt,
@@ -42,23 +42,24 @@ enum Level {
     High,
 }
 
-/// A wrapper around `MakeService` that discovers a new service when load is high, and removes a
-/// service when load is low. See [`Pool`].
-#[pin_project]
-pub struct PoolDiscoverer<MS, Target, Request>
-where
-    MS: MakeService<Target, Request>,
-{
-    maker: MS,
-    #[pin]
-    making: Option<MS::Future>,
-    target: Target,
-    load: Level,
-    services: Slab<()>,
-    died_tx: tokio::sync::mpsc::UnboundedSender<usize>,
-    #[pin]
-    died_rx: tokio::sync::mpsc::UnboundedReceiver<usize>,
-    limit: Option<usize>,
+pin_project! {
+    /// A wrapper around `MakeService` that discovers a new service when load is high, and removes a
+    /// service when load is low. See [`Pool`].
+    pub struct PoolDiscoverer<MS, Target, Request>
+    where
+        MS: MakeService<Target, Request>,
+    {
+        maker: MS,
+        #[pin]
+        making: Option<MS::Future>,
+        target: Target,
+        load: Level,
+        services: Slab<()>,
+        died_tx: tokio::sync::mpsc::UnboundedSender<usize>,
+        #[pin]
+        died_rx: tokio::sync::mpsc::UnboundedReceiver<usize>,
+        limit: Option<usize>,
+    }
 }
 
 impl<MS, Target, Request> fmt::Debug for PoolDiscoverer<MS, Target, Request>

--- a/tower/src/buffer/future.rs
+++ b/tower/src/buffer/future.rs
@@ -22,21 +22,29 @@ pub struct ResponseFuture<T> {
 #[pin_project(project = ResponseStateProj)]
 #[derive(Debug)]
 enum ResponseState<T> {
-    Failed(Option<crate::BoxError>),
-    Rx(#[pin] message::Rx<T>),
-    Poll(#[pin] T),
+    Failed {
+        error: Option<crate::BoxError>,
+    },
+    Rx {
+        #[pin]
+        rx: message::Rx<T>,
+    },
+    Poll {
+        #[pin]
+        fut: T,
+    },
 }
 
 impl<T> ResponseFuture<T> {
     pub(crate) fn new(rx: message::Rx<T>) -> Self {
         ResponseFuture {
-            state: ResponseState::Rx(rx),
+            state: ResponseState::Rx { rx },
         }
     }
 
     pub(crate) fn failed(err: crate::BoxError) -> Self {
         ResponseFuture {
-            state: ResponseState::Failed(Some(err)),
+            state: ResponseState::Failed { error: Some(err) },
         }
     }
 }
@@ -53,15 +61,15 @@ where
 
         loop {
             match this.state.as_mut().project() {
-                ResponseStateProj::Failed(e) => {
-                    return Poll::Ready(Err(e.take().expect("polled after error")));
+                ResponseStateProj::Failed { error } => {
+                    return Poll::Ready(Err(error.take().expect("polled after error")));
                 }
-                ResponseStateProj::Rx(rx) => match ready!(rx.poll(cx)) {
-                    Ok(Ok(f)) => this.state.set(ResponseState::Poll(f)),
+                ResponseStateProj::Rx { rx } => match ready!(rx.poll(cx)) {
+                    Ok(Ok(fut)) => this.state.set(ResponseState::Poll { fut }),
                     Ok(Err(e)) => return Poll::Ready(Err(e.into())),
                     Err(_) => return Poll::Ready(Err(Closed::new().into())),
                 },
-                ResponseStateProj::Poll(fut) => return fut.poll(cx).map_err(Into::into),
+                ResponseStateProj::Poll { fut } => return fut.poll(cx).map_err(Into::into),
             }
         }
     }

--- a/tower/src/buffer/future.rs
+++ b/tower/src/buffer/future.rs
@@ -4,35 +4,39 @@
 
 use super::{error::Closed, message};
 use futures_core::ready;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
 
-/// Future that completes when the buffered service eventually services the submitted request.
-#[pin_project]
-#[derive(Debug)]
-pub struct ResponseFuture<T> {
-    #[pin]
-    state: ResponseState<T>,
+pin_project! {
+    /// Future that completes when the buffered service eventually services the submitted request.
+    #[derive(Debug)]
+    pub struct ResponseFuture<T> {
+        #[pin]
+        state: ResponseState<T>,
+    }
 }
 
-#[pin_project(project = ResponseStateProj)]
-#[derive(Debug)]
-enum ResponseState<T> {
-    Failed {
-        error: Option<crate::BoxError>,
-    },
-    Rx {
-        #[pin]
-        rx: message::Rx<T>,
-    },
-    Poll {
-        #[pin]
-        fut: T,
-    },
+
+pin_project! {
+    #[project = ResponseStateProj]
+    #[derive(Debug)]
+    enum ResponseState<T> {
+        Failed {
+            error: Option<crate::BoxError>,
+        },
+        Rx {
+            #[pin]
+            rx: message::Rx<T>,
+        },
+        Poll {
+            #[pin]
+            fut: T,
+        },
+    }
 }
 
 impl<T> ResponseFuture<T> {

--- a/tower/src/buffer/future.rs
+++ b/tower/src/buffer/future.rs
@@ -20,7 +20,6 @@ pin_project! {
     }
 }
 
-
 pin_project! {
     #[project = ResponseStateProj]
     #[derive(Debug)]

--- a/tower/src/buffer/worker.rs
+++ b/tower/src/buffer/worker.rs
@@ -42,7 +42,6 @@ pin_project_lite::pin_project! {
     }
 }
 
-
 /// Get the error out
 #[derive(Debug)]
 pub(crate) struct Handle {
@@ -63,7 +62,6 @@ where
             tracing::trace!("buffer already closed");
         }
     }
-
 }
 
 impl<T, Request> Worker<T, Request>

--- a/tower/src/discover/list.rs
+++ b/tower/src/discover/list.rs
@@ -1,6 +1,6 @@
 use super::{error::Never, Change};
 use futures_core::Stream;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::iter::{Enumerate, IntoIterator};
 use std::{
     pin::Pin,
@@ -8,17 +8,18 @@ use std::{
 };
 use tower_service::Service;
 
-/// Static service discovery based on a predetermined list of services.
-///
-/// [`ServiceList`] is created with an initial list of services. The discovery
-/// process will yield this list once and do nothing after.
-#[pin_project]
-#[derive(Debug)]
-pub struct ServiceList<T>
-where
-    T: IntoIterator,
-{
-    inner: Enumerate<T::IntoIter>,
+pin_project! {
+    /// Static service discovery based on a predetermined list of services.
+    ///
+    /// [`ServiceList`] is created with an initial list of services. The discovery
+    /// process will yield this list once and do nothing after.
+    #[derive(Debug)]
+    pub struct ServiceList<T>
+    where
+        T: IntoIterator,
+    {
+        inner: Enumerate<T::IntoIter>,
+    }
 }
 
 impl<T, U> ServiceList<T>

--- a/tower/src/filter/future.rs
+++ b/tower/src/filter/future.rs
@@ -29,7 +29,6 @@ pin_project! {
     }
 }
 
-
 opaque_future! {
     /// Filtered response future from [`Filter`] services.
     ///
@@ -58,7 +57,6 @@ pin_project! {
     }
 }
 
-
 impl<P, S, Request> AsyncResponseFuture<P, S, Request>
 where
     P: AsyncPredicate<Request>,
@@ -86,7 +84,7 @@ where
 
         loop {
             match this.state.as_mut().project() {
-                StateProj::Check {mut check} => {
+                StateProj::Check { mut check } => {
                     let request = ready!(check.as_mut().poll(cx))?;
                     let response = this.service.call(request);
                     this.state.set(State::WaitResponse { response });

--- a/tower/src/filter/future.rs
+++ b/tower/src/filter/future.rs
@@ -3,7 +3,7 @@
 use super::AsyncPredicate;
 use crate::BoxError;
 use futures_core::ready;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
@@ -11,22 +11,24 @@ use std::{
 };
 use tower_service::Service;
 
-/// Filtered response future from [`AsyncFilter`] services.
-///
-/// [`AsyncFilter`]: crate::filter::AsyncFilter
-#[pin_project]
-#[derive(Debug)]
-pub struct AsyncResponseFuture<P, S, Request>
-where
-    P: AsyncPredicate<Request>,
-    S: Service<P::Request>,
-{
-    #[pin]
-    state: State<P::Future, S::Future>,
+pin_project! {
+    /// Filtered response future from [`AsyncFilter`] services.
+    ///
+    /// [`AsyncFilter`]: crate::filter::AsyncFilter
+    #[derive(Debug)]
+    pub struct AsyncResponseFuture<P, S, Request>
+    where
+        P: AsyncPredicate<Request>,
+        S: Service<P::Request>,
+    {
+        #[pin]
+        state: State<P::Future, S::Future>,
 
-    /// Inner service
-    service: S,
+        // Inner service
+        service: S,
+    }
 }
+
 
 opaque_future! {
     /// Filtered response future from [`Filter`] services.
@@ -39,20 +41,23 @@ opaque_future! {
         >;
 }
 
-#[pin_project(project = StateProj)]
-#[derive(Debug)]
-enum State<F, G> {
-    /// Waiting for the predicate future
-    Check {
-        #[pin]
-        check: F
-    },
-    /// Waiting for the response future
-    WaitResponse {
-        #[pin]
-        response: G
-    },
+pin_project! {
+    #[project = StateProj]
+    #[derive(Debug)]
+    enum State<F, G> {
+        /// Waiting for the predicate future
+        Check {
+            #[pin]
+            check: F
+        },
+        /// Waiting for the response future
+        WaitResponse {
+            #[pin]
+            response: G
+        },
+    }
 }
+
 
 impl<P, S, Request> AsyncResponseFuture<P, S, Request>
 where

--- a/tower/src/filter/mod.rs
+++ b/tower/src/filter/mod.rs
@@ -112,7 +112,7 @@ where
     }
 
     fn call(&mut self, request: Request) -> Self::Future {
-        ResponseFuture(match self.predicate.check(request) {
+        ResponseFuture::new(match self.predicate.check(request) {
             Ok(request) => Either::Right(self.inner.call(request).err_into()),
             Err(e) => Either::Left(futures_util::future::ready(Err(e.into()))),
         })

--- a/tower/src/hedge/delay.rs
+++ b/tower/src/hedge/delay.rs
@@ -1,5 +1,5 @@
 use futures_util::ready;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::time::Duration;
 use std::{
     future::Future,
@@ -23,29 +23,32 @@ pub struct Delay<P, S> {
     service: S,
 }
 
-#[pin_project]
-#[derive(Debug)]
-pub struct ResponseFuture<Request, S>
-where
-    S: Service<Request>,
-{
-    service: Option<S>,
-    #[pin]
-    state: State<Request, Oneshot<S, Request>>,
+pin_project! {
+    #[derive(Debug)]
+    pub struct ResponseFuture<Request, S>
+    where
+        S: Service<Request>,
+    {
+        service: Option<S>,
+        #[pin]
+        state: State<Request, Oneshot<S, Request>>,
+    }
 }
 
-#[pin_project(project = StateProj)]
-#[derive(Debug)]
-enum State<Request, F> {
-    Delaying {
-        #[pin]
-        delay: tokio::time::Sleep,
-        req: Option<Request>,
-    },
-    Called {
-        #[pin]
-        fut: F,
-    },
+pin_project! {
+    #[project = StateProj]
+    #[derive(Debug)]
+    enum State<Request, F> {
+        Delaying {
+            #[pin]
+            delay: tokio::time::Sleep,
+            req: Option<Request>,
+        },
+        Called {
+            #[pin]
+            fut: F,
+        },
+    }
 }
 
 impl<Request, F> State<Request, F> {

--- a/tower/src/hedge/latency.rs
+++ b/tower/src/hedge/latency.rs
@@ -1,5 +1,5 @@
 use futures_util::ready;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::time::Duration;
 use std::{
     future::Future,
@@ -24,13 +24,14 @@ pub struct Latency<R, S> {
     service: S,
 }
 
-#[pin_project]
-#[derive(Debug)]
-pub struct ResponseFuture<R, F> {
-    start: Instant,
-    rec: R,
-    #[pin]
-    inner: F,
+pin_project! {
+    #[derive(Debug)]
+    pub struct ResponseFuture<R, F> {
+        start: Instant,
+        rec: R,
+        #[pin]
+        inner: F,
+    }
 }
 
 impl<S, R> Latency<R, S>

--- a/tower/src/hedge/mod.rs
+++ b/tower/src/hedge/mod.rs
@@ -5,7 +5,7 @@
 
 use crate::filter::AsyncFilter;
 use futures_util::future;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use std::{
@@ -37,17 +37,18 @@ type Service<S, P> = select::Select<
 #[derive(Debug)]
 pub struct Hedge<S, P>(Service<S, P>);
 
-/// The [`Future`] returned by the [`Hedge`] service.
-///
-/// [`Future`]: std::future::Future
-#[pin_project]
-#[derive(Debug)]
-pub struct Future<S, Request>
-where
-    S: tower_service::Service<Request>,
-{
-    #[pin]
-    inner: S::Future,
+pin_project! {
+    /// The [`Future`] returned by the [`Hedge`] service.
+    ///
+    /// [`Future`]: std::future::Future
+    #[derive(Debug)]
+    pub struct Future<S, Request>
+    where
+        S: tower_service::Service<Request>,
+    {
+        #[pin]
+        inner: S::Future,
+    }
 }
 
 /// A policy which describes which requests can be cloned and then whether those

--- a/tower/src/hedge/select.rs
+++ b/tower/src/hedge/select.rs
@@ -1,4 +1,4 @@
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
@@ -23,13 +23,14 @@ pub struct Select<P, A, B> {
     b: B,
 }
 
-#[pin_project]
-#[derive(Debug)]
-pub struct ResponseFuture<AF, BF> {
-    #[pin]
-    a_fut: AF,
-    #[pin]
-    b_fut: Option<BF>,
+pin_project! {
+    #[derive(Debug)]
+    pub struct ResponseFuture<AF, BF> {
+        #[pin]
+        a_fut: AF,
+        #[pin]
+        b_fut: Option<BF>,
+    }
 }
 
 impl<P, A, B> Select<P, A, B> {

--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -5,7 +5,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![deny(broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![allow(elided_lifetimes_in_paths, clippy::type_complexity)]
 #![cfg_attr(test, allow(clippy::float_cmp))]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/tower/src/limit/concurrency/future.rs
+++ b/tower/src/limit/concurrency/future.rs
@@ -2,7 +2,7 @@
 //!
 //! [`Future`]: std::future::Future
 use futures_core::ready;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
@@ -10,16 +10,17 @@ use std::{
 };
 use tokio::sync::OwnedSemaphorePermit;
 
-/// Future for the [`ConcurrencyLimit`] service.
-///
-/// [`ConcurrencyLimit`]: crate::limit::ConcurrencyLimit
-#[pin_project]
-#[derive(Debug)]
-pub struct ResponseFuture<T> {
-    #[pin]
-    inner: T,
-    // Keep this around so that it is dropped when the future completes
-    _permit: OwnedSemaphorePermit,
+pin_project! {
+    /// Future for the [`ConcurrencyLimit`] service.
+    ///
+    /// [`ConcurrencyLimit`]: crate::limit::ConcurrencyLimit
+    #[derive(Debug)]
+    pub struct ResponseFuture<T> {
+        #[pin]
+        inner: T,
+        // Keep this around so that it is dropped when the future completes
+        _permit: OwnedSemaphorePermit,
+    }
 }
 
 impl<T> ResponseFuture<T> {

--- a/tower/src/load/completion.rs
+++ b/tower/src/load/completion.rs
@@ -1,7 +1,7 @@
 //! Application-specific request completion semantics.
 
 use futures_core::ready;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
@@ -44,14 +44,15 @@ pub trait TrackCompletion<H, V>: Clone {
 #[non_exhaustive]
 pub struct CompleteOnResponse;
 
-/// Attaches a `C`-typed completion tracker to the result of an `F`-typed [`Future`].
-#[pin_project]
-#[derive(Debug)]
-pub struct TrackCompletionFuture<F, C, H> {
-    #[pin]
-    future: F,
-    handle: Option<H>,
-    completion: C,
+pin_project! {
+    /// Attaches a `C`-typed completion tracker to the result of an `F`-typed [`Future`].
+    #[derive(Debug)]
+    pub struct TrackCompletionFuture<F, C, H> {
+        #[pin]
+        future: F,
+        handle: Option<H>,
+        completion: C,
+    }
 }
 
 // ===== impl InstrumentFuture =====

--- a/tower/src/load/constant.rs
+++ b/tower/src/load/constant.rs
@@ -8,19 +8,21 @@ use futures_core::{ready, Stream};
 use std::pin::Pin;
 
 use super::Load;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::task::{Context, Poll};
 use tower_service::Service;
 
-/// Wraps a type so that it implements [`Load`] and returns a constant load metric.
-///
-/// This load estimator is primarily useful for testing.
-#[pin_project]
-#[derive(Debug)]
-pub struct Constant<T, M> {
-    inner: T,
-    load: M,
+pin_project! {
+    #[derive(Debug)]
+    /// Wraps a type so that it implements [`Load`] and returns a constant load metric.
+    ///
+    /// This load estimator is primarily useful for testing.
+    pub struct Constant<T, M> {
+        inner: T,
+        load: M,
+    }
 }
+
 
 // ===== impl Constant =====
 

--- a/tower/src/load/constant.rs
+++ b/tower/src/load/constant.rs
@@ -23,7 +23,6 @@ pin_project! {
     }
 }
 
-
 // ===== impl Constant =====
 
 impl<T, M: Copy> Constant<T, M> {

--- a/tower/src/load/peak_ewma.rs
+++ b/tower/src/load/peak_ewma.rs
@@ -378,11 +378,11 @@ mod tests {
 
         time::advance(Duration::from_millis(100)).await;
         let () = assert_ready_ok!(rsp0.poll());
-        assert_eq!(svc.load(), Cost(404_000_000.0));
+        assert_eq!(svc.load(), Cost(400_000_000.0));
 
         time::advance(Duration::from_millis(100)).await;
         let () = assert_ready_ok!(rsp1.poll());
-        assert_eq!(svc.load(), Cost(202_000_000.0));
+        assert_eq!(svc.load(), Cost(200_000_000.0));
 
         // Check that values decay as time elapses
         time::advance(Duration::from_secs(1)).await;

--- a/tower/src/load/peak_ewma.rs
+++ b/tower/src/load/peak_ewma.rs
@@ -48,11 +48,11 @@ pub struct PeakEwma<S, C = CompleteOnResponse> {
     completion: C,
 }
 
+#[cfg(feature = "discover")]
+#[cfg_attr(docsrs, doc(cfg(feature = "discover")))]
 pin_project! {
     /// Wraps a `D`-typed stream of discovered services with `PeakEwma`.
     #[derive(Debug)]
-    #[cfg(feature = "discover")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "discover")))]
     pub struct PeakEwmaDiscover<D, C = CompleteOnResponse> {
         #[pin]
         discover: D,

--- a/tower/src/load/peak_ewma.rs
+++ b/tower/src/load/peak_ewma.rs
@@ -48,7 +48,6 @@ pub struct PeakEwma<S, C = CompleteOnResponse> {
     completion: C,
 }
 
-
 pin_project! {
     /// Wraps a `D`-typed stream of discovered services with `PeakEwma`.
     #[derive(Debug)]
@@ -62,7 +61,6 @@ pin_project! {
         completion: C,
     }
 }
-
 
 /// Represents the relative cost of communicating with a service.
 ///

--- a/tower/src/load/peak_ewma.rs
+++ b/tower/src/load/peak_ewma.rs
@@ -5,7 +5,7 @@ use crate::discover::{Change, Discover};
 #[cfg(feature = "discover")]
 use futures_core::{ready, Stream};
 #[cfg(feature = "discover")]
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 #[cfg(feature = "discover")]
 use std::pin::Pin;
 
@@ -48,18 +48,21 @@ pub struct PeakEwma<S, C = CompleteOnResponse> {
     completion: C,
 }
 
-/// Wraps a `D`-typed stream of discovered services with `PeakEwma`.
-#[pin_project]
-#[derive(Debug)]
-#[cfg(feature = "discover")]
-#[cfg_attr(docsrs, doc(cfg(feature = "discover")))]
-pub struct PeakEwmaDiscover<D, C = CompleteOnResponse> {
-    #[pin]
-    discover: D,
-    decay_ns: f64,
-    default_rtt: Duration,
-    completion: C,
+
+pin_project! {
+    /// Wraps a `D`-typed stream of discovered services with `PeakEwma`.
+    #[derive(Debug)]
+    #[cfg(feature = "discover")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "discover")))]
+    pub struct PeakEwmaDiscover<D, C = CompleteOnResponse> {
+        #[pin]
+        discover: D,
+        decay_ns: f64,
+        default_rtt: Duration,
+        completion: C,
+    }
 }
+
 
 /// Represents the relative cost of communicating with a service.
 ///

--- a/tower/src/load/pending_requests.rs
+++ b/tower/src/load/pending_requests.rs
@@ -27,11 +27,11 @@ pub struct PendingRequests<S, C = CompleteOnResponse> {
 #[derive(Clone, Debug, Default)]
 struct RefCount(Arc<()>);
 
+#[cfg(feature = "discover")]
+#[cfg_attr(docsrs, doc(cfg(feature = "discover")))]
 pin_project! {
     /// Wraps a `D`-typed stream of discovered services with [`PendingRequests`].
     #[derive(Debug)]
-    #[cfg(feature = "discover")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "discover")))]
     pub struct PendingRequestsDiscover<D, C = CompleteOnResponse> {
         #[pin]
         discover: D,

--- a/tower/src/load/pending_requests.rs
+++ b/tower/src/load/pending_requests.rs
@@ -27,7 +27,6 @@ pub struct PendingRequests<S, C = CompleteOnResponse> {
 #[derive(Clone, Debug, Default)]
 struct RefCount(Arc<()>);
 
-
 pin_project! {
     /// Wraps a `D`-typed stream of discovered services with [`PendingRequests`].
     #[derive(Debug)]

--- a/tower/src/load/pending_requests.rs
+++ b/tower/src/load/pending_requests.rs
@@ -5,7 +5,7 @@ use crate::discover::{Change, Discover};
 #[cfg(feature = "discover")]
 use futures_core::{ready, Stream};
 #[cfg(feature = "discover")]
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 #[cfg(feature = "discover")]
 use std::pin::Pin;
 
@@ -27,15 +27,17 @@ pub struct PendingRequests<S, C = CompleteOnResponse> {
 #[derive(Clone, Debug, Default)]
 struct RefCount(Arc<()>);
 
-/// Wraps a `D`-typed stream of discovered services with [`PendingRequests`].
-#[pin_project]
-#[derive(Debug)]
-#[cfg(feature = "discover")]
-#[cfg_attr(docsrs, doc(cfg(feature = "discover")))]
-pub struct PendingRequestsDiscover<D, C = CompleteOnResponse> {
-    #[pin]
-    discover: D,
-    completion: C,
+
+pin_project! {
+    /// Wraps a `D`-typed stream of discovered services with [`PendingRequests`].
+    #[derive(Debug)]
+    #[cfg(feature = "discover")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "discover")))]
+    pub struct PendingRequestsDiscover<D, C = CompleteOnResponse> {
+        #[pin]
+        discover: D,
+        completion: C,
+    }
 }
 
 /// Represents the number of currently-pending requests to a given service.

--- a/tower/src/load_shed/future.rs
+++ b/tower/src/load_shed/future.rs
@@ -6,26 +6,29 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use futures_core::ready;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
 use super::error::Overloaded;
 
-/// Future for the [`LoadShed`] service.
-///
-/// [`LoadShed`]: crate::load_shed::LoadShed
-#[pin_project]
-pub struct ResponseFuture<F> {
-    #[pin]
-    state: ResponseState<F>,
+pin_project! {
+    /// Future for the [`LoadShed`] service.
+    ///
+    /// [`LoadShed`]: crate::load_shed::LoadShed
+    pub struct ResponseFuture<F> {
+        #[pin]
+        state: ResponseState<F>,
+    }
 }
 
-#[pin_project(project = ResponseStateProj)]
-enum ResponseState<F> {
-    Called {
-        #[pin]
-        fut: F
-    },
-    Overloaded,
+pin_project! {
+    #[project = ResponseStateProj]
+    enum ResponseState<F> {
+        Called {
+            #[pin]
+            fut: F
+        },
+        Overloaded,
+    }
 }
 
 impl<F> ResponseFuture<F> {

--- a/tower/src/load_shed/future.rs
+++ b/tower/src/load_shed/future.rs
@@ -54,7 +54,9 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.project().state.project() {
-            ResponseStateProj::Called { fut } => Poll::Ready(ready!(fut.poll(cx)).map_err(Into::into)),
+            ResponseStateProj::Called { fut } => {
+                Poll::Ready(ready!(fut.poll(cx)).map_err(Into::into))
+            }
             ResponseStateProj::Overloaded => Poll::Ready(Err(Overloaded::new().into())),
         }
     }

--- a/tower/src/macros.rs
+++ b/tower/src/macros.rs
@@ -8,7 +8,18 @@ macro_rules! opaque_future {
     ($(#[$m:meta])* pub type $name:ident<$($param:ident),+> = $actual:ty;) => {
         #[pin_project::pin_project]
         $(#[$m])*
-        pub struct $name<$($param),+>(#[pin] pub(crate) $actual);
+        pub struct $name<$($param),+> {
+            #[pin]
+            inner: $actual
+        }
+
+        impl<$($param),+> $name<$($param),+> {
+            pub(crate) fn new(inner: $actual) -> Self {
+                Self {
+                    inner
+                }
+            }
+        }
 
         impl<$($param),+> std::fmt::Debug for $name<$($param),+> {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -23,7 +34,7 @@ macro_rules! opaque_future {
             type Output = <$actual as std::future::Future>::Output;
             #[inline]
             fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Self::Output> {
-                self.project().0.poll(cx)
+                self.project().inner.poll(cx)
             }
         }
     }

--- a/tower/src/macros.rs
+++ b/tower/src/macros.rs
@@ -6,11 +6,12 @@
 ))]
 macro_rules! opaque_future {
     ($(#[$m:meta])* pub type $name:ident<$($param:ident),+> = $actual:ty;) => {
-        #[pin_project::pin_project]
-        $(#[$m])*
-        pub struct $name<$($param),+> {
-            #[pin]
-            inner: $actual
+        pin_project_lite::pin_project! {
+            $(#[$m])*
+            pub struct $name<$($param),+> {
+                #[pin]
+                inner: $actual
+            }
         }
 
         impl<$($param),+> $name<$($param),+> {

--- a/tower/src/make/make_service/shared.rs
+++ b/tower/src/make/make_service/shared.rs
@@ -93,7 +93,7 @@ where
     }
 
     fn call(&mut self, _target: T) -> Self::Future {
-        SharedFuture(futures_util::future::ready(Ok(self.service.clone())))
+        SharedFuture::new(futures_util::future::ready(Ok(self.service.clone())))
     }
 }
 

--- a/tower/src/retry/mod.rs
+++ b/tower/src/retry/mod.rs
@@ -25,7 +25,6 @@ pin_project! {
     }
 }
 
-
 // ===== impl Retry =====
 
 impl<P, S> Retry<P, S> {

--- a/tower/src/retry/mod.rs
+++ b/tower/src/retry/mod.rs
@@ -9,20 +9,22 @@ pub use self::layer::RetryLayer;
 pub use self::policy::Policy;
 
 use self::future::ResponseFuture;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::task::{Context, Poll};
 use tower_service::Service;
 
-/// Configure retrying requests of "failed" responses.
-///
-/// A [`Policy`] classifies what is a "failed" response.
-#[pin_project]
-#[derive(Clone, Debug)]
-pub struct Retry<P, S> {
-    #[pin]
-    policy: P,
-    service: S,
+pin_project! {
+    /// Configure retrying requests of "failed" responses.
+    ///
+    /// A [`Policy`] classifies what is a "failed" response.
+    #[derive(Clone, Debug)]
+    pub struct Retry<P, S> {
+        #[pin]
+        policy: P,
+        service: S,
+    }
 }
+
 
 // ===== impl Retry =====
 

--- a/tower/src/spawn_ready/make.rs
+++ b/tower/src/spawn_ready/make.rs
@@ -1,6 +1,6 @@
 use super::SpawnReady;
 use futures_core::ready;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
@@ -21,12 +21,13 @@ impl<S> MakeSpawnReady<S> {
     }
 }
 
-/// Builds a [`SpawnReady`] with the result of an inner [`Future`].
-#[pin_project]
-#[derive(Debug)]
-pub struct MakeFuture<F> {
-    #[pin]
-    inner: F,
+pin_project! {
+    /// Builds a [`SpawnReady`] with the result of an inner [`Future`].
+    #[derive(Debug)]
+    pub struct MakeFuture<F> {
+        #[pin]
+        inner: F,
+    }
 }
 
 impl<S, Target> Service<Target> for MakeSpawnReady<S>

--- a/tower/src/spawn_ready/service.rs
+++ b/tower/src/spawn_ready/service.rs
@@ -75,7 +75,7 @@ where
     fn call(&mut self, request: Req) -> Self::Future {
         match self.inner {
             Inner::Service(Some(ref mut svc)) => {
-                ResponseFuture(svc.call(request).map_err(Into::into))
+                ResponseFuture::new(svc.call(request).map_err(Into::into))
             }
             _ => unreachable!("poll_ready must be called"),
         }

--- a/tower/src/timeout/future.rs
+++ b/tower/src/timeout/future.rs
@@ -1,7 +1,7 @@
 //! Future types
 
 use super::error::Elapsed;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
@@ -9,16 +9,17 @@ use std::{
 };
 use tokio::time::Sleep;
 
-/// [`Timeout`] response future
-///
-/// [`Timeout`]: crate::timeout::Timeout
-#[pin_project]
-#[derive(Debug)]
-pub struct ResponseFuture<T> {
-    #[pin]
-    response: T,
-    #[pin]
-    sleep: Sleep,
+pin_project! {
+    /// [`Timeout`] response future
+    ///
+    /// [`Timeout`]: crate::timeout::Timeout
+    #[derive(Debug)]
+    pub struct ResponseFuture<T> {
+        #[pin]
+        response: T,
+        #[pin]
+        sleep: Sleep,
+    }
 }
 
 impl<T> ResponseFuture<T> {

--- a/tower/src/util/and_then.rs
+++ b/tower/src/util/and_then.rs
@@ -28,13 +28,14 @@ where
     }
 }
 
-/// Response future from [`AndThen`] services.
-///
-/// [`AndThen`]: crate::util::AndThen
-#[pin_project::pin_project]
-pub struct AndThenFuture<F1, F2: TryFuture, N> {
-    #[pin]
-    inner: future::AndThen<future::ErrInto<F1, F2::Error>, F2, N>,
+pin_project_lite::pin_project! {
+    /// Response future from [`AndThen`] services.
+    ///
+    /// [`AndThen`]: crate::util::AndThen
+    pub struct AndThenFuture<F1, F2: TryFuture, N> {
+        #[pin]
+        inner: future::AndThen<future::ErrInto<F1, F2::Error>, F2, N>,
+    }
 }
 
 impl<F1, F2: TryFuture, N> AndThenFuture<F1, F2, N> {

--- a/tower/src/util/and_then.rs
+++ b/tower/src/util/and_then.rs
@@ -32,9 +32,16 @@ where
 ///
 /// [`AndThen`]: crate::util::AndThen
 #[pin_project::pin_project]
-pub struct AndThenFuture<F1, F2: TryFuture, N>(
-    #[pin] pub(crate) future::AndThen<future::ErrInto<F1, F2::Error>, F2, N>,
-);
+pub struct AndThenFuture<F1, F2: TryFuture, N> {
+    #[pin]
+    inner: future::AndThen<future::ErrInto<F1, F2::Error>, F2, N>,
+}
+
+impl<F1, F2: TryFuture, N> AndThenFuture<F1, F2, N> {
+    pub(crate) fn new(inner: future::AndThen<future::ErrInto<F1, F2::Error>, F2, N>) -> Self {
+        Self { inner }
+    }
+}
 
 impl<F1, F2: TryFuture, N> std::fmt::Debug for AndThenFuture<F1, F2, N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -52,7 +59,7 @@ where
 
     #[inline]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.project().0.poll(cx)
+        self.project().inner.poll(cx)
     }
 }
 
@@ -96,7 +103,7 @@ where
     }
 
     fn call(&mut self, request: Request) -> Self::Future {
-        AndThenFuture(self.inner.call(request).err_into().and_then(self.f.clone()))
+        AndThenFuture::new(self.inner.call(request).err_into().and_then(self.f.clone()))
     }
 }
 

--- a/tower/src/util/call_all/common.rs
+++ b/tower/src/util/call_all/common.rs
@@ -1,5 +1,5 @@
 use futures_core::{ready, Stream};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
@@ -7,15 +7,16 @@ use std::{
 };
 use tower_service::Service;
 
-/// The [`Future`] returned by the [`ServiceExt::call_all`] combinator.
-#[pin_project]
-#[derive(Debug)]
-pub(crate) struct CallAll<Svc, S, Q> {
-    service: Option<Svc>,
-    #[pin]
-    stream: S,
-    queue: Q,
-    eof: bool,
+pin_project! {
+    /// The [`Future`] returned by the [`ServiceExt::call_all`] combinator.
+    #[derive(Debug)]
+    pub(crate) struct CallAll<Svc, S, Q> {
+        service: Option<Svc>,
+        #[pin]
+        stream: S,
+        queue: Q,
+        eof: bool,
+    }
 }
 
 pub(crate) trait Drive<F: Future> {

--- a/tower/src/util/call_all/ordered.rs
+++ b/tower/src/util/call_all/ordered.rs
@@ -6,7 +6,7 @@
 use super::common;
 use futures_core::Stream;
 use futures_util::stream::FuturesOrdered;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
@@ -14,84 +14,85 @@ use std::{
 };
 use tower_service::Service;
 
-/// This is a [`Stream`] of responses resulting from calling the wrapped [`Service`] for each
-/// request received on the wrapped [`Stream`].
-///
-/// ```rust
-/// # use std::task::{Poll, Context};
-/// # use std::cell::Cell;
-/// # use std::error::Error;
-/// # use std::rc::Rc;
-/// #
-/// use futures::future::{ready, Ready};
-/// use futures::StreamExt;
-/// use futures::channel::mpsc;
-/// use tower_service::Service;
-/// use tower::util::ServiceExt;
-///
-/// // First, we need to have a Service to process our requests.
-/// #[derive(Debug, Eq, PartialEq)]
-/// struct FirstLetter;
-/// impl Service<&'static str> for FirstLetter {
-///      type Response = &'static str;
-///      type Error = Box<dyn Error + Send + Sync>;
-///      type Future = Ready<Result<Self::Response, Self::Error>>;
-///
-///      fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-///          Poll::Ready(Ok(()))
-///      }
-///
-///      fn call(&mut self, req: &'static str) -> Self::Future {
-///          ready(Ok(&req[..1]))
-///      }
-/// }
-///
-/// #[tokio::main]
-/// async fn main() {
-///     // Next, we need a Stream of requests.
-// TODO(eliza): when `tokio-util` has a nice way to convert MPSCs to streams,
-//              tokio::sync::mpsc again?
-///     let (mut reqs, rx) = mpsc::unbounded();
-///     // Note that we have to help Rust out here by telling it what error type to use.
-///     // Specifically, it has to be From<Service::Error> + From<Stream::Error>.
-///     let mut rsps = FirstLetter.call_all(rx);
-///
-///     // Now, let's send a few requests and then check that we get the corresponding responses.
-///     reqs.unbounded_send("one").unwrap();
-///     reqs.unbounded_send("two").unwrap();
-///     reqs.unbounded_send("three").unwrap();
-///     drop(reqs);
-///
-///     // We then loop over the response Strem that we get back from call_all.
-///     let mut i = 0usize;
-///     while let Some(rsp) = rsps.next().await {
-///         // Each response is a Result (we could also have used TryStream::try_next)
-///         match (i + 1, rsp.unwrap()) {
-///             (1, "o") |
-///             (2, "t") |
-///             (3, "t") => {}
-///             (n, i) => {
-///                 unreachable!("{}. response was '{}'", n, i);
-///             }
-///         }
-///         i += 1;
-///     }
-///
-///     // And at the end, we can get the Service back when there are no more requests.
-///     assert_eq!(rsps.into_inner(), FirstLetter);
-/// }
-/// ```
-///
-/// [`Stream`]: https://docs.rs/futures/latest/futures/stream/trait.Stream.html
-#[pin_project]
-#[derive(Debug)]
-pub struct CallAll<Svc, S>
-where
-    Svc: Service<S::Item>,
-    S: Stream,
-{
-    #[pin]
-    inner: common::CallAll<Svc, S, FuturesOrdered<Svc::Future>>,
+pin_project! {
+    /// This is a [`Stream`] of responses resulting from calling the wrapped [`Service`] for each
+    /// request received on the wrapped [`Stream`].
+    ///
+    /// ```rust
+    /// # use std::task::{Poll, Context};
+    /// # use std::cell::Cell;
+    /// # use std::error::Error;
+    /// # use std::rc::Rc;
+    /// #
+    /// use futures::future::{ready, Ready};
+    /// use futures::StreamExt;
+    /// use futures::channel::mpsc;
+    /// use tower_service::Service;
+    /// use tower::util::ServiceExt;
+    ///
+    /// // First, we need to have a Service to process our requests.
+    /// #[derive(Debug, Eq, PartialEq)]
+    /// struct FirstLetter;
+    /// impl Service<&'static str> for FirstLetter {
+    ///      type Response = &'static str;
+    ///      type Error = Box<dyn Error + Send + Sync>;
+    ///      type Future = Ready<Result<Self::Response, Self::Error>>;
+    ///
+    ///      fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    ///          Poll::Ready(Ok(()))
+    ///      }
+    ///
+    ///      fn call(&mut self, req: &'static str) -> Self::Future {
+    ///          ready(Ok(&req[..1]))
+    ///      }
+    /// }
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     // Next, we need a Stream of requests.
+    // TODO(eliza): when `tokio-util` has a nice way to convert MPSCs to streams,
+    //              tokio::sync::mpsc again?
+    ///     let (mut reqs, rx) = mpsc::unbounded();
+    ///     // Note that we have to help Rust out here by telling it what error type to use.
+    ///     // Specifically, it has to be From<Service::Error> + From<Stream::Error>.
+    ///     let mut rsps = FirstLetter.call_all(rx);
+    ///
+    ///     // Now, let's send a few requests and then check that we get the corresponding responses.
+    ///     reqs.unbounded_send("one").unwrap();
+    ///     reqs.unbounded_send("two").unwrap();
+    ///     reqs.unbounded_send("three").unwrap();
+    ///     drop(reqs);
+    ///
+    ///     // We then loop over the response Strem that we get back from call_all.
+    ///     let mut i = 0usize;
+    ///     while let Some(rsp) = rsps.next().await {
+    ///         // Each response is a Result (we could also have used TryStream::try_next)
+    ///         match (i + 1, rsp.unwrap()) {
+    ///             (1, "o") |
+    ///             (2, "t") |
+    ///             (3, "t") => {}
+    ///             (n, i) => {
+    ///                 unreachable!("{}. response was '{}'", n, i);
+    ///             }
+    ///         }
+    ///         i += 1;
+    ///     }
+    ///
+    ///     // And at the end, we can get the Service back when there are no more requests.
+    ///     assert_eq!(rsps.into_inner(), FirstLetter);
+    /// }
+    /// ```
+    ///
+    /// [`Stream`]: https://docs.rs/futures/latest/futures/stream/trait.Stream.html
+    #[derive(Debug)]
+    pub struct CallAll<Svc, S>
+    where
+        Svc: Service<S::Item>,
+        S: Stream,
+    {
+        #[pin]
+        inner: common::CallAll<Svc, S, FuturesOrdered<Svc::Future>>,
+    }
 }
 
 impl<Svc, S> CallAll<Svc, S>

--- a/tower/src/util/call_all/unordered.rs
+++ b/tower/src/util/call_all/unordered.rs
@@ -6,7 +6,7 @@
 use super::common;
 use futures_core::Stream;
 use futures_util::stream::FuturesUnordered;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
@@ -14,21 +14,22 @@ use std::{
 };
 use tower_service::Service;
 
-/// A stream of responses received from the inner service in received order.
-///
-/// Similar to [`CallAll`] except, instead of yielding responses in request order,
-/// responses are returned as they are available.
-///
-/// [`CallAll`]: crate::util::CallAll
-#[pin_project]
-#[derive(Debug)]
-pub struct CallAllUnordered<Svc, S>
-where
-    Svc: Service<S::Item>,
-    S: Stream,
-{
-    #[pin]
-    inner: common::CallAll<Svc, S, FuturesUnordered<Svc::Future>>,
+pin_project! {
+    /// A stream of responses received from the inner service in received order.
+    ///
+    /// Similar to [`CallAll`] except, instead of yielding responses in request order,
+    /// responses are returned as they are available.
+    ///
+    /// [`CallAll`]: crate::util::CallAll
+    #[derive(Debug)]
+    pub struct CallAllUnordered<Svc, S>
+    where
+        Svc: Service<S::Item>,
+        S: Stream,
+    {
+        #[pin]
+        inner: common::CallAll<Svc, S, FuturesUnordered<Svc::Future>>,
+    }
 }
 
 impl<Svc, S> CallAllUnordered<Svc, S>

--- a/tower/src/util/map_err.rs
+++ b/tower/src/util/map_err.rs
@@ -72,7 +72,7 @@ where
 
     #[inline]
     fn call(&mut self, request: Request) -> Self::Future {
-        MapErrFuture(self.inner.call(request).map_err(self.f.clone()))
+        MapErrFuture::new(self.inner.call(request).map_err(self.f.clone()))
     }
 }
 

--- a/tower/src/util/map_response.rs
+++ b/tower/src/util/map_response.rs
@@ -72,7 +72,7 @@ where
 
     #[inline]
     fn call(&mut self, request: Request) -> Self::Future {
-        MapResponseFuture(self.inner.call(request).map_ok(self.f.clone()))
+        MapResponseFuture::new(self.inner.call(request).map_ok(self.f.clone()))
     }
 }
 

--- a/tower/src/util/map_result.rs
+++ b/tower/src/util/map_result.rs
@@ -73,7 +73,7 @@ where
 
     #[inline]
     fn call(&mut self, request: Request) -> Self::Future {
-        MapResultFuture(self.inner.call(request).map(self.f.clone()))
+        MapResultFuture::new(self.inner.call(request).map(self.f.clone()))
     }
 }
 

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -133,7 +133,7 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// # struct DatabaseService;
     /// # impl DatabaseService {
     /// #   fn new(address: &str) -> Self {
-    /// #       DatabaseService  
+    /// #       DatabaseService
     /// #   }
     /// # }
     /// #

--- a/tower/src/util/oneshot.rs
+++ b/tower/src/util/oneshot.rs
@@ -1,5 +1,5 @@
 use futures_core::ready;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     fmt,
     future::Future,
@@ -8,27 +8,30 @@ use std::{
 };
 use tower_service::Service;
 
-/// A [`Future`] consuming a [`Service`] and request, waiting until the [`Service`]
-/// is ready, and then calling [`Service::call`] with the request, and
-/// waiting for that [`Future`].
-#[pin_project]
-#[derive(Debug)]
-pub struct Oneshot<S: Service<Req>, Req> {
-    #[pin]
-    state: State<S, Req>,
+pin_project! {
+    /// A [`Future`] consuming a [`Service`] and request, waiting until the [`Service`]
+    /// is ready, and then calling [`Service::call`] with the request, and
+    /// waiting for that [`Future`].
+    #[derive(Debug)]
+    pub struct Oneshot<S: Service<Req>, Req> {
+        #[pin]
+        state: State<S, Req>,
+    }
 }
 
-#[pin_project(project = StateProj)]
-enum State<S: Service<Req>, Req> {
-    NotReady {
-        svc: S,
-        req: Option<Req>,
-    },
-    Called {
-        #[pin]
-        fut: S::Future,
-    },
-    Done,
+pin_project! {
+    #[project = StateProj]
+    enum State<S: Service<Req>, Req> {
+        NotReady {
+            svc: S,
+            req: Option<Req>,
+        },
+        Called {
+            #[pin]
+            fut: S::Future,
+        },
+        Done,
+    }
 }
 
 impl<S: Service<Req>, Req> State<S, Req> {

--- a/tower/src/util/optional/future.rs
+++ b/tower/src/util/optional/future.rs
@@ -1,20 +1,21 @@
 use super::error;
 use futures_core::ready;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
 
-/// Response future returned by [`Optional`].
-///
-/// [`Optional`]: crate::util::Optional
-#[pin_project]
-#[derive(Debug)]
-pub struct ResponseFuture<T> {
-    #[pin]
-    inner: Option<T>,
+pin_project! {
+    /// Response future returned by [`Optional`].
+    ///
+    /// [`Optional`]: crate::util::Optional
+    #[derive(Debug)]
+    pub struct ResponseFuture<T> {
+        #[pin]
+        inner: Option<T>,
+    }
 }
 
 impl<T> ResponseFuture<T> {

--- a/tower/src/util/then.rs
+++ b/tower/src/util/then.rs
@@ -77,7 +77,7 @@ where
 
     #[inline]
     fn call(&mut self, request: Request) -> Self::Future {
-        ThenFuture(self.inner.call(request).then(self.f.clone()))
+        ThenFuture::new(self.inner.call(request).then(self.f.clone()))
     }
 }
 

--- a/tower/tests/balance/main.rs
+++ b/tower/tests/balance/main.rs
@@ -37,7 +37,7 @@ fn stress() {
     let _t = support::trace_init();
     let mut task = task::spawn(());
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Result<_, &'static str>>();
-    let mut cache = Balance::<_, Req>::new(support::IntoStream(rx));
+    let mut cache = Balance::<_, Req>::new(support::IntoStream::new(rx));
 
     let mut nready = 0;
     let mut services = slab::Slab::<(mock::Handle<Req, Req>, bool)>::new();

--- a/tower/tests/spawn_ready/main.rs
+++ b/tower/tests/spawn_ready/main.rs
@@ -81,5 +81,6 @@ async fn abort_on_drop() {
     // End the task and ensure that the inner service has been dropped.
     assert!(drop_tx.send(()).is_ok());
     tokio_test::assert_ready!(task.poll());
+    tokio::task::yield_now().await;
     assert!(tokio_test::assert_ready!(handle.poll_request()).is_none());
 }

--- a/tower/tests/util/call_all.rs
+++ b/tower/tests/util/call_all.rs
@@ -51,7 +51,7 @@ fn ordered() {
         admit: admit.clone(),
     };
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-    let ca = srv.call_all(support::IntoStream(rx));
+    let ca = srv.call_all(support::IntoStream::new(rx));
     pin_mut!(ca);
 
     assert_pending!(mock.enter(|cx, _| ca.as_mut().poll_next(cx)));


### PR DESCRIPTION
Clears out the easy parts of #594.

Remaining:

- [ ] `util::Either` -  it is public and the migration requires a breaking change ([as described here](https://github.com/tower-rs/tower/issues/594#issuecomment-885942142))
- [x] `buffer::worker` - would love to take a shot at the refactor with a little more guidance.