### PR TITLE
Add `#[must_use]` warning annotation to `Service::call()`

### DIFF
--- a/tower-service/src/lib.rs
+++ b/tower-service/src/lib.rs
@@ -351,6 +351,7 @@ pub trait Service<Request> {
     ///
     /// Implementations are permitted to panic if `call` is invoked without
     /// obtaining `Poll::Ready(Ok(()))` from `poll_ready`.
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
     fn call(&mut self, req: Request) -> Self::Future;
 }
 


### PR DESCRIPTION
While doing some unrelated work I noticed that the `Service::call()` method didn't provide a warning when its future wasn't used or awaited on. If this isn't intentional, I've added the annotation to the trait.

While patching my repo for the fix, I noticed some `Cargo.toml` version numbers were out of date as well, so I bumped them