### PR TITLE
chore(ci): Disable nightly CI runs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -91,7 +91,9 @@ jobs:
       # failure only occurs on a particular version.
       fail-fast: false
       matrix:
-        rust: [stable, beta, nightly]
+        # Nightly has been removed due to regressions, we can re-enable once the issue below is resolved.
+        # Related issue: https://github.com/rust-lang/rust/issues/99536
+        rust: [stable, beta]
     steps:
     - uses: actions/checkout@master
     - name: "install Rust ${{ matrix.rust }}"


### PR DESCRIPTION
Starting to see nightly fail with:
 ```
error[E0277]: `impl Send` is not a future
   --> examples/examples/tower-balance.rs:109:19
    |
109 |   fn gen_disco() -> impl Discover<
    |  ___________________^
110 | |     Key = Key,
111 | |     Error = Error,
112 | |     Service = ConcurrencyLimit<
113 | |         impl Service<Req, Response = Rsp, Error = Error, Future = impl Send> + Send,
114 | |     >,
115 | | > + Send {
    | |________^ `impl Send` is not a future
    |
    = help: the trait `std::future::Future` is not implemented for `impl Send`
    = note: impl Send must be a future or must implement `IntoFuture` to be awaited
    = note: required because of the requirements on the impl of `Service<Req>` for `ServiceFn<[closure@examples/examples/tower-balance.rs:121:45: 121:53]>`
    = note: required because of the requirements on the impl of `futures_core::stream::TryStream` for `Disco<ConcurrencyLimit<ServiceFn<[closure@examples/examples/tower-balance.rs:121:45: 121:53]>>>`
    = note: required because of the requirements on the impl of `tower::discover::Discover` for `Disco<ConcurrencyLimit<ServiceFn<[closure@examples/examples/tower-balance.rs:121:45: 121:53]>>>`
```

Which is a regression probably related to https://github.com/rust-lang/rust/issues/99536, I think for now its fine to disable nightly while keeping beta and stable for version checks.