### PR TITLE
log: don't enable this feature by default

### DIFF
--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -23,7 +23,6 @@ edition = "2018"
 rust-version = "1.49.0"
 
 [features]
-default = ["log"]
 
 # Internal
 __common = ["futures-core", "pin-project-lite"]


### PR DESCRIPTION
Unfortunately, tracing/log is a non-additive feature (https://github.com/tokio-rs/tracing/issues/1793), so enabling it is a bit radioactive.