### PR TITLE
util: remove deprecated `ServiceExt::ready_and`

### DIFF
--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+### Changed
+
+- **util**: Removed deprecated `ServiceExt::ready_and` method and `ReadyAnd`
+  future ([#652])
+
+
+[#652]: https://github.com/tower-rs/tower/pull/652
 
 # 0.4.12 (February 16, 2022)
 

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -32,7 +32,7 @@ pub use self::{
     map_result::{MapResult, MapResultLayer},
     oneshot::Oneshot,
     optional::Optional,
-    ready::{Ready, ReadyAnd, ReadyOneshot},
+    ready::{Ready, ReadyOneshot},
     service_fn::{service_fn, ServiceFn},
     then::{Then, ThenLayer},
 };

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -19,7 +19,6 @@ mod ready;
 mod service_fn;
 mod then;
 
-#[allow(deprecated)]
 pub use self::{
     and_then::{AndThen, AndThenLayer},
     boxed::{BoxLayer, BoxService, UnsyncBoxService},
@@ -70,19 +69,6 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
         Self: Sized,
     {
         Ready::new(self)
-    }
-
-    /// Yields a mutable reference to the service when it is ready to accept a request.
-    #[deprecated(
-        since = "0.4.6",
-        note = "please use the `ServiceExt::ready` method instead"
-    )]
-    #[allow(deprecated)]
-    fn ready_and(&mut self) -> ReadyAnd<'_, Self, Request>
-    where
-        Self: Sized,
-    {
-        ReadyAnd::new(self)
     }
 
     /// Yields the service when it is ready to accept a request.

--- a/tower/src/util/ready.rs
+++ b/tower/src/util/ready.rs
@@ -69,14 +69,6 @@ where
 /// [`ServiceExt::ready`]: crate::util::ServiceExt::ready
 pub struct Ready<'a, T, Request>(ReadyOneshot<&'a mut T, Request>);
 
-/// A future that yields a mutable reference to the service when it is ready to accept a request.
-///
-/// [`ReadyAnd`] values are produced by [`ServiceExt::ready_and`].
-///
-/// [`ServiceExt::ready_and`]: crate::util::ServiceExt::ready_and
-#[deprecated(since = "0.4.6", note = "Please use the Ready future instead")]
-pub type ReadyAnd<'a, T, Request> = Ready<'a, T, Request>;
-
 // Safety: This is safe for the same reason that the impl for ReadyOneshot is safe.
 impl<'a, T, Request> Unpin for Ready<'a, T, Request> {}
 


### PR DESCRIPTION
These was deprecated in #567. In 0.5, we can just remove them entirely.

Closes #568