### PR TITLE
Assert that no unsafe code is used in tower

### DIFF
--- a/tower-layer/src/lib.rs
+++ b/tower-layer/src/lib.rs
@@ -5,6 +5,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
+#![forbid(unsafe_code)]
 // `rustdoc::broken_intra_doc_links` is checked on CI
 
 //! Layer traits and extensions.

--- a/tower-service/src/lib.rs
+++ b/tower-service/src/lib.rs
@@ -5,6 +5,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
+#![forbid(unsafe_code)]
 // `rustdoc::broken_intra_doc_links` is checked on CI
 
 //! Definition of the core `Service` trait to Tower

--- a/tower-test/src/lib.rs
+++ b/tower-test/src/lib.rs
@@ -5,6 +5,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
+#![forbid(unsafe_code)]
 #![allow(elided_lifetimes_in_paths)]
 // `rustdoc::broken_intra_doc_links` is checked on CI
 

--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -5,6 +5,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
+#![forbid(unsafe_code)]
 #![allow(elided_lifetimes_in_paths, clippy::type_complexity)]
 #![cfg_attr(test, allow(clippy::float_cmp))]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
The tower crates do not include any `unsafe` code, but tools like
[`cargo-geiger`][cg] can't necessarily detect that. This change adds a
stronger assertion at the top of each crate with a
`#![forbid(unsafe_code)]` directive to assert that no unsafe code is
used in the crate. This also serves as a more obvious obstacle to
introducing unsafe code in future changes.

[cg]: https://github.com/rust-secure-code/cargo-geiger