### PR TITLE
Try out tokens

### DIFF
--- a/tower-layer/src/layer_fn.rs
+++ b/tower-layer/src/layer_fn.rs
@@ -33,11 +33,11 @@ use std::fmt;
 ///     type Error = S::Error;
 ///     type Future = S::Future;
 ///
-///     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+///     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
 ///         self.service.poll_ready(cx)
 ///     }
 ///
-///     fn call(&mut self, request: Request) -> Self::Future {
+///     fn call(&mut self, token: Self::Token, request: Request) -> Self::Future {
 ///         // Log the request
 ///         println!("request = {:?}, target = {:?}", request, self.target);
 ///

--- a/tower-layer/src/lib.rs
+++ b/tower-layer/src/lib.rs
@@ -74,11 +74,11 @@ pub use self::{
 ///     type Error = S::Error;
 ///     type Future = S::Future;
 ///
-///     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+///     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
 ///         self.service.poll_ready(cx)
 ///     }
 ///
-///     fn call(&mut self, request: Request) -> Self::Future {
+///     fn call(&mut self, token: Self::Token, request: Request) -> Self::Future {
 ///         // Insert log statement here or other functionality
 ///         println!("request = {:?}, target = {:?}", request, self.target);
 ///         self.service.call(request)

--- a/tower-test/src/mock/spawn.rs
+++ b/tower-test/src/mock/spawn.rs
@@ -31,7 +31,7 @@ impl<T> Spawn<T> {
     }
 
     /// Poll this service ready.
-    pub fn poll_ready<Request>(&mut self) -> Poll<Result<(), T::Error>>
+    pub fn poll_ready<Request>(&mut self) -> Poll<Result<T::Token, T::Error>>
     where
         T: Service<Request>,
     {
@@ -42,11 +42,11 @@ impl<T> Spawn<T> {
     }
 
     /// Call the inner Service.
-    pub fn call<Request>(&mut self, req: Request) -> T::Future
+    pub fn call<Request>(&mut self, token: T::Token, req: Request) -> T::Future
     where
         T: Service<Request>,
     {
-        self.inner.call(req)
+        self.inner.call(token, req)
     }
 
     /// Get the inner service.

--- a/tower-test/tests/mock.rs
+++ b/tower-test/tests/mock.rs
@@ -7,9 +7,9 @@ async fn single_request_ready() {
 
     assert_pending!(handle.poll_request());
 
-    assert_ready!(service.poll_ready()).unwrap();
+    let token = assert_ready!(service.poll_ready()).unwrap();
 
-    let response = service.call("hello");
+    let response = service.call(token, "hello");
 
     assert_request_eq!(handle, "hello").send_response("world");
 
@@ -17,13 +17,10 @@ async fn single_request_ready() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-#[should_panic]
 async fn backpressure() {
-    let (mut service, mut handle) = mock::spawn::<_, ()>();
+    let (mut service, mut handle) = mock::spawn::<&'static str, ()>();
 
     handle.allow(0);
 
     assert_pending!(service.poll_ready());
-
-    service.call("hello").await.unwrap();
 }

--- a/tower/src/balance/p2c/make.rs
+++ b/tower/src/balance/p2c/make.rs
@@ -72,15 +72,16 @@ where
 {
     type Response = Balance<S::Response, Req>;
     type Error = S::Error;
+    type Token = S::Token;
     type Future = MakeFuture<S::Future, Req>;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, target: Target) -> Self::Future {
+    fn call(&mut self, token: Self::Token, target: Target) -> Self::Future {
         MakeFuture {
-            inner: self.inner.call(target),
+            inner: self.inner.call(token, target),
             _marker: PhantomData,
         }
     }

--- a/tower/src/balance/p2c/test.rs
+++ b/tower/src/balance/p2c/test.rs
@@ -32,9 +32,9 @@ async fn single_endpoint() {
     );
 
     handle.allow(1);
-    assert_ready_ok!(svc.poll_ready());
+    let token = assert_ready_ok!(svc.poll_ready());
 
-    let mut fut = task::spawn(svc.call(()));
+    let mut fut = task::spawn(svc.call(token, ()));
 
     assert_request_eq!(handle, ()).send_response(1);
 

--- a/tower/src/buffer/worker.rs
+++ b/tower/src/buffer/worker.rs
@@ -193,9 +193,9 @@ where
                         message = "worker received request; waiting for service readiness"
                     );
                     match self.service.poll_ready(cx) {
-                        Poll::Ready(Ok(())) => {
+                        Poll::Ready(Ok(token)) => {
                             tracing::debug!(service.ready = true, message = "processing request");
-                            let response = self.service.call(msg.request);
+                            let response = self.service.call(token, msg.request);
 
                             // Send the response future back to the sender.
                             //

--- a/tower/src/hedge/delay.rs
+++ b/tower/src/hedge/delay.rs
@@ -80,16 +80,17 @@ where
 {
     type Response = S::Response;
     type Error = crate::BoxError;
+    type Token = ();
     type Future = ResponseFuture<Request, S>;
 
-    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
         // Calling self.service.poll_ready would reserve a slot for the delayed request,
         // potentially well in advance of actually making it.  Instead, signal readiness here and
         // treat the service as a Oneshot in the future.
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, request: Request) -> Self::Future {
+    fn call(&mut self, token: Self::Token, request: Request) -> Self::Future {
         let delay = self.policy.delay(&request);
         ResponseFuture {
             service: Some(self.service.clone()),

--- a/tower/src/hedge/latency.rs
+++ b/tower/src/hedge/latency.rs
@@ -55,17 +55,18 @@ where
 {
     type Response = S::Response;
     type Error = crate::BoxError;
+    type Token = S::Token;
     type Future = ResponseFuture<R, S::Future>;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
         self.service.poll_ready(cx).map_err(Into::into)
     }
 
-    fn call(&mut self, request: Request) -> Self::Future {
+    fn call(&mut self, token: Self::Token, request: Request) -> Self::Future {
         ResponseFuture {
             start: Instant::now(),
             rec: self.rec.clone(),
-            inner: self.service.call(request),
+            inner: self.service.call(token, request),
         }
     }
 }

--- a/tower/src/hedge/select.rs
+++ b/tower/src/hedge/select.rs
@@ -17,10 +17,12 @@ pub trait Policy<Request> {
 /// the cloned request to the B service.  Both resulting futures will be polled
 /// and whichever future completes first will be used as the result.
 #[derive(Debug)]
-pub struct Select<P, A, B> {
+pub struct Select<Request, P, A: Service<Request>, B: Service<Request>> {
     policy: P,
     a: A,
     b: B,
+    a_token: Option<A::Token>,
+    b_token: Option<B::Token>,
 }
 
 pin_project! {
@@ -33,8 +35,12 @@ pin_project! {
     }
 }
 
-impl<P, A, B> Select<P, A, B> {
-    pub fn new<Request>(policy: P, a: A, b: B) -> Self
+impl<P, A, B, Request> Select<Request, P, A, B>
+where
+    A: Service<Request>,
+    B: Service<Request>,
+{
+    pub fn new(policy: P, a: A, b: B) -> Self
     where
         P: Policy<Request>,
         A: Service<Request>,
@@ -42,11 +48,23 @@ impl<P, A, B> Select<P, A, B> {
         B: Service<Request, Response = A::Response>,
         B::Error: Into<crate::BoxError>,
     {
-        Select { policy, a, b }
+        Select {
+            policy,
+            a,
+            b,
+            a_token: None,
+            b_token: None,
+        }
     }
 }
 
-impl<P, A, B, Request> Service<Request> for Select<P, A, B>
+#[derive(Debug)]
+pub struct Token<A, B> {
+    a: A,
+    b: B,
+}
+
+impl<P, A, B, Request> Service<Request> for Select<Request, P, A, B>
 where
     P: Policy<Request>,
     A: Service<Request>,
@@ -56,25 +74,35 @@ where
 {
     type Response = A::Response;
     type Error = crate::BoxError;
+    type Token = Token<A::Token, B::Token>;
     type Future = ResponseFuture<A::Future, B::Future>;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        match (self.a.poll_ready(cx), self.b.poll_ready(cx)) {
-            (Poll::Ready(Ok(())), Poll::Ready(Ok(()))) => Poll::Ready(Ok(())),
-            (Poll::Ready(Err(e)), _) => Poll::Ready(Err(e.into())),
-            (_, Poll::Ready(Err(e))) => Poll::Ready(Err(e.into())),
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
+        if self.a_token.is_none() {
+            if let Poll::Ready(token) = self.a.poll_ready(cx).map_err(Into::into)? {
+                self.a_token = Some(token);
+            }
+        }
+        if self.b_token.is_none() {
+            if let Poll::Ready(token) = self.b.poll_ready(cx).map_err(Into::into)? {
+                self.b_token = Some(token);
+            }
+        }
+
+        match (self.a_token, self.b_token) {
+            (Some(a), Some(b)) => Poll::Ready(Ok(Token { a, b })),
             _ => Poll::Pending,
         }
     }
 
-    fn call(&mut self, request: Request) -> Self::Future {
+    fn call(&mut self, token: Self::Token, request: Request) -> Self::Future {
         let b_fut = if let Some(cloned_req) = self.policy.clone_request(&request) {
-            Some(self.b.call(cloned_req))
+            Some(self.b.call(token.b, cloned_req))
         } else {
             None
         };
         ResponseFuture {
-            a_fut: self.a.call(request),
+            a_fut: self.a.call(token.a, request),
             b_fut,
         }
     }

--- a/tower/src/limit/concurrency/service.rs
+++ b/tower/src/limit/concurrency/service.rs
@@ -15,12 +15,6 @@ use std::{
 pub struct ConcurrencyLimit<T> {
     inner: T,
     semaphore: PollSemaphore,
-    /// The currently acquired semaphore permit, if there is sufficient
-    /// concurrency to send a new request.
-    ///
-    /// The permit is acquired in `poll_ready`, and taken in `call` when sending
-    /// a new request.
-    permit: Option<OwnedSemaphorePermit>,
 }
 
 impl<T> ConcurrencyLimit<T> {
@@ -34,7 +28,6 @@ impl<T> ConcurrencyLimit<T> {
         ConcurrencyLimit {
             inner,
             semaphore: PollSemaphore::new(semaphore),
-            permit: None,
         }
     }
 
@@ -54,42 +47,38 @@ impl<T> ConcurrencyLimit<T> {
     }
 }
 
+#[derive(Debug)]
+pub struct Token<T> {
+    inner: T,
+    permit: OwnedSemaphorePermit,
+}
+
 impl<S, Request> Service<Request> for ConcurrencyLimit<S>
 where
     S: Service<Request>,
 {
     type Response = S::Response;
     type Error = S::Error;
+    type Token = Token<S::Token>;
     type Future = ResponseFuture<S::Future>;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // If we haven't already acquired a permit from the semaphore, try to
-        // acquire one first.
-        if self.permit.is_none() {
-            self.permit = ready!(self.semaphore.poll_acquire(cx));
-            debug_assert!(
-                self.permit.is_some(),
-                "ConcurrencyLimit semaphore is never closed, so `poll_acquire` \
-                 should never fail",
-            );
-        }
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
+        let permit = ready!(self.semaphore.poll_acquire(cx)).expect(
+            "ConcurrencyLimit semaphore is never closed, so `poll_acquire` \
+                should never fail",
+        );
 
-        // Once we've acquired a permit (or if we already had one), poll the
-        // inner service.
-        self.inner.poll_ready(cx)
+        // Once we've acquired a permit, poll the inner service.
+        self.inner
+            .poll_ready(cx)
+            .map_ok(move |inner| Token { inner, permit })
     }
 
-    fn call(&mut self, request: Request) -> Self::Future {
-        // Take the permit
-        let permit = self
-            .permit
-            .take()
-            .expect("max requests in-flight; poll_ready must be called first");
-
+    fn call(&mut self, token: Self::Token, request: Request) -> Self::Future {
         // Call the inner service
-        let future = self.inner.call(request);
+        let future = self.inner.call(token.inner, request);
 
-        ResponseFuture::new(future, permit)
+        ResponseFuture::new(future, token.permit)
     }
 }
 
@@ -101,7 +90,6 @@ impl<T: Clone> Clone for ConcurrencyLimit<T> {
         Self {
             inner: self.inner.clone(),
             semaphore: self.semaphore.clone(),
-            permit: None,
         }
     }
 }

--- a/tower/src/load/constant.rs
+++ b/tower/src/load/constant.rs
@@ -47,14 +47,15 @@ where
 {
     type Response = S::Response;
     type Error = S::Error;
+    type Token = S::Token;
     type Future = S::Future;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, req: Request) -> Self::Future {
-        self.inner.call(req)
+    fn call(&mut self, token: Self::Token, req: Request) -> Self::Future {
+        self.inner.call(token, req)
     }
 }
 

--- a/tower/src/load/peak_ewma.rs
+++ b/tower/src/load/peak_ewma.rs
@@ -115,17 +115,18 @@ where
 {
     type Response = C::Output;
     type Error = S::Error;
+    type Token = S::Token;
     type Future = TrackCompletionFuture<S::Future, C, Handle>;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
         self.service.poll_ready(cx)
     }
 
-    fn call(&mut self, req: Request) -> Self::Future {
+    fn call(&mut self, token: Self::Token, req: Request) -> Self::Future {
         TrackCompletionFuture::new(
             self.completion.clone(),
             self.handle(),
-            self.service.call(req),
+            self.service.call(token, req),
         )
     }
 }
@@ -320,13 +321,14 @@ mod tests {
     impl Service<()> for Svc {
         type Response = ();
         type Error = ();
+        type Token = ();
         type Future = future::Ready<Result<(), ()>>;
 
         fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), ()>> {
             Poll::Ready(Ok(()))
         }
 
-        fn call(&mut self, (): ()) -> Self::Future {
+        fn call(&mut self, (): (), (): ()) -> Self::Future {
             future::ok(())
         }
     }
@@ -370,11 +372,11 @@ mod tests {
         assert_eq!(svc.load(), Cost(20.0 * NANOS_PER_MILLI));
 
         time::advance(Duration::from_millis(100)).await;
-        let mut rsp0 = task::spawn(svc.call(()));
+        let mut rsp0 = task::spawn(svc.call((), ()));
         assert!(svc.load() > Cost(20.0 * NANOS_PER_MILLI));
 
         time::advance(Duration::from_millis(100)).await;
-        let mut rsp1 = task::spawn(svc.call(()));
+        let mut rsp1 = task::spawn(svc.call((), ()));
         assert!(svc.load() > Cost(40.0 * NANOS_PER_MILLI));
 
         time::advance(Duration::from_millis(100)).await;

--- a/tower/src/retry/future.rs
+++ b/tower/src/retry/future.rs
@@ -107,14 +107,14 @@ where
                     // we need to make that assumption to avoid adding an Unpin bound to the Policy
                     // in Ready to make it Unpin so that we can get &mut Ready as needed to call
                     // poll_ready on it.
-                    ready!(this.retry.as_mut().project().service.poll_ready(cx))?;
+                    let token = ready!(this.retry.as_mut().project().service.poll_ready(cx))?;
                     let req = this
                         .request
                         .take()
                         .expect("retrying requires cloned request");
                     *this.request = this.retry.policy.clone_request(&req);
                     this.state.set(State::Called {
-                        future: this.retry.as_mut().project().service.call(req),
+                        future: this.retry.as_mut().project().service.call(token, req),
                     });
                 }
             }

--- a/tower/src/retry/mod.rs
+++ b/tower/src/retry/mod.rs
@@ -56,18 +56,19 @@ where
 {
     type Response = S::Response;
     type Error = S::Error;
+    type Token = S::Token;
     type Future = ResponseFuture<P, S, Request>;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
         // NOTE: the Future::poll impl for ResponseFuture assumes that Retry::poll_ready is
         // equivalent to Ready.service.poll_ready. If this ever changes, that code must be updated
         // as well.
         self.service.poll_ready(cx)
     }
 
-    fn call(&mut self, request: Request) -> Self::Future {
+    fn call(&mut self, token: Self::Token, request: Request) -> Self::Future {
         let cloned = self.policy.clone_request(&request);
-        let future = self.service.call(request);
+        let future = self.service.call(token, request);
 
         ResponseFuture::new(cloned, self.clone(), future)
     }

--- a/tower/src/spawn_ready/make.rs
+++ b/tower/src/spawn_ready/make.rs
@@ -36,15 +36,16 @@ where
 {
     type Response = SpawnReady<S::Response>;
     type Error = S::Error;
+    type Token = S::Token;
     type Future = MakeFuture<S::Future>;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, target: Target) -> Self::Future {
+    fn call(&mut self, token: Self::Token, target: Target) -> Self::Future {
         MakeFuture {
-            inner: self.inner.call(target),
+            inner: self.inner.call(token, target),
         }
     }
 }

--- a/tower/src/timeout/mod.rs
+++ b/tower/src/timeout/mod.rs
@@ -52,17 +52,18 @@ where
 {
     type Response = S::Response;
     type Error = crate::BoxError;
+    type Token = S::Token;
     type Future = ResponseFuture<S::Future>;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
         match self.inner.poll_ready(cx) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(r) => Poll::Ready(r.map_err(Into::into)),
         }
     }
 
-    fn call(&mut self, request: Request) -> Self::Future {
-        let response = self.inner.call(request);
+    fn call(&mut self, token: Self::Token, request: Request) -> Self::Future {
+        let response = self.inner.call(token, request);
         let sleep = tokio::time::sleep(self.timeout);
 
         ResponseFuture::new(response, sleep)

--- a/tower/src/util/and_then.rs
+++ b/tower/src/util/and_then.rs
@@ -97,14 +97,15 @@ where
 {
     type Response = Fut::Ok;
     type Error = Fut::Error;
+    type Token = S::Token;
     type Future = AndThenFuture<S::Future, Fut, F>;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
         self.inner.poll_ready(cx).map_err(Into::into)
     }
 
-    fn call(&mut self, request: Request) -> Self::Future {
-        AndThenFuture::new(self.inner.call(request).err_into().and_then(self.f.clone()))
+    fn call(&mut self, token: Self::Token, request: Request) -> Self::Future {
+        AndThenFuture::new(self.inner.call(token, request).err_into().and_then(self.f.clone()))
     }
 }
 

--- a/tower/src/util/boxed/layer.rs
+++ b/tower/src/util/boxed/layer.rs
@@ -1,5 +1,5 @@
 use crate::util::BoxService;
-use std::{fmt, sync::Arc};
+use std::{any::Any, fmt, sync::Arc};
 use tower_layer::{layer_fn, Layer};
 use tower_service::Service;
 
@@ -61,6 +61,7 @@ impl<In, T, U, E> BoxLayer<In, T, U, E> {
     where
         L: Layer<In> + Send + Sync + 'static,
         L::Service: Service<T, Response = U, Error = E> + Send + 'static,
+        <L::Service as Service<T>>::Token: Any + Send + 'static,
         <L::Service as Service<T>>::Future: Send + 'static,
     {
         let layer = layer_fn(move |inner: In| {

--- a/tower/src/util/boxed/unsync.rs
+++ b/tower/src/util/boxed/unsync.rs
@@ -1,6 +1,7 @@
 use tower_layer::{layer_fn, LayerFn};
 use tower_service::Service;
 
+use std::any::Any;
 use std::fmt;
 use std::{
     future::Future,
@@ -10,7 +11,15 @@ use std::{
 
 /// A boxed [`Service`] trait object.
 pub struct UnsyncBoxService<T, U, E> {
-    inner: Box<dyn Service<T, Response = U, Error = E, Future = UnsyncBoxFuture<U, E>>>,
+    inner: Box<
+        dyn Service<
+            T,
+            Response = U,
+            Error = E,
+            Token = Box<dyn Any>,
+            Future = UnsyncBoxFuture<U, E>,
+        >,
+    >,
 }
 
 /// A boxed [`Future`] trait object.
@@ -29,6 +38,7 @@ impl<T, U, E> UnsyncBoxService<T, U, E> {
     pub fn new<S>(inner: S) -> Self
     where
         S: Service<T, Response = U, Error = E> + 'static,
+        S::Token: Any + 'static,
         S::Future: 'static,
     {
         let inner = Box::new(UnsyncBoxed { inner });
@@ -41,6 +51,7 @@ impl<T, U, E> UnsyncBoxService<T, U, E> {
     pub fn layer<S>() -> LayerFn<fn(S) -> Self>
     where
         S: Service<T, Response = U, Error = E> + 'static,
+        S::Token: Any + 'static,
         S::Future: 'static,
     {
         layer_fn(Self::new)
@@ -50,14 +61,15 @@ impl<T, U, E> UnsyncBoxService<T, U, E> {
 impl<T, U, E> Service<T> for UnsyncBoxService<T, U, E> {
     type Response = U;
     type Error = E;
+    type Token = Box<dyn Any>;
     type Future = UnsyncBoxFuture<U, E>;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), E>> {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, E>> {
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, request: T) -> UnsyncBoxFuture<U, E> {
-        self.inner.call(request)
+    fn call(&mut self, token: Self::Token, request: T) -> UnsyncBoxFuture<U, E> {
+        self.inner.call(token, request)
     }
 }
 
@@ -70,17 +82,28 @@ impl<T, U, E> fmt::Debug for UnsyncBoxService<T, U, E> {
 impl<S, Request> Service<Request> for UnsyncBoxed<S>
 where
     S: Service<Request> + 'static,
+    S::Token: Any + 'static,
     S::Future: 'static,
 {
     type Response = S::Response;
     type Error = S::Error;
+    type Token = Box<dyn Any>;
     type Future = Pin<Box<dyn Future<Output = Result<S::Response, S::Error>>>>;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
+        self.inner
+            .poll_ready(cx)
+            .map_ok(|t| Box::new(t) as Box<dyn Any>)
     }
 
-    fn call(&mut self, request: Request) -> Self::Future {
-        Box::pin(self.inner.call(request))
+    fn call(&mut self, token: Self::Token, request: Request) -> Self::Future {
+        Box::pin(
+            self.inner.call(
+                *token
+                    .downcast()
+                    .expect("Invalid token passed to UnsyncBoxService."),
+                request,
+            ),
+        )
     }
 }

--- a/tower/src/util/call_all/common.rs
+++ b/tower/src/util/call_all/common.rs
@@ -97,13 +97,13 @@ where
                 .service
                 .as_mut()
                 .expect("Using CallAll after extracing inner Service");
-            ready!(svc.poll_ready(cx)).map_err(Into::into)?;
+            let token = ready!(svc.poll_ready(cx)).map_err(Into::into)?;
 
             // If it is, gather the next request (if there is one)
             match this.stream.as_mut().poll_next(cx) {
                 Poll::Ready(r) => match r {
                     Some(req) => {
-                        this.queue.push(svc.call(req));
+                        this.queue.push(svc.call(token, req));
                     }
                     None => {
                         // We're all done once any outstanding requests have completed

--- a/tower/src/util/call_all/ordered.rs
+++ b/tower/src/util/call_all/ordered.rs
@@ -38,11 +38,11 @@ pin_project! {
     ///      type Error = Box<dyn Error + Send + Sync>;
     ///      type Future = Ready<Result<Self::Response, Self::Error>>;
     ///
-    ///      fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    ///      fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
     ///          Poll::Ready(Ok(()))
     ///      }
     ///
-    ///      fn call(&mut self, req: &'static str) -> Self::Future {
+    ///      fn call(&mut self, token: Self::Token, req: &'static str) -> Self::Future {
     ///          ready(Ok(&req[..1]))
     ///      }
     /// }

--- a/tower/src/util/map_err.rs
+++ b/tower/src/util/map_err.rs
@@ -63,16 +63,17 @@ where
 {
     type Response = S::Response;
     type Error = Error;
+    type Token = S::Token;
     type Future = MapErrFuture<S::Future, F>;
 
     #[inline]
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
         self.inner.poll_ready(cx).map_err(self.f.clone())
     }
 
     #[inline]
-    fn call(&mut self, request: Request) -> Self::Future {
-        MapErrFuture::new(self.inner.call(request).map_err(self.f.clone()))
+    fn call(&mut self, token: Self::Token, request: Request) -> Self::Future {
+        MapErrFuture::new(self.inner.call(token, request).map_err(self.f.clone()))
     }
 }
 

--- a/tower/src/util/map_future.rs
+++ b/tower/src/util/map_future.rs
@@ -55,14 +55,15 @@ where
 {
     type Response = T;
     type Error = E;
+    type Token = S::Token;
     type Future = Fut;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
         self.inner.poll_ready(cx).map_err(From::from)
     }
 
-    fn call(&mut self, req: R) -> Self::Future {
-        (self.f)(self.inner.call(req))
+    fn call(&mut self, token: Self::Token, req: R) -> Self::Future {
+        (self.f)(self.inner.call(token, req))
     }
 }
 

--- a/tower/src/util/map_request.rs
+++ b/tower/src/util/map_request.rs
@@ -47,16 +47,17 @@ where
 {
     type Response = S::Response;
     type Error = S::Error;
+    type Token = S::Token;
     type Future = S::Future;
 
     #[inline]
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), S::Error>> {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<S::Token, S::Error>> {
         self.inner.poll_ready(cx)
     }
 
     #[inline]
-    fn call(&mut self, request: R1) -> S::Future {
-        self.inner.call((self.f)(request))
+    fn call(&mut self, token: Self::Token, request: R1) -> S::Future {
+        self.inner.call(token, (self.f)(request))
     }
 }
 

--- a/tower/src/util/map_response.rs
+++ b/tower/src/util/map_response.rs
@@ -63,16 +63,17 @@ where
 {
     type Response = Response;
     type Error = S::Error;
+    type Token = S::Token;
     type Future = MapResponseFuture<S::Future, F>;
 
     #[inline]
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
         self.inner.poll_ready(cx)
     }
 
     #[inline]
-    fn call(&mut self, request: Request) -> Self::Future {
-        MapResponseFuture::new(self.inner.call(request).map_ok(self.f.clone()))
+    fn call(&mut self, token: Self::Token, request: Request) -> Self::Future {
+        MapResponseFuture::new(self.inner.call(token, request).map_ok(self.f.clone()))
     }
 }
 

--- a/tower/src/util/map_result.rs
+++ b/tower/src/util/map_result.rs
@@ -64,16 +64,17 @@ where
 {
     type Response = Response;
     type Error = Error;
+    type Token = S::Token;
     type Future = MapResultFuture<S::Future, F>;
 
     #[inline]
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
         self.inner.poll_ready(cx).map_err(Into::into)
     }
 
     #[inline]
-    fn call(&mut self, request: Request) -> Self::Future {
-        MapResultFuture::new(self.inner.call(request).map(self.f.clone()))
+    fn call(&mut self, token: Self::Token, request: Request) -> Self::Future {
+        MapResultFuture::new(self.inner.call(token, request).map(self.f.clone()))
     }
 }
 

--- a/tower/src/util/map_token.rs
+++ b/tower/src/util/map_token.rs
@@ -1,0 +1,117 @@
+use std::{
+    fmt,
+    task::{Context, Poll},
+};
+use tower_layer::Layer;
+use tower_service::Service;
+
+/// [`Service`] returned by the [`map_token`] combinator.
+///
+/// [`map_future`]: crate::util::ServiceExt::map_token
+#[derive(Clone)]
+pub struct MapToken<S, F, G> {
+    inner: S,
+    f: F,
+    g: G,
+}
+
+impl<S, F, G> MapToken<S, F, G> {
+    /// Creates a new [`MapToken`] service.
+    pub fn new(inner: S, f: F, g: G) -> Self {
+        Self { inner, f, g }
+    }
+
+    /// Returns a new [`Layer`] that produces [`MapToken`] services.
+    ///
+    /// This is a convenience function that simply calls [`MapTokenLayer::new`].
+    ///
+    /// [`Layer`]: tower_layer::Layer
+    pub fn layer(f: F, g: G) -> MapTokenLayer<F, G> {
+        MapTokenLayer::new(f, g)
+    }
+
+    /// Get a reference to the inner service
+    pub fn get_ref(&self) -> &S {
+        &self.inner
+    }
+
+    /// Get a mutable reference to the inner service
+    pub fn get_mut(&mut self) -> &mut S {
+        &mut self.inner
+    }
+
+    /// Consume `self`, returning the inner service
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
+}
+
+impl<R, S, F, G, Token> Service<R> for MapToken<S, F, G>
+where
+    S: Service<R>,
+    F: FnMut(S::Token) -> Token,
+    G: FnMut(Token) -> S::Token,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Token = Token;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
+        self.inner.poll_ready(cx).map_ok(self.f).map_err(From::from)
+    }
+
+    fn call(&mut self, token: Self::Token, req: R) -> Self::Future {
+        self.inner.call((self.g)(token), req)
+    }
+}
+
+impl<S, F, G> fmt::Debug for MapToken<S, F, G>
+where
+    S: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MapToken")
+            .field("inner", &self.inner)
+            .field("f", &format_args!("{}", std::any::type_name::<F>()))
+            .field("g", &format_args!("{}", std::any::type_name::<G>()))
+            .finish()
+    }
+}
+
+/// A [`Layer`] that produces a [`MapToken`] service.
+///
+/// [`Layer`]: tower_layer::Layer
+#[derive(Clone)]
+pub struct MapTokenLayer<F, G> {
+    f: F,
+    g: G,
+}
+
+impl<F, G> MapTokenLayer<F, G> {
+    /// Creates a new [`MapTokenLayer`] layer.
+    pub fn new(f: F, g: G) -> Self {
+        Self { f, g }
+    }
+}
+
+impl<S, F, G> Layer<S> for MapTokenLayer<F, G>
+where
+    F: Clone,
+    G: Clone,
+{
+    type Service = MapToken<S, F, G>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        MapToken::new(inner, self.f.clone(), self.g.clone())
+    }
+}
+
+impl<F, G> fmt::Debug for MapTokenLayer<F, G> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MapTokenLayer")
+            .field("f", &format_args!("{}", std::any::type_name::<F>()))
+            .field("g", &format_args!("{}", std::any::type_name::<G>()))
+            .finish()
+    }
+}

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -11,6 +11,7 @@ mod map_err;
 mod map_request;
 mod map_response;
 mod map_result;
+mod map_token;
 
 mod map_future;
 mod oneshot;
@@ -31,6 +32,7 @@ pub use self::{
     map_request::{MapRequest, MapRequestLayer},
     map_response::{MapResponse, MapResponseLayer},
     map_result::{MapResult, MapResultLayer},
+    map_token::{MapToken, MapTokenLayer},
     oneshot::Oneshot,
     optional::Optional,
     ready::{Ready, ReadyAnd, ReadyOneshot},
@@ -39,7 +41,7 @@ pub use self::{
 };
 
 pub use self::call_all::{CallAll, CallAllUnordered};
-use std::future::Future;
+use std::{any::Any, future::Future};
 
 use crate::layer::util::Identity;
 
@@ -149,11 +151,11 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// #   type Error = u8;
     /// #   type Future = futures_util::future::Ready<Result<Record, u8>>;
     /// #
-    /// #   fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    /// #   fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
     /// #       Poll::Ready(Ok(()))
     /// #   }
     /// #
-    /// #   fn call(&mut self, request: u32) -> Self::Future {
+    /// #   fn call(&mut self, token: Self::Token, request: u32) -> Self::Future {
     /// #       futures_util::future::ready(Ok(Record { name: "Jack".into(), age: 32 }))
     /// #   }
     /// # }
@@ -218,11 +220,11 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// #   type Error = u8;
     /// #   type Future = futures_util::future::Ready<Result<Record, u8>>;
     /// #
-    /// #   fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    /// #   fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
     /// #       Poll::Ready(Ok(()))
     /// #   }
     /// #
-    /// #   fn call(&mut self, request: u32) -> Self::Future {
+    /// #   fn call(&mut self, token: Self::Token, request: u32) -> Self::Future {
     /// #       futures_util::future::ready(Ok(Record { name: "Jack".into(), age: 32 }))
     /// #   }
     /// # }
@@ -285,11 +287,11 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// #   type Error = Error;
     /// #   type Future = futures_util::future::Ready<Result<String, Error>>;
     /// #
-    /// #   fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    /// #   fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
     /// #       Poll::Ready(Ok(()))
     /// #   }
     /// #
-    /// #   fn call(&mut self, request: u32) -> Self::Future {
+    /// #   fn call(&mut self, token: Self::Token, request: u32) -> Self::Future {
     /// #       futures_util::future::ready(Ok(String::new()))
     /// #   }
     /// # }
@@ -380,11 +382,11 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// #   type Error = DbError;
     /// #   type Future = futures_util::future::Ready<Result<Vec<Record>, DbError>>;
     /// #
-    /// #   fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    /// #   fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
     /// #       Poll::Ready(Ok(()))
     /// #   }
     /// #
-    /// #   fn call(&mut self, request: u32) -> Self::Future {
+    /// #   fn call(&mut self, token: Self::Token, request: u32) -> Self::Future {
     /// #       futures_util::future::ready(Ok(vec![Record { name: "Jack".into(), age: 32 }]))
     /// #   }
     /// # }
@@ -440,11 +442,11 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// #   type Error = DbError;
     /// #   type Future = futures_util::future::Ready<Result<Record, DbError>>;
     /// #
-    /// #   fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    /// #   fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
     /// #       Poll::Ready(Ok(()))
     /// #   }
     /// #
-    /// #   fn call(&mut self, request: u32) -> Self::Future {
+    /// #   fn call(&mut self, token: Self::Token, request: u32) -> Self::Future {
     /// #       futures_util::future::ready(Ok(Record { name: "Jack".into(), age: 32 }))
     /// #   }
     /// # }
@@ -504,11 +506,11 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// #   type Error = u8;
     /// #   type Future = futures_util::future::Ready<Result<String, u8>>;
     /// #
-    /// #   fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    /// #   fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
     /// #       Poll::Ready(Ok(()))
     /// #   }
     /// #
-    /// #   fn call(&mut self, request: u32) -> Self::Future {
+    /// #   fn call(&mut self, token: Self::Token, request: u32) -> Self::Future {
     /// #       futures_util::future::ready(Ok(String::new()))
     /// #   }
     /// # }
@@ -575,11 +577,11 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// #   type Error = u8;
     /// #   type Future = futures_util::future::Ready<Result<String, u8>>;
     /// #
-    /// #   fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    /// #   fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
     /// #       Poll::Ready(Ok(()))
     /// #   }
     /// #
-    /// #   fn call(&mut self, request: String) -> Self::Future {
+    /// #   fn call(&mut self, token: Self::Token, request: String) -> Self::Future {
     /// #       futures_util::future::ready(Ok(String::new()))
     /// #   }
     /// # }
@@ -643,11 +645,11 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// #   type Error = DbError;
     /// #   type Future = futures_util::future::Ready<Result<String, DbError>>;
     /// #
-    /// #   fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    /// #   fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
     /// #       Poll::Ready(Ok(()))
     /// #   }
     /// #
-    /// #   fn call(&mut self, request: u32) -> Self::Future {
+    /// #   fn call(&mut self, token: Self::Token, request: u32) -> Self::Future {
     /// #       futures_util::future::ready(Ok(String::new()))
     /// #   }
     /// # }
@@ -717,11 +719,11 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// #   type Error = DbError;
     /// #   type Future = futures_util::future::Ready<Result<String, DbError>>;
     /// #
-    /// #   fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    /// #   fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
     /// #       Poll::Ready(Ok(()))
     /// #   }
     /// #
-    /// #   fn call(&mut self, request: u32) -> Self::Future {
+    /// #   fn call(&mut self, token: Self::Token, request: u32) -> Self::Future {
     /// #       futures_util::future::ready(Ok(String::new()))
     /// #   }
     /// # }
@@ -820,11 +822,11 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// #   type Error = DbError;
     /// #   type Future = futures_util::future::Ready<Result<Record, DbError>>;
     /// #
-    /// #   fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    /// #   fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
     /// #       Poll::Ready(Ok(()))
     /// #   }
     /// #
-    /// #   fn call(&mut self, request: u32) -> Self::Future {
+    /// #   fn call(&mut self, token: Self::Token, request: u32) -> Self::Future {
     /// #       futures_util::future::ready(Ok(()))
     /// #   }
     /// # }
@@ -906,11 +908,11 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     /// #   type Error = DbError;
     /// #   type Future = futures_util::future::Ready<Result<Record, DbError>>;
     /// #
-    /// #   fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    /// #   fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
     /// #       Poll::Ready(Ok(()))
     /// #   }
     /// #
-    /// #   fn call(&mut self, request: u32) -> Self::Future {
+    /// #   fn call(&mut self, token: Self::Token, request: u32) -> Self::Future {
     /// #       futures_util::future::ready(Ok(()))
     /// #   }
     /// # }
@@ -997,6 +999,7 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     fn boxed(self) -> BoxService<Request, Self::Response, Self::Error>
     where
         Self: Sized + Send + 'static,
+        Self::Token: Any + Send + 'static,
         Self::Future: Send + 'static,
     {
         BoxService::new(self)
@@ -1043,12 +1046,21 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     ///
     /// [`Service`]: crate::Service
     /// [`boxed`]: Self::boxed
-    fn boxed_clone(self) -> BoxCloneService<Request, Self::Response, Self::Error>
+    fn boxed_clone(self) -> BoxCloneService<Request, Self::Response, Self::Error, Self::Token>
     where
         Self: Clone + Sized + Send + 'static,
         Self::Future: Send + 'static,
     {
         BoxCloneService::new(self)
+    }
+
+    fn map_token<F, G, NewToken>(self, f: F, g: G) -> MapToken<Self, F, G>
+    where
+        Self: Sized,
+        F: FnMut(Self::Token) -> NewToken,
+        G: FnMut(NewToken) -> Self::Token,
+    {
+        MapToken::new(self, f, g)
     }
 }
 

--- a/tower/src/util/oneshot.rs
+++ b/tower/src/util/oneshot.rs
@@ -89,8 +89,8 @@ where
         loop {
             match this.state.as_mut().project() {
                 StateProj::NotReady { svc, req } => {
-                    let _ = ready!(svc.poll_ready(cx))?;
-                    let f = svc.call(req.take().expect("already called"));
+                    let token = ready!(svc.poll_ready(cx))?;
+                    let f = svc.call(token, req.take().expect("already called"));
                     this.state.set(State::called(f));
                 }
                 StateProj::Called { fut } => {

--- a/tower/src/util/service_fn.rs
+++ b/tower/src/util/service_fn.rs
@@ -70,13 +70,14 @@ where
 {
     type Response = R;
     type Error = E;
+    type Token = ();
     type Future = F;
 
     fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), E>> {
         Ok(()).into()
     }
 
-    fn call(&mut self, req: Request) -> Self::Future {
+    fn call(&mut self, _token: (), req: Request) -> Self::Future {
         (self.f)(req)
     }
 }

--- a/tower/src/util/then.rs
+++ b/tower/src/util/then.rs
@@ -68,16 +68,17 @@ where
 {
     type Response = Response;
     type Error = Error;
+    type Token = S::Token;
     type Future = ThenFuture<S::Future, Fut, F>;
 
     #[inline]
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
         self.inner.poll_ready(cx).map_err(Into::into)
     }
 
     #[inline]
-    fn call(&mut self, request: Request) -> Self::Future {
-        ThenFuture::new(self.inner.call(request).then(self.f.clone()))
+    fn call(&mut self, token: Self::Token, request: Request) -> Self::Future {
+        ThenFuture::new(self.inner.call(token, request).then(self.f.clone()))
     }
 }
 

--- a/tower/tests/balance/main.rs
+++ b/tower/tests/balance/main.rs
@@ -17,11 +17,11 @@ impl Service<Req> for Mock {
     type Response = <mock::Mock<Req, Req> as Service<Req>>::Response;
     type Error = <mock::Mock<Req, Req> as Service<Req>>::Error;
     type Future = <mock::Mock<Req, Req> as Service<Req>>::Future;
-    fn poll_ready(&mut self, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, cx: &mut Context) -> Poll<Result<Self::Token, Self::Error>> {
         self.0.poll_ready(cx)
     }
-    fn call(&mut self, req: Req) -> Self::Future {
-        self.0.call(req)
+    fn call(&mut self, token: Self::Token, req: Req) -> Self::Future {
+        self.0.call(token, req)
     }
 }
 

--- a/tower/tests/steer/main.rs
+++ b/tower/tests/steer/main.rs
@@ -16,7 +16,7 @@ impl Service<String> for MyService {
     type Error = StdError;
     type Future = Ready<Result<u8, Self::Error>>;
 
-    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
         if !self.1 {
             Poll::Pending
         } else {

--- a/tower/tests/support.rs
+++ b/tower/tests/support.rs
@@ -96,7 +96,7 @@ impl Service<()> for AssertSpanSvc {
     type Error = AssertSpanError;
     type Future = future::Ready<Result<Self::Response, Self::Error>>;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
         if self.polled {
             return Poll::Ready(self.check("poll_ready"));
         }

--- a/tower/tests/util/call_all.rs
+++ b/tower/tests/util/call_all.rs
@@ -23,7 +23,7 @@ impl Service<&'static str> for Srv {
     type Error = Error;
     type Future = Ready<Result<Self::Response, Error>>;
 
-    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<Self::Token, Self::Error>> {
         if !self.admit.get() {
             return Poll::Pending;
         }
@@ -32,7 +32,7 @@ impl Service<&'static str> for Srv {
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, req: &'static str) -> Self::Future {
+    fn call(&mut self, token: Self::Token, req: &'static str) -> Self::Future {
         self.count.set(self.count.get() + 1);
         ready(Ok(req))
     }


### PR DESCRIPTION
This is a quick example of what a token implementation might look like. It was mostly mechanical however the most interesting changes where to BoxService, and all the middlewares that have more than one backing service (I gave up entirely with balance as it's current structure just doesn't work with this form of Token).

The most interesting takeaway I had is that currently you can only get *one* "Token" at a time per Service instance, which means that services can store readiness state in the service itself; with a Token you have to store readiness in the token as you can give out more than one at a time. That forces tokens to allocate if the number of backing services isn't known at compile time.