### PR TITLE
Bump `Cargo.toml` version numbers to match what's on crates.io

### DIFF
--- a/tower-layer/Cargo.toml
+++ b/tower-layer/Cargo.toml
@@ -6,7 +6,7 @@ name = "tower-layer"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"

--- a/tower-service/Cargo.toml
+++ b/tower-service/Cargo.toml
@@ -6,7 +6,7 @@ name = "tower-service"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -6,7 +6,7 @@ name = "tower"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "vX.X.X" git tag.
-version = "0.4.12"
+version = "0.4.13"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
As in title, broken out from https://github.com/tower-rs/tower/pull/728