### PR TITLE
tower: update `tokio-util` to v0.7

### DIFF
--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -74,7 +74,7 @@ rand = { version = "0.8", features = ["small_rng"], optional = true }
 slab = { version = "0.4", optional = true }
 tokio = { version = "1", optional = true, features = ["sync"] }
 tokio-stream = { version = "0.1.0", optional = true }
-tokio-util = { version = "0.6.3", default-features = false, optional = true }
+tokio-util = { version = "0.7.0", default-features = false, optional = true }
 tracing = { version = "0.1.2", optional = true }
 
 [dev-dependencies]

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -74,7 +74,7 @@ hdrhistogram = { version = "7.0", optional = true }
 indexmap = { version = "1.0.2", optional = true }
 rand = { version = "0.8", features = ["small_rng"], optional = true }
 slab = { version = "0.4", optional = true }
-tokio = { version = "1", optional = true, features = ["sync"] }
+tokio = { version = "1.6", optional = true, features = ["sync"] }
 tokio-stream = { version = "0.1.0", optional = true }
 tokio-util = { version = "0.7.0", default-features = false, optional = true }
 tracing = { version = "0.1.2", default-features = false, features = ["std"], optional = true }
@@ -85,7 +85,7 @@ pin-project-lite = { version = "0.2.7", optional = true }
 futures = "0.3"
 hdrhistogram = "7.0"
 pin-project-lite = "0.2.7"
-tokio = { version = "1", features = ["macros", "sync", "test-util", "rt-multi-thread"] }
+tokio = { version = "1.6", features = ["macros", "sync", "test-util", "rt-multi-thread"] }
 tokio-stream = "0.1"
 tokio-test = "0.4"
 tower-test = { version = "0.4", path = "../tower-test" }


### PR DESCRIPTION
This PR updates `tokio-util` to v0.7.

It also updates the minimum `tokio` dependency to v1.6.0.
This is because `tokio-util` requires at least `tokio` v1.6.0 for
`mpsc::Sender::reserve_owned`, but it only specifies a minimum version
of v1.0.0. This is incorrect and should be considered an upstream bug,
but updating our tokio dep fixes this, so that should at least unbreak
`tower`'s build for now.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>