### PR TITLE
use a simpler random 2-sampler

### DIFF
--- a/tower/src/balance/p2c/service.rs
+++ b/tower/src/balance/p2c/service.rs
@@ -2,7 +2,7 @@ use super::super::error;
 use crate::discover::{Change, Discover};
 use crate::load::Load;
 use crate::ready_cache::{error::Failed, ReadyCache};
-use crate::util::rng::{sample_inplace, HasherRng, Rng};
+use crate::util::rng::{sample_floyd2, HasherRng, Rng};
 use futures_core::ready;
 use futures_util::future::{self, TryFutureExt};
 use pin_project_lite::pin_project;
@@ -185,10 +185,7 @@ where
             len => {
                 // Get two distinct random indexes (in a random order) and
                 // compare the loads of the service at each index.
-                let idxs = sample_inplace(&mut self.rng, len as u32, 2);
-
-                let aidx = idxs[0];
-                let bidx = idxs[1];
+                let [aidx, bidx] = sample_floyd2(&mut self.rng, len as u64);
                 debug_assert_ne!(aidx, bidx, "random indices must be distinct");
 
                 let aload = self.ready_index_load(aidx as usize);

--- a/tower/src/util/rng.rs
+++ b/tower/src/util/rng.rs
@@ -159,13 +159,22 @@ mod tests {
             let mut rng = HasherRng::default();
             rng.counter = counter;
 
-            let [a, b] = super::sample_floyd2(&mut rng, length, amount);
+            let [a, b] = super::sample_floyd2(&mut rng, length);
 
             if a >= length || b >= length || a == b {
                 return TestResult::failed();
             }
 
             TestResult::passed()
+        }
+    }
+
+    #[test]
+    fn sample_inplace_boundaries() {
+        let mut r = HasherRng::default();
+        match super::sample_floyd2(&mut r, 2) {
+            [0, 1] | [1, 0] => (),
+            err => panic!("{err:?}"),
         }
     }
 }


### PR DESCRIPTION
While this only saves 40ns (70ns down to 30ns - probably more if there are other threads causing allocator contention)
per sample, I still think it makes sense to not allocate here.

This was the only use of `sample_inplace` in this codebase. I also have an impl that scales to higher `amount`s, but it uses const generics which won't fit in the current MSRV