### PR TITLE
chore: prepare to release tower-layer v0.3.2

### DIFF
--- a/tower-layer/CHANGELOG.md
+++ b/tower-layer/CHANGELOG.md
@@ -1,6 +1,10 @@
-# 0.3.1 (January 7, 2021)
+# 0.3.2 (October 7, 2022)
 
-### Added
+- Implement `Layer` for tuples of up to 16 elements ([#694])
+
+[#694]: https://github.com/tower-rs/tower/pull/694
+
+# 0.3.1 (January 7, 2021)
 
 - Added `layer_fn`, for constructing a `Layer` from a function taking
   a `Service` and returning a different `Service` ([#491])

--- a/tower-layer/Cargo.toml
+++ b/tower-layer/Cargo.toml
@@ -6,13 +6,12 @@ name = "tower-layer"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tower-rs/tower"
 homepage = "https://github.com/tower-rs/tower"
-documentation = "https://docs.rs/tower-layer/0.3.0-alpha.2"
 description = """
 Decorates a `Service` to allow easy composition between `Service`s.
 """


### PR DESCRIPTION
I've backported https://github.com/tower-rs/tower/pull/694 to the `v0.4.x` branch. This creates a release of tower-layer for that.