### PR TITLE
util: add `CloneBoxService`

### DIFF
--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **util**: Add `CloneService` which is a `Clone + Send` boxed `Service`.
+
 ### Fixed
 
 - **balance**: Remove redundant `Req: Clone` bound from `Clone` impls

--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- **util**: Add `CloneService` which is a `Clone + Send` boxed `Service`.
+- **util**: Add `CloneBoxService` which is a `Clone + Send` boxed `Service`.
 
 ### Fixed
 

--- a/tower/src/util/boxed/sync.rs
+++ b/tower/src/util/boxed/sync.rs
@@ -15,6 +15,9 @@ use std::{
 /// future type to be dynamic. This type requires both the service and the
 /// response future to be [`Send`].
 ///
+/// If you need a boxed [`Service`] that implements [`Clone`] consider using
+/// [`CloneBoxService`](crate::util::CloneBoxService).
+///
 /// See module level documentation for more details.
 pub struct BoxService<T, U, E> {
     inner: Box<dyn Service<T, Response = U, Error = E, Future = BoxFuture<U, E>> + Send>,

--- a/tower/src/util/clone_boxed.rs
+++ b/tower/src/util/clone_boxed.rs
@@ -1,0 +1,138 @@
+use super::ServiceExt;
+use futures_util::future::BoxFuture;
+use std::{
+    fmt,
+    task::{Context, Poll},
+};
+use tower_layer::{layer_fn, LayerFn};
+use tower_service::Service;
+
+/// A `Clone + Send` boxed `Service`.
+///
+/// [`CloneBoxService`] turns a service into a trait object, allowing the
+/// response future type to be dynamic, and allowing the service to be cloned.
+///
+/// # Example
+///
+/// ```
+/// use tower::{Service, ServiceBuilder, BoxError, util::CloneBoxService};
+/// use std::time::Duration;
+/// #
+/// # struct Request;
+/// # struct Response;
+/// # impl Response {
+/// #     fn new() -> Self { Self }
+/// # }
+///
+/// // This service has a complex type that is hard to name
+/// let service = ServiceBuilder::new()
+///     .map_request(|req| {
+///         println!("received request");
+///         req
+///     })
+///     .map_response(|res| {
+///         println!("response produced");
+///         res
+///     })
+///     .load_shed()
+///     .concurrency_limit(64)
+///     .timeout(Duration::from_secs(10))
+///     .service_fn(|req: Request| async {
+///         Ok::<_, BoxError>(Response::new())
+///     });
+/// # let service = assert_service(service);
+///
+/// // `CloneService` will erase the type so its nameable
+/// let service: CloneBoxService<Request, Response, BoxError> = CloneBoxService::new(service);
+/// # let service = assert_service(service);
+///
+/// // And we can still clone the service
+/// let cloned_service = service.clone();
+/// #
+/// # fn assert_service<S, R>(svc: S) -> S
+/// # where S: Service<R> { svc }
+/// ```
+pub struct CloneBoxService<T, U, E>(
+    Box<
+        dyn CloneService<T, Response = U, Error = E, Future = BoxFuture<'static, Result<U, E>>>
+            + Send,
+    >,
+);
+
+impl<T, U, E> CloneBoxService<T, U, E> {
+    /// Create a new `CloneBoxService`.
+    pub fn new<S>(inner: S) -> Self
+    where
+        S: Service<T, Response = U, Error = E> + Clone + Send + 'static,
+        S::Future: Send + 'static,
+    {
+        let inner = inner.map_future(|f| Box::pin(f) as _);
+        CloneBoxService(Box::new(inner))
+    }
+
+    /// Returns a [`Layer`] for wrapping a [`Service`] in a [`CloneBoxService`]
+    /// middleware.
+    ///
+    /// [`Layer`]: crate::Layer
+    pub fn layer<S>() -> LayerFn<fn(S) -> Self>
+    where
+        S: Service<T, Response = U, Error = E> + Clone + Send + 'static,
+        S::Future: Send + 'static,
+    {
+        layer_fn(Self::new)
+    }
+}
+
+impl<T, U, E> Service<T> for CloneBoxService<T, U, E> {
+    type Response = U;
+    type Error = E;
+    type Future = BoxFuture<'static, Result<U, E>>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), E>> {
+        self.0.poll_ready(cx)
+    }
+
+    #[inline]
+    fn call(&mut self, request: T) -> Self::Future {
+        self.0.call(request)
+    }
+}
+
+impl<T, U, E> Clone for CloneBoxService<T, U, E> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone_box())
+    }
+}
+
+trait CloneService<R>: Service<R> {
+    fn clone_box(
+        &self,
+    ) -> Box<
+        dyn CloneService<R, Response = Self::Response, Error = Self::Error, Future = Self::Future>
+            + Send,
+    >;
+}
+
+impl<R, T> CloneService<R> for T
+where
+    T: Service<R> + Send + Clone + 'static,
+{
+    fn clone_box(
+        &self,
+    ) -> Box<dyn CloneService<R, Response = T::Response, Error = T::Error, Future = T::Future> + Send>
+    {
+        Box::new(self.clone())
+    }
+}
+
+impl<T, U, E> fmt::Debug for CloneBoxService<T, U, E>
+where
+    T: fmt::Debug,
+    U: fmt::Debug,
+    E: fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("CloneBoxService").finish()
+    }
+}

