### PR TITLE
Replace `ready_and()` with `ready()` in docs

### DIFF
--- a/tower/src/util/service_fn.rs
+++ b/tower/src/util/service_fn.rs
@@ -33,7 +33,7 @@ use tower_service::Service;
 /// let mut service = service_fn(handle);
 ///
 /// let response = service
-///     .ready_and()
+///     .ready()
 ///     .await?
 ///     .call(Request::new())
 ///     .await?;


### PR DESCRIPTION
Since `ServiceExt::ready_and()` is deprecated, we should use `ServiceExt::ready()` instead. 