### PR TITLE
chore: bump MSRV to 1.49.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,7 +68,7 @@ jobs:
       # failure only occurs on a particular version.
       fail-fast: false
       matrix:
-        rust: [stable, beta, nightly, 1.46.0]
+        rust: [stable, beta, nightly, 1.49.0]
     steps:
     - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
       # failure only occurs on a particular version.
       fail-fast: false
       matrix:
-        rust: [stable, 1.46.0]
+        rust: [stable, 1.49.0]
     steps:
     - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1

--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ Tower aims to make it as easy as possible to build robust networking clients and
 servers. It is protocol agnostic, but is designed around a request / response
 pattern. If your protocol is entirely stream based, Tower may not be a good fit.
 
-## Minimum supported Rust version
+## Supported Rust Versions
 
-tower's MSRV is 1.46.
+Tower will keep a rolling MSRV (minimum supported Rust version) policy of **at
+least** 6 months. When increasing the MSRV, the new Rust version must have been
+released at least six months ago. The current MSRV is 1.49.0.
 
 ## Getting Started
 

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -20,6 +20,7 @@ clients and servers.
 categories = ["asynchronous", "network-programming"]
 keywords = ["io", "async", "non-blocking", "futures", "service"]
 edition = "2018"
+rust-version = "1.49.0"
 
 [features]
 default = ["log"]

--- a/tower/README.md
+++ b/tower/README.md
@@ -172,6 +172,13 @@ Tower.
 [`retry`]: https://docs.rs/tower/latest/tower/retry
 [open a PR]: https://github.com/tower-rs/tower/compare
 
+
+## Supported Rust Versions
+
+Tower will keep a rolling MSRV (minimum supported Rust version) policy of **at
+least** 6 months. When increasing the MSRV, the new Rust version must have been
+released at least six months ago. The current MSRV is 1.49.0.
+
 ## License
 
 This project is licensed under the [MIT license](LICENSE).

--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -140,6 +140,13 @@
 //! See [here](#modules) for a complete list of all middleware provided by
 //! Tower.
 //!
+//!
+//! #! Supported Rust Versions
+//!
+//! Tower will keep a rolling MSRV (minimum supported Rust version) policy of **at
+//! least** 6 months. When increasing the MSRV, the new Rust version must have been
+//! released at least six months ago. The current MSRV is 1.49.0.
+//!
 //! [`Service`]: crate::Service
 //! [`Layer`]: crate::Layer
 //! [timeouts]: crate::timeout


### PR DESCRIPTION
`tower` builds are now failing on CI because Tokio v1.17.0 bumped MSRV
to 1.49.0. This branch updates `tower`'s MSRV to 1.49.0 to track Tokio's
MSRV. I also added nicer documentation of the MSRV based on Tokio's, and
added the `rust-version` Cargo metadata to the `tower` crate's
`Cargo.toml`.

Note that `tower-service` and `tower-layer` can technically continue to
support much earlier Rust versions than `tower` can, since they don't
depend on external crates and are very small. We could consider testing
separate, older MSRVs on CI for those crates individually. I didn't do
that in this PR, though, because I wasn't sure if this was worth the
effort and I just wanted to get CI passing again.