--- a/tower/src/util/clone_boxed.rs
+++ b/tower/src/util/clone_boxed.rs
@@ -7,10 +7,13 @@ use std::{
 use tower_layer::{layer_fn, LayerFn};
 use tower_service::Service;
 
-/// A `Clone + Send` boxed `Service`.
+/// A [`Clone`] + [`Send`] boxed [`Service`].
 ///
 /// [`CloneBoxService`] turns a service into a trait object, allowing the
 /// response future type to be dynamic, and allowing the service to be cloned.
+///
+/// This is similar to [`BoxService`](super::BoxService) except the resulting
+/// service implements [`Clone`].
 ///
 /// # Example
 ///
@@ -42,7 +45,7 @@ use tower_service::Service;
 ///     });
 /// # let service = assert_service(service);
 ///
-/// // `CloneService` will erase the type so its nameable
+/// // `CloneBoxService` will erase the type so it's nameable
 /// let service: CloneBoxService<Request, Response, BoxError> = CloneBoxService::new(service);
 /// # let service = assert_service(service);
 ///

--- a/tower/src/util/clone_boxed.rs
+++ b/tower/src/util/clone_boxed.rs
@@ -129,12 +129,7 @@ where
     }
 }
 
-impl<T, U, E> fmt::Debug for CloneBoxService<T, U, E>
-where
-    T: fmt::Debug,
-    U: fmt::Debug,
-    E: fmt::Debug,
-{
+impl<T, U, E> fmt::Debug for CloneBoxService<T, U, E> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("CloneBoxService").finish()
     }

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -3,6 +3,7 @@
 mod and_then;
 mod boxed;
 mod call_all;
+mod clone_boxed;
 mod either;
 
 mod future_service;
@@ -22,6 +23,7 @@ mod then;
 pub use self::{
     and_then::{AndThen, AndThenLayer},
     boxed::{BoxLayer, BoxService, UnsyncBoxService},
+    clone_boxed::CloneBoxService,
     either::Either,
     future_service::{future_service, FutureService},
     map_err::{MapErr, MapErrLayer},


### PR DESCRIPTION
This upstreams a little utility I'm using a bunch in axum. Its often
useful to erase the type of a service while still being able to clone
it.

`BoxService` isn't `Clone` so previously you had to combine it with
`Buffer` but doing that a lot (which we did in axum) had measurable
impact on performance.

Note this doesn't add a `!Send` variant. I personally have no use
for that but if someone thinks it would be nice I can do a follow up PR.