### PR TITLE
Import tracing without the attributes feature

### DIFF
--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -75,7 +75,7 @@ slab = { version = "0.4", optional = true }
 tokio = { version = "1", optional = true, features = ["sync"] }
 tokio-stream = { version = "0.1.0", optional = true }
 tokio-util = { version = "0.6.3", default-features = false, optional = true }
-tracing = { version = "0.1.2", optional = true }
+tracing = { version = "0.1.2", default-features = false, features = ["std"], optional = true }
 pin-project-lite = "0.2.7"
 
 [dev-dependencies]


### PR DESCRIPTION
tracing-attributes depends on syn and proc-macro2, which are slow to compile