### PR TITLE
buffer: change `Buffer` to be generic over inner service's `Future`

### DIFF
--- a/tower/src/buffer/layer.rs
+++ b/tower/src/buffer/layer.rs
@@ -48,7 +48,7 @@ where
     S::Error: Into<crate::BoxError> + Send + Sync,
     Request: Send + 'static,
 {
-    type Service = Buffer<S, Request>;
+    type Service = Buffer<Request, S::Future>;
 
     fn layer(&self, service: S) -> Self::Service {
         Buffer::new(service, self.bound)

--- a/tower/tests/buffer/main.rs
+++ b/tower/tests/buffer/main.rs
@@ -437,15 +437,15 @@ async fn doesnt_leak_permits() {
     assert_ready_ok!(ready3.poll());
 }
 
-type Mock = mock::Mock<&'static str, &'static str>;
 type Handle = mock::Handle<&'static str, &'static str>;
+type MockBuffer = Buffer<&'static str, mock::future::ResponseFuture<&'static str>>;
 
-fn new_service() -> (mock::Spawn<Buffer<Mock, &'static str>>, Handle) {
+fn new_service() -> (mock::Spawn<MockBuffer>, Handle) {
     // bound is >0 here because clears_canceled_requests needs multiple outstanding requests
     new_service_with_bound(10)
 }
 
-fn new_service_with_bound(bound: usize) -> (mock::Spawn<Buffer<Mock, &'static str>>, Handle) {
+fn new_service_with_bound(bound: usize) -> (mock::Spawn<MockBuffer>, Handle) {
     mock::spawn_with(|s| {
         let (svc, worker) = Buffer::pair(s, bound);
 


### PR DESCRIPTION
This commit changes the `Buffer` service to be generic over the inner
service's `Future` type, rather than over the `Service` type itself. The
`Worker` type is still generic over the inner `Service` (and, it must
be, as it stores an instance of that service). This should reduce type
complexity of buffers a bit, as they will erase nested service types.

Unfortunately, `Buffer` is still generic over the inner service's
`Future`, which may also be nested, but it is likely to be less complex
than the `Service`. It would be nice if we could erase the `Future` type
as well, but I don't believe this is possible without either boxing the
futures or changing them to always be spawned on a background task,
neither of which seems desirable here.

Closes #641