### PR TITLE
chore: prepare to release `tower-service` v0.3.2

### DIFF
--- a/tower-service/CHANGELOG.md
+++ b/tower-service/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Unreleased
 
-- Clarify subtlety around cloning and readiness in the `Service` docs.
+- None
+
+# 0.3.2 (June 17, 2022)
+
+## Added
+
+- **docs**: Clarify subtlety around cloning and readiness in the `Service` docs
+  ([#548])
+- **docs**: Clarify details around shared resource consumption in `poll_ready()`
+  ([#662])
+
+
+[#548]: https://github.com/tower-rs/tower/pull/548
+[#662]: https://github.com/tower-rs/tower/pull/662
+
 
 # 0.3.1 (November 29, 2019)
 

--- a/tower-service/Cargo.toml
+++ b/tower-service/Cargo.toml
@@ -5,14 +5,14 @@ name = "tower-service"
 #   - Cargo.toml
 #   - README.md
 # - Update CHANGELOG.md.
-# - Create "v0.2.x" git tag.
-version = "0.3.1"
+# - Create "v0.3.x" git tag.
+version = "0.3.2"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tower-rs/tower"
 homepage = "https://github.com/tower-rs/tower"
-documentation = "https://docs.rs/tower-service/0.3.1"
+documentation = "https://docs.rs/tower-service/0.3.2"
 description = """
 Trait representing an asynchronous, request / response based, client or server.
 """


### PR DESCRIPTION
# 0.3.2 (June 17, 2022)

## Added

- **docs**: Clarify subtlety around cloning and readiness in the
  `Service` docs ([#548])
- **docs**: Clarify details around shared resource consumption in
  `poll_ready()` ([#662])

[#548]: https://github.com/tower-rs/tower/pull/548
[#662]: https://github.com/tower-rs/tower/pull/662