### PR TITLE
ci: fix wrong tag regex for `tower`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: create github release
+
+on:
+  push:
+    tags:
+      - tower-[0-9]+.*
+      - tower-[a-z]+-v[0-9]+.*
+
+jobs:
+  create-release:
+    name: Create GitHub release
+    # only publish from the origin repository
+    if: github.repository_owner == 'tower-rs'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: taiki-e/create-gh-release-action@v1.3.0
+        with:
+          prefix: "(tower)|(tower-[a-z]+)"
+          changelog: "$prefix/CHANGELOG.md"
+          title: "$prefix $version"
+          branch: master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In #643, I accidentally included a `v` before the version number in the
regex for matching release tags for the `tower` crate.

All previous release tags on this repo don't use a `v`, so adding it
was a mistake. This branch removes it.