### PR TITLE
tower: update hdrhistogram to 7.0 and remove useless dependencies

### DIFF
--- a/tower-test/Cargo.toml
+++ b/tower-test/Cargo.toml
@@ -26,7 +26,7 @@ futures-util = { version = "0.3", default-features = false }
 tokio = { version = "1.0", features = ["sync"] }
 tokio-test = "0.4"
 tower-layer = { version = "0.3", path = "../tower-layer" }
-tower-service = { version = "0.3" }
+tower-service = { version = "0.3", path = "../tower-service" }
 pin-project-lite = "0.2"
 
 [dev-dependencies]

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -65,10 +65,10 @@ util = ["futures-util"]
 futures-core = "0.3"
 pin-project = "1"
 tower-layer = { version = "0.3.1", path = "../tower-layer" }
-tower-service = { version = "0.3" }
+tower-service = { version = "0.3.1", path = "../tower-service" }
 
 futures-util = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
-hdrhistogram = { version = "6.0", optional = true }
+hdrhistogram = { version = "7.0", optional = true }
 indexmap = { version = "1.0.2", optional = true }
 rand = { version = "0.8", features = ["small_rng"], optional = true }
 slab = { version = "0.4", optional = true }
@@ -80,8 +80,7 @@ pin-project-lite = "0.2.7"
 
 [dev-dependencies]
 futures = "0.3"
-hdrhistogram = "6.0"
-quickcheck = { version = "0.9", default-features = false }
+hdrhistogram = "7.0"
 tokio = { version = "1", features = ["macros", "sync", "test-util", "rt-multi-thread"] }
 tokio-stream = "0.1"
 tokio-test = "0.4"


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

* update `hdrhistogram` to 7.0
* remove useless dependency 'quickcheck'
* add `path` for `tower-service` dependency.