### PR TITLE
Recommend Axum instead of Warp

### DIFF
--- a/tower/README.md
+++ b/tower/README.md
@@ -106,8 +106,7 @@ The following is an incomplete list of such libraries:
 * [`tonic`]: A [gRPC-over-HTTP/2][grpc] implementation built on top of
   [`hyper`]. See [here][tonic-examples] for examples of using [`tonic`] with
   Tower.
-* [`warp`]: A lightweight, composable web framework. See
-  [here][warp-service] for details on using [`warp`] with Tower.
+* [`axum`]: Ergonomic and modular web framework built with Tokio, Tower, and Hyper.
 * [`tower-lsp`]: implementations of the [Language
   Server Protocol][lsp] based on Tower.
 * [`kube`]: Kubernetes client and futures controller runtime. [`kube::Client`]


### PR DESCRIPTION
According to lib.rs and crates.io, Axum has been having major success and is now the number 1 [HTTP server](https://lib.rs/web-programming/http-server) with [more downloads](https://lib.rs/crates/axum) than [Warp](https://lib.rs/crates/warp).

I propose that tonic recommends Axum instead of Warp.