### PR TITLE
util: Fix call_all hang when stream is pending

### DIFF
--- a/tower/src/util/call_all/common.rs
+++ b/tower/src/util/call_all/common.rs
@@ -111,6 +111,7 @@ where
                 Poll::Pending => {
                     // TODO: We probably want to "release" the slot we reserved in Svc here.
                     // It may be a while until we get around to actually using it.
+                    return Poll::Pending;
                 }
             }
         }

--- a/tower/src/util/call_all/common.rs
+++ b/tower/src/util/call_all/common.rs
@@ -97,21 +97,18 @@ where
                 .expect("Using CallAll after extracing inner Service");
             ready!(svc.poll_ready(cx))?;
 
-            // If it is, gather the next request (if there is one)
-            match this.stream.as_mut().poll_next(cx) {
-                Poll::Ready(r) => match r {
-                    Some(req) => {
-                        this.queue.push(svc.call(req));
-                    }
-                    None => {
-                        // We're all done once any outstanding requests have completed
-                        *this.eof = true;
-                    }
-                },
-                Poll::Pending => {
-                    // TODO: We probably want to "release" the slot we reserved in Svc here.
-                    // It may be a while until we get around to actually using it.
-                    return Poll::Pending;
+            // If it is, gather the next request (if there is one), or return `Pending` if the
+            // stream is not ready.
+            // TODO: We probably want to "release" the slot we reserved in Svc if the
+            // stream returns `Pending`. It may be a while until we get around to actually
+            // using it.
+            match ready!(this.stream.as_mut().poll_next(cx)) {
+                Some(req) => {
+                    this.queue.push(svc.call(req));
+                }
+                None => {
+                    // We're all done once any outstanding requests have completed
+                    *this.eof = true;
                 }
             }
         }


### PR DESCRIPTION
Currently `call_all` will hang in a busy loop if called when the input stream is pending.