### PR TITLE
tower: prepare to release 0.4.9

### DIFF
--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -7,9 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- **builder**: Implement `Layer` for `ServiceBuilder`.
+- None.
+
+# 0.4.9 (October 13, 2021)
+
+- Migrate to pin-project-lite ([#595])
+- **builder**: Implement `Layer` for `ServiceBuilder` ([#600])
 - **builder**: Add `ServiceBuilder::and_then` analogous to
-  `ServiceExt::and_then`
+  `ServiceExt::and_then` ([#601])
+
+[#600]: https://github.com/tower-rs/tower/pull/600
+[#601]: https://github.com/tower-rs/tower/pull/601
+[#595]: https://github.com/tower-rs/tower/pull/595
+[pin-project-lite]: https://crates.io/crates/pin-project-lite
 
 # 0.4.8 (May 28, 2021)
 

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -8,13 +8,13 @@ name = "tower"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "vX.X.X" git tag.
-version = "0.4.8"
+version = "0.4.9"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tower-rs/tower"
 homepage = "https://github.com/tower-rs/tower"
-documentation = "https://docs.rs/tower/0.4.8"
+documentation = "https://docs.rs/tower/0.4.9"
 description = """
 Tower is a library of modular and reusable components for building robust
 clients and servers.

--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tower/0.4.8")]
+#![doc(html_root_url = "https://docs.rs/tower/0.4.9")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
- Migrate to pin-project-lite ([#595])
- **builder**: Implement `Layer` for `ServiceBuilder` ([#600])
- **builder**: Add `ServiceBuilder::and_then` analogous to
  `ServiceExt::and_then` ([#601])

[#600]: https://github.com/tower-rs/tower/pull/600
[#601]: https://github.com/tower-rs/tower/pull/601
[#595]: https://github.com/tower-rs/tower/pull/595
[pin-project-lite]: https://crates.io/crates/pin-project-lite