### PR TITLE
discover: Implement Clone for Change

### DIFF
--- a/tower/src/discover/mod.rs
+++ b/tower/src/discover/mod.rs
@@ -97,7 +97,7 @@ where
 }
 
 /// A change in the service set.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Change<K, V> {
     /// A new service identified by key `K` was identified.
     Insert(K, V),


### PR DESCRIPTION
Implements Clone for discover::Change, if the underlying key and value both implement clone.

This is convenient for use-cases where a single change is duplicated so that it can be sent to multiple discover streams.