### PR TITLE
Update indexmap dependency & fix compiler warnings

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,7 +7,7 @@ on:
   pull_request: {}
 
 env:
-  MSRV: 1.49.0
+  MSRV: 1.63.0
 
 jobs:
   check-stable:

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -20,7 +20,7 @@ clients and servers.
 categories = ["asynchronous", "network-programming"]
 keywords = ["io", "async", "non-blocking", "futures", "service"]
 edition = "2018"
-rust-version = "1.49.0"
+rust-version = "1.63.0"
 
 [features]
 
@@ -71,7 +71,7 @@ tower-service = { version = "0.3.1", path = "../tower-service" }
 futures-core = { version = "0.3", optional = true }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
 hdrhistogram = { version = "7.0", optional = true, default-features = false }
-indexmap = { version = "1.0.2", optional = true }
+indexmap = { version = "2.0", optional = true }
 slab = { version = "0.4", optional = true }
 tokio = { version = "1.6", optional = true, features = ["sync"] }
 tokio-stream = { version = "0.1.0", optional = true }
@@ -91,7 +91,6 @@ tower-test = { version = "0.4", path = "../tower-test" }
 tracing = { version = "0.1.2", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "ansi"] }
 http = "0.2"
-lazy_static = "1.4.0"
 rand = { version = "0.8", features = ["small_rng"] }
 quickcheck = "1"
 

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -69,7 +69,7 @@ tower-layer = { version = "0.3.1", path = "../tower-layer" }
 tower-service = { version = "0.3.1", path = "../tower-service" }
 
 futures-core = { version = "0.3", optional = true }
-futures-util = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
+futures-util = { version = "0.3.22", default-features = false, features = ["alloc"], optional = true }
 hdrhistogram = { version = "7.0", optional = true, default-features = false }
 indexmap = { version = "2.0.2", optional = true }
 slab = { version = "0.4", optional = true }

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -71,7 +71,7 @@ tower-service = { version = "0.3.1", path = "../tower-service" }
 futures-core = { version = "0.3", optional = true }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
 hdrhistogram = { version = "7.0", optional = true, default-features = false }
-indexmap = { version = "2.0", optional = true }
+indexmap = { version = "2.0.2", optional = true }
 slab = { version = "0.4", optional = true }
 tokio = { version = "1.6", optional = true, features = ["sync"] }
 tokio-stream = { version = "0.1.0", optional = true }

--- a/tower/src/ready_cache/cache.rs
+++ b/tower/src/ready_cache/cache.rs
@@ -4,7 +4,7 @@ use super::error;
 use futures_core::Stream;
 use futures_util::{stream::FuturesUnordered, task::AtomicWaker};
 pub use indexmap::Equivalent;
-use indexmap::IndexMap;
+use indexmap::{IndexMap, map::MutableKeys as _};
 use std::fmt;
 use std::future::Future;
 use std::hash::Hash;
@@ -194,7 +194,7 @@ where
 
     /// Obtains a mutable reference to a service in the ready set by index.
     pub fn get_ready_index_mut(&mut self, idx: usize) -> Option<(&mut K, &mut S)> {
-        self.ready.get_index_mut(idx).map(|(k, v)| (k, &mut v.0))
+        self.ready.get_index_mut2(idx).map(|(k, v)| (k, &mut v.0))
     }
 
     /// Returns an iterator over the ready keys and services.

--- a/tower/src/ready_cache/cache.rs
+++ b/tower/src/ready_cache/cache.rs
@@ -4,7 +4,7 @@ use super::error;
 use futures_core::Stream;
 use futures_util::{stream::FuturesUnordered, task::AtomicWaker};
 pub use indexmap::Equivalent;
-use indexmap::{IndexMap, map::MutableKeys as _};
+use indexmap::{map::MutableKeys as _, IndexMap};
 use std::fmt;
 use std::future::Future;
 use std::hash::Hash;

--- a/tower/src/util/call_all/ordered.rs
+++ b/tower/src/util/call_all/ordered.rs
@@ -168,7 +168,7 @@ impl<F: Future> common::Drive<F> for FuturesOrdered<F> {
     }
 
     fn push(&mut self, future: F) {
-        FuturesOrdered::push(self, future)
+        FuturesOrdered::push_back(self, future)
     }
 
     fn poll(&mut self, cx: &mut Context<'_>) -> Poll<Option<F::Output>> {

--- a/tower/src/util/rng.rs
+++ b/tower/src/util/rng.rs
@@ -174,7 +174,7 @@ mod tests {
         let mut r = HasherRng::default();
         match super::sample_floyd2(&mut r, 2) {
             [0, 1] | [1, 0] => (),
-            err => panic!("{err:?}"),
+            err => panic!("{:?}", err),
         }
     }
 }


### PR DESCRIPTION
#741 proposes changing `get_ready_index_mut`'s signature, but that would be a semver breaking change, so can wait for `0.5`

Also remove unused lazy_static dev dependency