### PR TITLE
chore: Remove unmatched deny ignore config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -2,7 +2,6 @@
 vulnerability = "deny"
 unmaintained = "warn"
 notice = "warn"
-ignore = ["RUSTSEC-2020-0159"]
 
 [licenses]
 unlicensed = "deny"


### PR DESCRIPTION
This cargo-deny config could be removed according to the warning.

```
warning[advisory-not-detected]: advisory was not encountered
  ┌─ /github/workspace/deny.toml:5:11
  │
5 │ ignore = ["RUSTSEC-2020-0159"]
  │           ^^^^^^^^^^^^^^^^^^^ no crate matched advisory criteria

advisories ok, bans ok, licenses ok, sources ok
```

ref: https://github.com/tower-rs/tower/actions/runs/4829234227/jobs/8604020802#step:4:13