### PR TITLE
feat: enable non-`'static` where possible

### DIFF
--- a/tower/src/buffer/service.rs
+++ b/tower/src/buffer/service.rs
@@ -65,7 +65,7 @@ where
     /// the background `Worker` that you can then spawn.
     pub fn pair<S>(service: S, bound: usize) -> (Self, Worker<S, Req>)
     where
-        S: Service<Req, Future = F> + Send + 'static,
+        S: Service<Req, Future = F> + Send,
         F: Send,
         S::Error: Into<crate::BoxError> + Send + Sync,
         Req: Send + 'static,
@@ -132,8 +132,8 @@ where
 
 impl<Req, F> Clone for Buffer<Req, F>
 where
-    Req: Send + 'static,
-    F: Send + 'static,
+    Req: Send,
+    F: Send,
 {
     fn clone(&self) -> Self {
         Self {

--- a/tower/src/builder/mod.rs
+++ b/tower/src/builder/mod.rs
@@ -75,7 +75,7 @@ use std::fmt;
 /// # #[cfg(feature = "limit")]
 /// # use tower::limit::concurrency::ConcurrencyLimitLayer;
 /// # #[cfg(feature = "limit")]
-/// # async fn wrap<S>(svc: S) where S: Service<(), Error = &'static str> + 'static + Send, S::Future: Send {
+/// # async fn wrap<S>(svc: S) where S: Service<(), Error = &'static str> + Send, S::Future: Send {
 /// ServiceBuilder::new()
 ///     .concurrency_limit(5)
 ///     .service(svc);
@@ -703,7 +703,7 @@ impl<L> ServiceBuilder<L> {
     ///
     /// [`BoxService::layer()`]: crate::util::BoxService::layer()
     #[cfg(feature = "util")]
-    pub fn boxed<S, R>(
+    pub fn boxed<'a, S, R>(
         self,
     ) -> ServiceBuilder<
         Stack<
@@ -711,6 +711,7 @@ impl<L> ServiceBuilder<L> {
                 fn(
                     L::Service,
                 ) -> crate::util::BoxService<
+                    'a,
                     R,
                     <L::Service as Service<R>>::Response,
                     <L::Service as Service<R>>::Error,
@@ -721,8 +722,8 @@ impl<L> ServiceBuilder<L> {
     >
     where
         L: Layer<S>,
-        L::Service: Service<R> + Send + 'static,
-        <L::Service as Service<R>>::Future: Send + 'static,
+        L::Service: Service<R> + Send + 'a,
+        <L::Service as Service<R>>::Future: Send + 'a,
     {
         self.layer(crate::util::BoxService::layer())
     }
@@ -766,7 +767,7 @@ impl<L> ServiceBuilder<L> {
     /// [`BoxCloneService`]: crate::util::BoxCloneService
     /// [`boxed`]: Self::boxed
     #[cfg(feature = "util")]
-    pub fn boxed_clone<S, R>(
+    pub fn boxed_clone<'a, S, R>(
         self,
     ) -> ServiceBuilder<
         Stack<
@@ -774,6 +775,7 @@ impl<L> ServiceBuilder<L> {
                 fn(
                     L::Service,
                 ) -> crate::util::BoxCloneService<
+                    'a,
                     R,
                     <L::Service as Service<R>>::Response,
                     <L::Service as Service<R>>::Error,
@@ -784,8 +786,8 @@ impl<L> ServiceBuilder<L> {
     >
     where
         L: Layer<S>,
-        L::Service: Service<R> + Clone + Send + 'static,
-        <L::Service as Service<R>>::Future: Send + 'static,
+        L::Service: Service<R> + Clone + Send + 'a,
+        <L::Service as Service<R>>::Future: Send + 'a,
     {
         self.layer(crate::util::BoxCloneService::layer())
     }

--- a/tower/src/util/boxed/unsync.rs
+++ b/tower/src/util/boxed/unsync.rs
@@ -4,34 +4,36 @@ use tower_service::Service;
 use std::fmt;
 use std::{
     future::Future,
+    marker::PhantomData,
     pin::Pin,
     task::{Context, Poll},
 };
 
 /// A boxed [`Service`] trait object.
-pub struct UnsyncBoxService<T, U, E> {
-    inner: Box<dyn Service<T, Response = U, Error = E, Future = UnsyncBoxFuture<U, E>>>,
+pub struct UnsyncBoxService<'a, T, U, E> {
+    inner: Box<dyn Service<T, Response = U, Error = E, Future = UnsyncBoxFuture<'a, U, E>> + 'a>,
 }
 
 /// A boxed [`Future`] trait object.
 ///
 /// This type alias represents a boxed future that is *not* [`Send`] and must
 /// remain on the current thread.
-type UnsyncBoxFuture<T, E> = Pin<Box<dyn Future<Output = Result<T, E>>>>;
+type UnsyncBoxFuture<'a, T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + 'a>>;
 
 #[derive(Debug)]
-struct UnsyncBoxed<S> {
+struct UnsyncBoxed<'a, S> {
     inner: S,
+    _marker: PhantomData<&'a ()>,
 }
 
-impl<T, U, E> UnsyncBoxService<T, U, E> {
+impl<'a, T, U, E> UnsyncBoxService<'a, T, U, E> {
     #[allow(missing_docs)]
     pub fn new<S>(inner: S) -> Self
     where
-        S: Service<T, Response = U, Error = E> + 'static,
-        S::Future: 'static,
+        S: Service<T, Response = U, Error = E> + 'a,
+        S::Future: 'a,
     {
-        let inner = Box::new(UnsyncBoxed { inner });
+        let inner = Box::new(UnsyncBoxed { inner, _marker: PhantomData });
         UnsyncBoxService { inner }
     }
 
@@ -40,41 +42,41 @@ impl<T, U, E> UnsyncBoxService<T, U, E> {
     /// [`Layer`]: crate::Layer
     pub fn layer<S>() -> LayerFn<fn(S) -> Self>
     where
-        S: Service<T, Response = U, Error = E> + 'static,
-        S::Future: 'static,
+        S: Service<T, Response = U, Error = E> + 'a,
+        S::Future: 'a,
     {
         layer_fn(Self::new)
     }
 }
 
-impl<T, U, E> Service<T> for UnsyncBoxService<T, U, E> {
+impl<'a, T, U, E> Service<T> for UnsyncBoxService<'a, T, U, E> {
     type Response = U;
     type Error = E;
-    type Future = UnsyncBoxFuture<U, E>;
+    type Future = UnsyncBoxFuture<'a, U, E>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), E>> {
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, request: T) -> UnsyncBoxFuture<U, E> {
+    fn call(&mut self, request: T) -> UnsyncBoxFuture<'a, U, E> {
         self.inner.call(request)
     }
 }
 
-impl<T, U, E> fmt::Debug for UnsyncBoxService<T, U, E> {
+impl<'a, T, U, E> fmt::Debug for UnsyncBoxService<'a, T, U, E> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("UnsyncBoxService").finish()
     }
 }
 
-impl<S, Request> Service<Request> for UnsyncBoxed<S>
+impl<'a, S, Request> Service<Request> for UnsyncBoxed<'a, S>
 where
-    S: Service<Request> + 'static,
-    S::Future: 'static,
+    S: Service<Request> + 'a,
+    S::Future: 'a,
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = Pin<Box<dyn Future<Output = Result<S::Response, S::Error>>>>;
+    type Future = Pin<Box<dyn Future<Output = Result<S::Response, S::Error>> + 'a>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)

--- a/tower/src/util/boxed_clone.rs
+++ b/tower/src/util/boxed_clone.rs
@@ -55,19 +55,19 @@ use tower_service::Service;
 /// # fn assert_service<S, R>(svc: S) -> S
 /// # where S: Service<R> { svc }
 /// ```
-pub struct BoxCloneService<T, U, E>(
+pub struct BoxCloneService<'a, T, U, E>(
     Box<
-        dyn CloneService<T, Response = U, Error = E, Future = BoxFuture<'static, Result<U, E>>>
+        dyn 'a+CloneService<T, Response = U, Error = E, Future = BoxFuture<'a, Result<U, E>>>
             + Send,
     >,
 );
 
-impl<T, U, E> BoxCloneService<T, U, E> {
+impl<'a, T, U, E> BoxCloneService<'a, T, U, E> {
     /// Create a new `BoxCloneService`.
     pub fn new<S>(inner: S) -> Self
     where
-        S: Service<T, Response = U, Error = E> + Clone + Send + 'static,
-        S::Future: Send + 'static,
+        S: Service<T, Response = U, Error = E> + Clone + Send + 'a,
+        S::Future: Send + 'a,
     {
         let inner = inner.map_future(|f| Box::pin(f) as _);
         BoxCloneService(Box::new(inner))
@@ -79,17 +79,17 @@ impl<T, U, E> BoxCloneService<T, U, E> {
     /// [`Layer`]: crate::Layer
     pub fn layer<S>() -> LayerFn<fn(S) -> Self>
     where
-        S: Service<T, Response = U, Error = E> + Clone + Send + 'static,
-        S::Future: Send + 'static,
+        S: Service<T, Response = U, Error = E> + Clone + Send + 'a,
+        S::Future: Send + 'a,
     {
         layer_fn(Self::new)
     }
 }
 
-impl<T, U, E> Service<T> for BoxCloneService<T, U, E> {
+impl<'a, T, U, E> Service<T> for BoxCloneService<'a, T, U, E> {
     type Response = U;
     type Error = E;
-    type Future = BoxFuture<'static, Result<U, E>>;
+    type Future = BoxFuture<'a, Result<U, E>>;
 
     #[inline]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), E>> {
@@ -102,34 +102,37 @@ impl<T, U, E> Service<T> for BoxCloneService<T, U, E> {
     }
 }
 
-impl<T, U, E> Clone for BoxCloneService<T, U, E> {
+impl<'a, T: 'a, U: 'a, E: 'a> Clone for BoxCloneService<'a, T, U, E> {
     fn clone(&self) -> Self {
         Self(self.0.clone_box())
     }
 }
 
 trait CloneService<R>: Service<R> {
-    fn clone_box(
+    fn clone_box<'a>(
         &self,
     ) -> Box<
-        dyn CloneService<R, Response = Self::Response, Error = Self::Error, Future = Self::Future>
+        dyn 'a+CloneService<R, Response = Self::Response, Error = Self::Error, Future = Self::Future>
             + Send,
-    >;
+    >
+    where Self: 'a;
 }
 
 impl<R, T> CloneService<R> for T
 where
-    T: Service<R> + Send + Clone + 'static,
+    T: Service<R> + Send + Clone,
 {
-    fn clone_box(
+    fn clone_box<'a>(
         &self,
-    ) -> Box<dyn CloneService<R, Response = T::Response, Error = T::Error, Future = T::Future> + Send>
+    ) -> Box<dyn CloneService<R, Response = T::Response, Error = T::Error, Future = T::Future> + Send + 'a>
+    where Self: 'a
     {
-        Box::new(self.clone())
+        let v = self.clone();
+        Box::new(v)
     }
 }
 
-impl<T, U, E> fmt::Debug for BoxCloneService<T, U, E> {
+impl<'a, T, U, E> fmt::Debug for BoxCloneService<'a, T, U, E> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("BoxCloneService").finish()
     }

--- a/tower/src/util/mod.rs
+++ b/tower/src/util/mod.rs
@@ -980,10 +980,10 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     ///
     /// [`Service`]: crate::Service
     /// [`boxed_clone`]: Self::boxed_clone
-    fn boxed(self) -> BoxService<Request, Self::Response, Self::Error>
+    fn boxed<'a>(self) -> BoxService<'a, Request, Self::Response, Self::Error>
     where
-        Self: Sized + Send + 'static,
-        Self::Future: Send + 'static,
+        Self: Sized + Send + 'a,
+        Self::Future: Send + 'a,
     {
         BoxService::new(self)
     }
@@ -1029,10 +1029,10 @@ pub trait ServiceExt<Request>: tower_service::Service<Request> {
     ///
     /// [`Service`]: crate::Service
     /// [`boxed`]: Self::boxed
-    fn boxed_clone(self) -> BoxCloneService<Request, Self::Response, Self::Error>
+    fn boxed_clone<'a>(self) -> BoxCloneService<'a, Request, Self::Response, Self::Error>
     where
-        Self: Clone + Sized + Send + 'static,
-        Self::Future: Send + 'static,
+        Self: Clone + Sized + Send + 'a,
+        Self::Future: Send + 'a,
     {
         BoxCloneService::new(self)
     }


### PR DESCRIPTION
## Motivation

Currently, many tower service wrappers and layers are limited to working with `'static` types, which limits its usefulness when working with non-`static`ally borrowed things to and from scoped tasks (e.g. `async-scoped`).

## Solution

Remove the `'static` restrictions where possible, mostly by introducing lifetime parameters.

This change excludes `Buffer` and `BufferLayer` which are more difficult to make non-`'static`. It is possible to do by abstracting `tokio::spawn` into a trait (which `async_scoped::Scope` can also implement), this is also pending the publish of the recently merged tokio-rs/tokio#5665.