### PR TITLE
chore: update GitHub Actions CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,25 +15,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
-        profile: minimal
-        override: true
     - name: Check
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: --workspace --all-features --all-targets
+      run: cargo check --workspace --all-features --all-targets
 
   check-docs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
-        profile: minimal
     - name: cargo doc
       working-directory: ${{ matrix.subcrate }}
       env:
@@ -45,36 +39,27 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: "install Rust ${{ env.MSRV }}"
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ env.MSRV }}
-        profile: minimal
     - name: "install Rust nightly"
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: nightly
-        profile: minimal
     - name: Select minimal versions
-      uses: actions-rs/cargo@v1
-      with:
-        command: update
-        args: -Z minimal-versions
-        toolchain: nightly
+      run: cargo update -Z minimal-versions
     - name: Check
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: --all --all-targets --all-features --locked
-        toolchain: ${{ env.MSRV }}
+      run: |
+        rustup default ${{ env.MSRV }}
+        cargo check --all --all-targets --all-features --locked
 
   cargo-hack:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
-        profile: minimal
     - name: install cargo-hack
       uses: taiki-e/install-action@cargo-hack
     - name: cargo hack check
@@ -95,16 +80,11 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: "install Rust ${{ matrix.rust }}"
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
-        profile: minimal
-        override: true
     - name: Run tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --workspace --all-features
+      run: cargo test --workspace --all-features
 
   test-msrv:
     needs: check-msrv
@@ -112,49 +92,37 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: "install Rust ${{ env.MSRV }}"
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ env.MSRV }}
-        profile: minimal
     - name: "install Rust nightly"
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: nightly
-        profile: minimal
     - name: Select minimal versions
-      uses: actions-rs/cargo@v1
-      with:
-        command: update
-        args: -Z minimal-versions
-        toolchain: nightly
+      run: cargo update -Z minimal-versions
     - name: test
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: --workspace --all-features --locked
-        toolchain: ${{ env.MSRV }}
+      run: |
+        rustup default ${{ env.MSRV }}
+        cargo check --workspace --all-features --locked
 
   style:
     needs: check-stable
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
         components: rustfmt
-        profile: minimal
     - name: rustfmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
+      run: cargo fmt --all -- --check
 
   deny-check:
     name: cargo-deny check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - uses: EmbarkStudios/cargo-deny-action@v1
       with:
         command: check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,19 +12,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Install nightly Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          profile: minimal
       - name: Generate documentation
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --workspace --no-deps --all-features
-          # Tower uses nightly-only RustDoc features
-          toolchain: nightly
+        run: cargo doc --workspace --no-deps --all-features
         env:
           # Enable the RustDoc `#[doc(cfg(...))]` attribute.
           RUSTDOCFLAGS: --cfg docsrs
@@ -36,4 +30,3 @@ jobs:
           build_dir: target/doc
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository_owner == 'tower-rs'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: taiki-e/create-gh-release-action@v1.3.0
         with:
           prefix: "(tower)|(tower-[a-z]+)"


### PR DESCRIPTION
The following updates are performed:
* update [`actions/checkout`](https://github.com/actions/checkout) to v4
* replace [unmaintained](https://github.com/actions-rs/toolchain/issues/216) `actions-rs/toolchain` by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain)
* replace unmaintained `actions-rs/cargo` by direct invocation of `cargo`

Still using the outdated / unmaintained actions will generate several warnings in CI runs, for example in https://github.com/tower-rs/tower/actions/runs/4995991400:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions-rs/toolchain@v1, actions-rs/cargo@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings.