### PR TITLE
retry: Extend `Policy` trait documentation

### DIFF
--- a/tower/src/retry/policy.rs
+++ b/tower/src/retry/policy.rs
@@ -84,7 +84,8 @@ pub trait Policy<Req, Res, E> {
 
     /// Tries to clone a request before being passed to the inner service.
     ///
-    /// If the request cannot be cloned, return [`None`].
+    /// If the request cannot be cloned, return [`None`]. Moreover, the retry
+    /// function will not be called if the [`None`] is returned.
     fn clone_request(&mut self, req: &Req) -> Option<Req>;
 }
 


### PR DESCRIPTION
Last week I was debugging while my `Retry` service was not behaving as expected. I found out in the source code that if my `Policy` implementation returns `None` in `clone_request`, then the retry logic will not be called. I would like to mention this in the interface to save time for the folks that could probably debug the same behavior.