### PR TITLE
tower: prepare to release 0.4.11

### DIFF
--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -7,16 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- **util**: Add `CloneBoxService` which is a `Clone + Send` boxed `Service`.
-- **util:** Add `ServiceExt::boxed` and `ServiceExt::clone_boxed` for applying the
-  `BoxService` and `CloneBoxService` middleware.
-- **builder:** Add `ServiceBuilder::boxed` and `ServiceBuilder::clone_boxed` for
-  applying `BoxService` and `CloneBoxService` layers.
-- **util**: Remove unnecessary `Debug` bounds from `impl Debug for BoxService`.
-- **util**: Remove unnecessary `Debug` bounds from `impl Debug for UnsyncBoxService`.
+- None.
+
+# 0.4.11 (November 18, 2021)
+
+### Added
+
+- **util**: Add `CloneBoxService` which is a `Clone + Send` boxed `Service` ([#615])
+- **util**: Add `ServiceExt::boxed` and `ServiceExt::clone_boxed` for applying the
+  `BoxService` and `CloneBoxService` middleware ([#616])
+- **builder**: Add `ServiceBuilder::boxed` and `ServiceBuilder::clone_boxed` for
+  applying `BoxService` and `CloneBoxService` layers ([#616])
 
 ### Fixed
 
+- **util**: Remove redundant `F: Clone` bound from `ServiceExt::map_request` ([#607])
+- **util**: Remove unnecessary `Debug` bounds from `impl Debug for BoxService` ([#617])
+- **util**: Remove unnecessary `Debug` bounds from `impl Debug for UnsyncBoxService` ([#617])
 - **balance**: Remove redundant `Req: Clone` bound from `Clone` impls
   for `MakeBalance`, and `MakeBalanceLayer` ([#607])
 - **balance**: Remove redundant `Req: Debug` bound from `Debug` impls
@@ -25,13 +32,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for `ReadyCache` ([#607])
 - **steer**: Remove redundant `Req: Debug` bound from `Debug` impl
   for `Steer` ([#607])
-- **util**: Remove redundant `F: Clone` bound
-  from `ServiceExt::map_request` ([#607])
 - **docs**: Fix `doc(cfg(...))` attributes
   of `PeakEwmaDiscover`, and `PendingRequestsDiscover` ([#610])
 
 [#607]: https://github.com/tower-rs/tower/pull/607
 [#610]: https://github.com/tower-rs/tower/pull/610
+[#616]: https://github.com/tower-rs/tower/pull/616
+[#617]: https://github.com/tower-rs/tower/pull/617
+[#615]: https://github.com/tower-rs/tower/pull/615
 
 # 0.4.10 (October 19, 2021)
 

--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -13,11 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **util**: Add `CloneBoxService` which is a `Clone + Send` boxed `Service` ([#615])
-- **util**: Add `ServiceExt::boxed` and `ServiceExt::clone_boxed` for applying the
-  `BoxService` and `CloneBoxService` middleware ([#616])
-- **builder**: Add `ServiceBuilder::boxed` and `ServiceBuilder::clone_boxed` for
-  applying `BoxService` and `CloneBoxService` layers ([#616])
+- **util**: Add `BoxCloneService` which is a `Clone + Send` boxed `Service` ([#615])
+- **util**: Add `ServiceExt::boxed` and `ServiceExt::boxed_clone` for applying the
+  `BoxService` and `BoxCloneService` middleware ([#616])
+- **builder**: Add `ServiceBuilder::boxed` and `ServiceBuilder::boxed_clone` for
+  applying `BoxService` and `BoxCloneService` layers ([#616])
 
 ### Fixed
 

--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -37,9 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#607]: https://github.com/tower-rs/tower/pull/607
 [#610]: https://github.com/tower-rs/tower/pull/610
+[#615]: https://github.com/tower-rs/tower/pull/615
 [#616]: https://github.com/tower-rs/tower/pull/616
 [#617]: https://github.com/tower-rs/tower/pull/617
-[#615]: https://github.com/tower-rs/tower/pull/615
 
 # 0.4.10 (October 19, 2021)
 

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -8,13 +8,13 @@ name = "tower"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "vX.X.X" git tag.
-version = "0.4.10"
+version = "0.4.11"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tower-rs/tower"
 homepage = "https://github.com/tower-rs/tower"
-documentation = "https://docs.rs/tower/0.4.10"
+documentation = "https://docs.rs/tower/0.4.11"
 description = """
 Tower is a library of modular and reusable components for building robust
 clients and servers.

--- a/tower/src/builder/mod.rs
+++ b/tower/src/builder/mod.rs
@@ -745,17 +745,17 @@ impl<L> ServiceBuilder<L> {
         self.layer(crate::util::BoxService::layer())
     }
 
-    /// This wraps the inner service with the [`Layer`] returned by [`CloneBoxService::layer()`].
+    /// This wraps the inner service with the [`Layer`] returned by [`BoxCloneService::layer()`].
     ///
     /// This is similar to the [`boxed`] method, but it requires that `Self` implement
     /// [`Clone`], and the returned boxed service implements [`Clone`].
     ///
-    /// See [`CloneBoxService`] for more details.
+    /// See [`BoxCloneService`] for more details.
     ///
     /// # Example
     ///
     /// ```
-    /// use tower::{Service, ServiceBuilder, BoxError, util::CloneBoxService};
+    /// use tower::{Service, ServiceBuilder, BoxError, util::BoxCloneService};
     /// use std::time::Duration;
     /// #
     /// # struct Request;
@@ -764,8 +764,8 @@ impl<L> ServiceBuilder<L> {
     /// #     fn new() -> Self { Self }
     /// # }
     ///
-    /// let service: CloneBoxService<Request, Response, BoxError> = ServiceBuilder::new()
-    ///     .clone_boxed()
+    /// let service: BoxCloneService<Request, Response, BoxError> = ServiceBuilder::new()
+    ///     .boxed_clone()
     ///     .load_shed()
     ///     .concurrency_limit(64)
     ///     .timeout(Duration::from_secs(10))
@@ -780,19 +780,19 @@ impl<L> ServiceBuilder<L> {
     /// # where S: Service<R> { svc }
     /// ```
     ///
-    /// [`CloneBoxService::layer()`]: crate::util::CloneBoxService::layer()
-    /// [`CloneBoxService`]: crate::util::CloneBoxService
+    /// [`BoxCloneService::layer()`]: crate::util::BoxCloneService::layer()
+    /// [`BoxCloneService`]: crate::util::BoxCloneService
     /// [`boxed`]: Self::boxed
     #[cfg(feature = "util")]
     #[cfg_attr(docsrs, doc(cfg(feature = "util")))]
-    pub fn clone_boxed<S, R>(
+    pub fn boxed_clone<S, R>(
         self,
     ) -> ServiceBuilder<
         Stack<
             tower_layer::LayerFn<
                 fn(
                     L::Service,
-                ) -> crate::util::CloneBoxService<
+                ) -> crate::util::BoxCloneService<
                     R,
                     <L::Service as Service<R>>::Response,
                     <L::Service as Service<R>>::Error,
@@ -806,7 +806,7 @@ impl<L> ServiceBuilder<L> {
         L::Service: Service<R> + Clone + Send + 'static,
         <L::Service as Service<R>>::Future: Send + 'static,
     {
-        self.layer(crate::util::CloneBoxService::layer())
+        self.layer(crate::util::BoxCloneService::layer())
     }
 }
 

--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tower/0.4.10")]
+#![doc(html_root_url = "https://docs.rs/tower/0.4.11")]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tower/src/util/boxed/sync.rs
+++ b/tower/src/util/boxed/sync.rs
@@ -16,7 +16,7 @@ use std::{
 /// response future to be [`Send`].
 ///
 /// If you need a boxed [`Service`] that implements [`Clone`] consider using
-/// [`CloneBoxService`](crate::util::CloneBoxService).
+/// [`BoxCloneService`](crate::util::BoxCloneService).
 ///
 /// See module level documentation for more details.
 pub struct BoxService<T, U, E> {

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -3,7 +3,7 @@
 mod and_then;
 mod boxed;
 mod call_all;
-mod clone_boxed;
+mod boxed_clone;
 mod either;
 
 mod future_service;
@@ -23,7 +23,7 @@ mod then;
 pub use self::{
     and_then::{AndThen, AndThenLayer},
     boxed::{BoxLayer, BoxService, UnsyncBoxService},
-    clone_boxed::CloneBoxService,
+    boxed_clone::BoxCloneService,
     either::Either,
     future_service::{future_service, FutureService},
     map_err::{MapErr, MapErrLayer},
@@ -958,7 +958,7 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     ///
     /// See [`BoxService`] for more details.
     ///
-    /// If `Self` implements the [`Clone`] trait, the [`clone_boxed`] method
+    /// If `Self` implements the [`Clone`] trait, the [`boxed_clone`] method
     /// can be used instead, to produce a boxed service which will also
     /// implement [`Clone`].
     ///
@@ -993,7 +993,7 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// ```
     ///
     /// [`Service`]: crate::Service
-    /// [`clone_boxed`]: Self::clone_boxed
+    /// [`boxed_clone`]: Self::boxed_clone
     fn boxed(self) -> BoxService<Request, Self::Response, Self::Error>
     where
         Self: Sized + Send + 'static,
@@ -1006,12 +1006,12 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     ///
     /// This is similar to the [`boxed`] method, but it requires that `Self` implement
     /// [`Clone`], and the returned boxed service implements [`Clone`].
-    /// See [`CloneBoxService`] for more details.
+    /// See [`BoxCloneService`] for more details.
     ///
     /// # Example
     ///
     /// ```
-    /// use tower::{Service, ServiceExt, BoxError, service_fn, util::CloneBoxService};
+    /// use tower::{Service, ServiceExt, BoxError, service_fn, util::BoxCloneService};
     /// #
     /// # struct Request;
     /// # struct Response;
@@ -1023,7 +1023,7 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     ///     Ok::<_, BoxError>(Response::new())
     /// });
     ///
-    /// let service: CloneBoxService<Request, Response, BoxError> = service
+    /// let service: BoxCloneService<Request, Response, BoxError> = service
     ///     .map_request(|req| {
     ///         println!("received request");
     ///         req
@@ -1032,7 +1032,7 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     ///         println!("response produced");
     ///         res
     ///     })
-    ///     .clone_boxed();
+    ///     .boxed_clone();
     ///
     /// // The boxed service can still be cloned.
     /// service.clone();
@@ -1043,12 +1043,12 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     ///
     /// [`Service`]: crate::Service
     /// [`boxed`]: Self::boxed
-    fn clone_boxed(self) -> CloneBoxService<Request, Self::Response, Self::Error>
+    fn boxed_clone(self) -> BoxCloneService<Request, Self::Response, Self::Error>
     where
         Self: Clone + Sized + Send + 'static,
         Self::Future: Send + 'static,
     {
-        CloneBoxService::new(self)
+        BoxCloneService::new(self)
     }
 }
 

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -2,8 +2,8 @@
 
 mod and_then;
 mod boxed;
-mod call_all;
 mod boxed_clone;
+mod call_all;
 mod either;
 
 mod future_service;


### PR DESCRIPTION
### Added

- **util**: Add `BoxCloneService` which is a `Clone + Send` boxed `Service` ([#615])
- **util**: Add `ServiceExt::boxed` and `ServiceExt::boxed_clone` for applying the
  `BoxService` and `BoxCloneService` middleware ([#616])
- **builder**: Add `ServiceBuilder::boxed` and `ServiceBuilder::boxed_clone` for
  applying `BoxService` and `BoxCloneService` layers ([#616])

### Fixed

- **util**: Remove redundant `F: Clone` bound from `ServiceExt::map_request` ([#607])
- **util**: Remove unnecessary `Debug` bounds from `impl Debug for BoxService` ([#617])
- **util**: Remove unnecessary `Debug` bounds from `impl Debug for UnsyncBoxService` ([#617])
- **balance**: Remove redundant `Req: Clone` bound from `Clone` impls
  for `MakeBalance`, and `MakeBalanceLayer` ([#607])
- **balance**: Remove redundant `Req: Debug` bound from `Debug` impls
  for `MakeBalance`, `MakeFuture`, `Balance`, and `Pool` ([#607])
- **ready-cache**: Remove redundant `Req: Debug` bound from `Debug` impl
  for `ReadyCache` ([#607])
- **steer**: Remove redundant `Req: Debug` bound from `Debug` impl
  for `Steer` ([#607])
- **docs**: Fix `doc(cfg(...))` attributes
  of `PeakEwmaDiscover`, and `PendingRequestsDiscover` ([#610])

[#607]: https://github.com/tower-rs/tower/pull/607
[#610]: https://github.com/tower-rs/tower/pull/610
[#615]: https://github.com/tower-rs/tower/pull/615
[#616]: https://github.com/tower-rs/tower/pull/616
[#617]: https://github.com/tower-rs/tower/pull/617
