### PR TITLE
docs: Fix `doc(cfg(...))` attributes

### DIFF
--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -19,8 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for `Steer` ([#607])
 - **util**: Remove redundant `F: Clone` bound
   from `ServiceExt::map_request` ([#607])
+- **docs**: Fix `doc(cfg(...))` attributes
+  of `PeakEwmaDiscover`, and `PendingRequestsDiscover` ([#610])
 
 [#607]: https://github.com/tower-rs/tower/pull/607
+[#610]: https://github.com/tower-rs/tower/pull/610
 
 # 0.4.10 (October 19, 2021)
 

--- a/tower/src/load/peak_ewma.rs
+++ b/tower/src/load/peak_ewma.rs
@@ -49,9 +49,9 @@ pub struct PeakEwma<S, C = CompleteOnResponse> {
 }
 
 #[cfg(feature = "discover")]
-#[cfg_attr(docsrs, doc(cfg(feature = "discover")))]
 pin_project! {
     /// Wraps a `D`-typed stream of discovered services with `PeakEwma`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "discover")))]
     #[derive(Debug)]
     pub struct PeakEwmaDiscover<D, C = CompleteOnResponse> {
         #[pin]

--- a/tower/src/load/pending_requests.rs
+++ b/tower/src/load/pending_requests.rs
@@ -28,9 +28,9 @@ pub struct PendingRequests<S, C = CompleteOnResponse> {
 struct RefCount(Arc<()>);
 
 #[cfg(feature = "discover")]
-#[cfg_attr(docsrs, doc(cfg(feature = "discover")))]
 pin_project! {
     /// Wraps a `D`-typed stream of discovered services with [`PendingRequests`].
+    #[cfg_attr(docsrs, doc(cfg(feature = "discover")))]
     #[derive(Debug)]
     pub struct PendingRequestsDiscover<D, C = CompleteOnResponse> {
         #[pin]


### PR DESCRIPTION
`RUSTDOCFLAGS='--cfg docsrs' cargo +nightly doc --all-features` outputs some warnings
```
warning: unused attribute `doc`
  --> tower/src/load/peak_ewma.rs:52:20
   |
52 | #[cfg_attr(docsrs, doc(cfg(feature = "discover")))]
   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_attributes)]` on by default
note: the built-in attribute `doc` will be ignored, since it's applied to the macro invocation `pin_project`
  --> tower/src/load/peak_ewma.rs:53:1
   |
53 | pin_project! {
   | ^^^^^^^^^^^

warning: unused attribute `doc`
  --> tower/src/load/pending_requests.rs:31:20
   |
31 | #[cfg_attr(docsrs, doc(cfg(feature = "discover")))]
   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
note: the built-in attribute `doc` will be ignored, since it's applied to the macro invocation `pin_project`
  --> tower/src/load/pending_requests.rs:32:1
   |
32 | pin_project! {
   | ^^^^^^^^^^^

warning: `tower` (lib doc) generated 2 warnings
```

This PR is an attempt to fix this.