### PR TITLE
chore: allow publishing releases from version branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,6 @@ jobs:
           prefix: "(tower)|(tower-[a-z]+)"
           changelog: "$prefix/CHANGELOG.md"
           title: "$prefix $version"
-          branch: master
+          branch: "(master)|(v[0-9]+.[0-9]+.x)"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Currently, the GitHub Release automation requires that tags be pushed to
the `master` branch. In some cases, we may wish to cut releases from
earlier versions (such as now, when `master` contains breaking changes).

This commit updates the release workflow to also allow releases when
tags are pushed to branches matching the regex `v[0-9]+.[0-9]+.x`. This
should allow the workflow to also run when a release tag is pushed to a
branch for a prior version.