### PR TITLE
load_shed: make constructor for Overloaded error public

### DIFF
--- a/tower/src/load_shed/error.rs
+++ b/tower/src/load_shed/error.rs
@@ -7,6 +7,7 @@ use std::fmt;
 /// called.
 ///
 /// [`LoadShed`]: crate::load_shed::LoadShed
+#[derive(Default)]
 pub struct Overloaded {
     _p: (),
 }

--- a/tower/src/load_shed/error.rs
+++ b/tower/src/load_shed/error.rs
@@ -12,7 +12,8 @@ pub struct Overloaded {
 }
 
 impl Overloaded {
-    pub(crate) fn new() -> Self {
+    /// Construct a new overloaded error
+    pub fn new() -> Self {
         Overloaded { _p: () }
     }
 }


### PR DESCRIPTION
This allows for mocking. This also matches what is done for
the timeout Elapsed error.

Signed-off-by: Matt Klein <mklein@lyft.com>