### PR TITLE
remove generic parameters from Reconnect::new

### DIFF
--- a/tower/src/reconnect/mod.rs
+++ b/tower/src/reconnect/mod.rs
@@ -49,7 +49,7 @@ where
     M: Service<Target>,
 {
     /// Lazily connect and reconnect to a [`Service`].
-    pub fn new<S, Request>(mk_service: M, target: Target) -> Self {
+    pub fn new(mk_service: M, target: Target) -> Self {
         Reconnect {
             mk_service,
             state: State::Idle,


### PR DESCRIPTION
these were not used, as the only parameters used
come from the impl block (directly and indirectly)

Closes #737 