### PR TITLE
util: rework `Either`

### DIFF
--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -62,7 +62,7 @@ retry = ["__common", "tokio/time"]
 spawn-ready = ["__common", "futures-util", "tokio/sync", "tokio/rt", "util", "tracing"]
 steer = []
 timeout = ["pin-project-lite", "tokio/time"]
-util = ["__common", "futures-util", "pin-project"]
+util = ["__common", "futures-util", "pin-project-lite"]
 
 [dependencies]
 tower-layer = { version = "0.3.1", path = "../tower-layer" }
@@ -78,7 +78,6 @@ tokio = { version = "1", optional = true, features = ["sync"] }
 tokio-stream = { version = "0.1.0", optional = true }
 tokio-util = { version = "0.6.3", default-features = false, optional = true }
 tracing = { version = "0.1.2", default-features = false, features = ["std"], optional = true }
-pin-project = { version = "1", optional = true }
 pin-project-lite = { version = "0.2.7", optional = true }
 
 [dev-dependencies]

--- a/tower/src/util/either.rs
+++ b/tower/src/util/either.rs
@@ -2,8 +2,7 @@
 //!
 //! See [`Either`] documentation for more details.
 
-use futures_core::ready;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
@@ -17,58 +16,73 @@ use tower_service::Service;
 /// Both services must be of the same request, response, and error types.
 /// [`Either`] is useful for handling conditional branching in service middleware
 /// to different inner service types.
-#[pin_project(project = EitherProj)]
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum Either<A, B> {
-    /// One type of backing [`Service`].
-    A(#[pin] A),
-    /// The other type of backing [`Service`].
-    B(#[pin] B),
+    #[allow(missing_docs)]
+    A(A),
+    #[allow(missing_docs)]
+    B(B),
 }
 
 impl<A, B, Request> Service<Request> for Either<A, B>
 where
     A: Service<Request>,
-    A::Error: Into<crate::BoxError>,
-    B: Service<Request, Response = A::Response>,
-    B::Error: Into<crate::BoxError>,
+    B: Service<Request, Response = A::Response, Error = A::Error>,
 {
     type Response = A::Response;
-    type Error = crate::BoxError;
-    type Future = Either<A::Future, B::Future>;
+    type Error = A::Error;
+    type Future = EitherResponseFuture<A::Future, B::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        use self::Either::*;
-
         match self {
-            A(service) => Poll::Ready(Ok(ready!(service.poll_ready(cx)).map_err(Into::into)?)),
-            B(service) => Poll::Ready(Ok(ready!(service.poll_ready(cx)).map_err(Into::into)?)),
+            Either::A(service) => service.poll_ready(cx),
+            Either::B(service) => service.poll_ready(cx),
         }
     }
 
     fn call(&mut self, request: Request) -> Self::Future {
-        use self::Either::*;
-
         match self {
-            A(service) => A(service.call(request)),
-            B(service) => B(service.call(request)),
+            Either::A(service) => EitherResponseFuture {
+                kind: Kind::A {
+                    inner: service.call(request),
+                },
+            },
+            Either::B(service) => EitherResponseFuture {
+                kind: Kind::B {
+                    inner: service.call(request),
+                },
+            },
         }
     }
 }
 
-impl<A, B, T, AE, BE> Future for Either<A, B>
+pin_project! {
+    /// Response future for [`Either`].
+    pub struct EitherResponseFuture<A, B> {
+        #[pin]
+        kind: Kind<A, B>
+    }
+}
+
+pin_project! {
+    #[project = KindProj]
+    enum Kind<A, B> {
+        A { #[pin] inner: A },
+        B { #[pin] inner: B },
+    }
+}
+
+impl<A, B> Future for EitherResponseFuture<A, B>
 where
-    A: Future<Output = Result<T, AE>>,
-    AE: Into<crate::BoxError>,
-    B: Future<Output = Result<T, BE>>,
-    BE: Into<crate::BoxError>,
+    A: Future,
+    B: Future<Output = A::Output>,
 {
-    type Output = Result<T, crate::BoxError>;
+    type Output = A::Output;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match self.project() {
-            EitherProj::A(fut) => Poll::Ready(Ok(ready!(fut.poll(cx)).map_err(Into::into)?)),
-            EitherProj::B(fut) => Poll::Ready(Ok(ready!(fut.poll(cx)).map_err(Into::into)?)),
+        match self.project().kind.project() {
+            KindProj::A { inner } => inner.poll(cx),
+            KindProj::B { inner } => inner.poll(cx),
         }
     }
 }

--- a/tower/src/util/either.rs
+++ b/tower/src/util/either.rs
@@ -62,7 +62,9 @@ pin_project! {
         #[pin]
         kind: Kind<A, B>
     }
+}
 
+pin_project! {
     #[project = KindProj]
     enum Kind<A, B> {
         Left { #[pin] inner: A },

--- a/tower/src/util/either.rs
+++ b/tower/src/util/either.rs
@@ -62,9 +62,7 @@ pin_project! {
         #[pin]
         kind: Kind<A, B>
     }
-}
 
-pin_project! {
     #[project = KindProj]
     enum Kind<A, B> {
         Left { #[pin] inner: A },

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -1077,8 +1077,8 @@ impl<T: ?Sized, Request> ServiceExt<Request> for T where T: tower_service::Servi
 /// [`Layer`]: crate::layer::Layer
 pub fn option_layer<L>(layer: Option<L>) -> Either<L, Identity> {
     if let Some(layer) = layer {
-        Either::A(layer)
+        Either::Left(layer)
     } else {
-        Either::B(Identity::new())
+        Either::Right(Identity::new())
     }
 }

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -53,6 +53,7 @@ pub mod future {
     //! Future types
 
     pub use super::and_then::AndThenFuture;
+    pub use super::either::EitherResponseFuture;
     pub use super::map_err::MapErrFuture;
     pub use super::map_response::MapResponseFuture;
     pub use super::map_result::MapResultFuture;


### PR DESCRIPTION
In practice I've found `Either` be hard to use since it changes the error type to `BoxError`. That means if you combine two infallible services you get a service that, to the type system, is fallible. That doesn't work well with [axum's error handling](https://docs.rs/axum/latest/axum/error_handling/index.html) model which requires all services to be infallible and thus always return a response. So you end up having to add boilerplate just to please the type system.

Additionally, the fact that `Either` implements `Future` also means we cannot fully remove the dependency on `pin-project` since `pin-project-lite` doesn't support tuple enum variants, only named fields.

This PR reworks `Either` to address these:

- It now requires the two services to have the same error type so no type information is lost. I did consider doing something like `where B::Error: From<A::Error>` but I hope this simpler model will lead to better compiler errors.
- Changes the response future to be a struct with a private enum using `pin-project-lite`
- Removes the `Future` impl so we can remove the dependency on `pin-project`

Goes without saying that this is a breaking change so we have to wait until tower 0.5 to ship this.

cc @jplatte

Fixes https://github.com/tower-rs/tower/issues/594
Fixes https://github.com/tower-rs/tower/issues/550