### PR TITLE
Add a timeout for service discovery

### DIFF
--- a/tower/src/balance/p2c/future.rs
+++ b/tower/src/balance/p2c/future.rs
@@ -1,0 +1,64 @@
+//! Future types
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_core::ready;
+use pin_project_lite::pin_project;
+
+use crate::timeout::error::Elapsed;
+
+pin_project! {
+    /// Future for the [`Balance`] service.
+    ///
+    /// [`Balance`]: crate::balance::p2c::Balance
+    #[derive(Debug)]
+    pub struct ResponseFuture<F> {
+        #[pin]
+        state: ResponseState<F>,
+    }
+}
+
+pin_project! {
+    #[project = ResponseStateProj]
+    #[derive(Debug)]
+    enum ResponseState<F> {
+        Called {
+            #[pin]
+            fut: F
+        },
+        TimedOut,
+    }
+}
+
+impl<F> ResponseFuture<F> {
+    pub(crate) fn called(fut: F) -> Self {
+        ResponseFuture {
+            state: ResponseState::Called { fut },
+        }
+    }
+
+    pub(crate) fn timed_out() -> Self {
+        ResponseFuture {
+            state: ResponseState::TimedOut,
+        }
+    }
+}
+
+impl<F, T, E> Future for ResponseFuture<F>
+where
+    F: Future<Output = Result<T, E>>,
+    E: Into<crate::BoxError>,
+{
+    type Output = Result<T, crate::BoxError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.project().state.project() {
+            ResponseStateProj::Called { fut } => {
+                Poll::Ready(ready!(fut.poll(cx)).map_err(Into::into))
+            }
+            ResponseStateProj::TimedOut => Poll::Ready(Err(Elapsed::new().into())),
+        }
+    }
+}

--- a/tower/src/balance/p2c/mod.rs
+++ b/tower/src/balance/p2c/mod.rs
@@ -29,6 +29,7 @@
 //! [finagle]: https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-least-loaded
 //! [`Stream`]: https://docs.rs/futures/0.3/futures/stream/trait.Stream.html
 
+mod future;
 mod layer;
 mod make;
 mod service;


### PR DESCRIPTION
## Context

As part of looking into timeouts in various parts of the stack in TrueLayer/ginepro#37 I found that we have no timeout for DNS resolution. As currently implemented, it's possible for requests to hang forever if DNS never resolves and no services are discovered.

Applications can add their own timeouts around requests, but I think it can be helpful for underlying libraries to offer timeouts for things like TCP connection and DNS resolution (or general service discovery), especially as fallbacks for when higher level timeouts are forgotten!

## Changes

I've taken a shot at solving this, but I'm not very familiar with writing lower level async code using `poll` etc. rather than async/await. I can't say I'm confident that this is the best approach or that I haven't missed something.

With that in mind:

1. Is there a better way to solve this problem?
2. Is the change in the type of `Balance::Future` a problematic breaking change?
3. Are there any more docs or test cases I should consider adding?

I should probably have raised an issue first before diving into a solution, but it's Christmas and I got carried away 😅