### PR TITLE
Implement `Layer` for `ServiceBuilder`

### DIFF
--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-Nothing yet.
+- **builder**: Implement `Layer` for `ServiceBuilder`.
 
 # 0.4.8 (May 28, 2021)
 

--- a/tower/src/builder/mod.rs
+++ b/tower/src/builder/mod.rs
@@ -673,3 +673,14 @@ impl<L: fmt::Debug> fmt::Debug for ServiceBuilder<L> {
         f.debug_tuple("ServiceBuilder").field(&self.layer).finish()
     }
 }
+
+impl<S, L> Layer<S> for ServiceBuilder<L>
+where
+    L: Layer<S>,
+{
+    type Service = L::Service;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        self.layer.layer(inner)
+    }
+}


### PR DESCRIPTION
@jonhoo from discord:

> I may feel silly for asking this, but why doesn't ServiceBuilder implement Layer?
> Like, it has into_inner, but why is the indirection required?

I have wondered the same thing. It compiles and seems sensible to me.