### PR TITLE
feat: Make new functions const when possible

### DIFF
--- a/tower-layer/src/identity.rs
+++ b/tower-layer/src/identity.rs
@@ -14,7 +14,7 @@ pub struct Identity {
 
 impl Identity {
     /// Create a new [`Identity`] value
-    pub fn new() -> Identity {
+    pub const fn new() -> Identity {
         Identity { _p: () }
     }
 }

--- a/tower-layer/src/stack.rs
+++ b/tower-layer/src/stack.rs
@@ -10,7 +10,7 @@ pub struct Stack<Inner, Outer> {
 
 impl<Inner, Outer> Stack<Inner, Outer> {
     /// Create a new `Stack`.
-    pub fn new(inner: Inner, outer: Outer) -> Self {
+    pub const fn new(inner: Inner, outer: Outer) -> Self {
         Stack { inner, outer }
     }
 }

--- a/tower-service/src/lib.rs
+++ b/tower-service/src/lib.rs
@@ -130,7 +130,7 @@ use std::task::{Context, Poll};
 /// }
 ///
 /// impl<T> Timeout<T> {
-///     pub fn new(inner: T, timeout: Duration) -> Timeout<T> {
+///     pub const fn new(inner: T, timeout: Duration) -> Timeout<T> {
 ///         Timeout {
 ///             inner,
 ///             timeout
@@ -204,7 +204,7 @@ use std::task::{Context, Poll};
 /// pub struct TimeoutLayer(Duration);
 ///
 /// impl TimeoutLayer {
-///     pub fn new(delay: Duration) -> Self {
+///     pub const fn new(delay: Duration) -> Self {
 ///         TimeoutLayer(delay)
 ///     }
 /// }

--- a/tower/src/balance/p2c/layer.rs
+++ b/tower/src/balance/p2c/layer.rs
@@ -24,7 +24,7 @@ pub struct MakeBalanceLayer<D, Req> {
 
 impl<D, Req> MakeBalanceLayer<D, Req> {
     /// Build balancers using operating system entropy.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             _marker: PhantomData,
         }

--- a/tower/src/balance/p2c/make.rs
+++ b/tower/src/balance/p2c/make.rs
@@ -42,7 +42,7 @@ pin_project! {
 
 impl<S, Req> MakeBalance<S, Req> {
     /// Build balancers using operating system entropy.
-    pub fn new(make_discover: S) -> Self {
+    pub const fn new(make_discover: S) -> Self {
         Self {
             inner: make_discover,
             _marker: PhantomData,

--- a/tower/src/buffer/layer.rs
+++ b/tower/src/buffer/layer.rs
@@ -33,7 +33,7 @@ impl<Request> BufferLayer<Request> {
     /// [`Poll::Ready`]: std::task::Poll::Ready
     /// [`call`]: crate::Service::call
     /// [`poll_ready`]: crate::Service::poll_ready
-    pub fn new(bound: usize) -> Self {
+    pub const fn new(bound: usize) -> Self {
         BufferLayer {
             bound,
             _p: PhantomData,

--- a/tower/src/builder/mod.rs
+++ b/tower/src/builder/mod.rs
@@ -115,7 +115,7 @@ impl Default for ServiceBuilder<Identity> {
 
 impl ServiceBuilder<Identity> {
     /// Create a new [`ServiceBuilder`].
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         ServiceBuilder {
             layer: Identity::new(),
         }

--- a/tower/src/filter/layer.rs
+++ b/tower/src/filter/layer.rs
@@ -35,7 +35,7 @@ impl<U> FilterLayer<U> {
     ///
     /// [`Predicate`]: crate::filter::Predicate
     /// [`Filter`]: crate::filter::Filter
-    pub fn new(predicate: U) -> Self {
+    pub const fn new(predicate: U) -> Self {
         Self { predicate }
     }
 }
@@ -57,7 +57,7 @@ impl<U> AsyncFilterLayer<U> {
     ///
     /// [`AsyncPredicate`]: crate::filter::AsyncPredicate
     /// [`Filter`]: crate::filter::Filter
-    pub fn new(predicate: U) -> Self {
+    pub const fn new(predicate: U) -> Self {
         Self { predicate }
     }
 }

--- a/tower/src/filter/mod.rs
+++ b/tower/src/filter/mod.rs
@@ -61,7 +61,7 @@ pub struct AsyncFilter<T, U> {
 
 impl<T, U> Filter<T, U> {
     /// Returns a new [`Filter`] service wrapping `inner`.
-    pub fn new(inner: T, predicate: U) -> Self {
+    pub const fn new(inner: T, predicate: U) -> Self {
         Self { inner, predicate }
     }
 
@@ -123,7 +123,7 @@ where
 
 impl<T, U> AsyncFilter<T, U> {
     /// Returns a new [`AsyncFilter`] service wrapping `inner`.
-    pub fn new(inner: T, predicate: U) -> Self {
+    pub const fn new(inner: T, predicate: U) -> Self {
         Self { inner, predicate }
     }
 

--- a/tower/src/hedge/delay.rs
+++ b/tower/src/hedge/delay.rs
@@ -62,7 +62,7 @@ impl<Request, F> State<Request, F> {
 }
 
 impl<P, S> Delay<P, S> {
-    pub fn new<Request>(policy: P, service: S) -> Self
+    pub const fn new<Request>(policy: P, service: S) -> Self
     where
         P: Policy<Request>,
         S: Service<Request> + Clone,

--- a/tower/src/hedge/latency.rs
+++ b/tower/src/hedge/latency.rs
@@ -38,7 +38,7 @@ impl<S, R> Latency<R, S>
 where
     R: Record + Clone,
 {
-    pub fn new<Request>(rec: R, service: S) -> Self
+    pub const fn new<Request>(rec: R, service: S) -> Self
     where
         S: Service<Request>,
         S::Error: Into<crate::BoxError>,

--- a/tower/src/hedge/select.rs
+++ b/tower/src/hedge/select.rs
@@ -34,7 +34,7 @@ pin_project! {
 }
 
 impl<P, A, B> Select<P, A, B> {
-    pub fn new<Request>(policy: P, a: A, b: B) -> Self
+    pub const fn new<Request>(policy: P, a: A, b: B) -> Self
     where
         P: Policy<Request>,
         A: Service<Request>,

--- a/tower/src/limit/concurrency/layer.rs
+++ b/tower/src/limit/concurrency/layer.rs
@@ -13,7 +13,7 @@ pub struct ConcurrencyLimitLayer {
 
 impl ConcurrencyLimitLayer {
     /// Create a new concurrency limit layer.
-    pub fn new(max: usize) -> Self {
+    pub const fn new(max: usize) -> Self {
         ConcurrencyLimitLayer { max }
     }
 }

--- a/tower/src/limit/rate/layer.rs
+++ b/tower/src/limit/rate/layer.rs
@@ -11,7 +11,7 @@ pub struct RateLimitLayer {
 
 impl RateLimitLayer {
     /// Create new rate limit layer.
-    pub fn new(num: u64, per: Duration) -> Self {
+    pub const fn new(num: u64, per: Duration) -> Self {
         let rate = Rate::new(num, per);
         RateLimitLayer { rate }
     }

--- a/tower/src/limit/rate/rate.rs
+++ b/tower/src/limit/rate/rate.rs
@@ -15,7 +15,7 @@ impl Rate {
     /// This function panics if `num` or `per` is 0.
     pub const fn new(num: u64, per: Duration) -> Self {
         assert!(num > 0);
-        assert!(!per.is_zero());
+        assert!(per.as_nanos() > 0);
 
         Rate { num, per }
     }

--- a/tower/src/limit/rate/rate.rs
+++ b/tower/src/limit/rate/rate.rs
@@ -13,9 +13,9 @@ impl Rate {
     /// # Panics
     ///
     /// This function panics if `num` or `per` is 0.
-    pub fn new(num: u64, per: Duration) -> Self {
+    pub const fn new(num: u64, per: Duration) -> Self {
         assert!(num > 0);
-        assert!(per > Duration::from_millis(0));
+        assert!(!per.is_zero());
 
         Rate { num, per }
     }

--- a/tower/src/load/completion.rs
+++ b/tower/src/load/completion.rs
@@ -59,7 +59,7 @@ pin_project! {
 
 impl<F, C, H> TrackCompletionFuture<F, C, H> {
     /// Wraps a future, propagating the tracker into its value if successful.
-    pub fn new(completion: C, handle: H, future: F) -> Self {
+    pub const fn new(completion: C, handle: H, future: F) -> Self {
         TrackCompletionFuture {
             future,
             completion,

--- a/tower/src/load/constant.rs
+++ b/tower/src/load/constant.rs
@@ -27,7 +27,7 @@ pin_project! {
 
 impl<T, M: Copy> Constant<T, M> {
     /// Wraps a `T`-typed service with a constant `M`-typed load metric.
-    pub fn new(inner: T, load: M) -> Self {
+    pub const fn new(inner: T, load: M) -> Self {
         Self { inner, load }
     }
 }

--- a/tower/src/load/pending_requests.rs
+++ b/tower/src/load/pending_requests.rs
@@ -100,7 +100,7 @@ where
 #[cfg(feature = "discover")]
 impl<D, C> PendingRequestsDiscover<D, C> {
     /// Wraps a [`Discover`], wrapping all of its services with [`PendingRequests`].
-    pub fn new<Request>(discover: D, completion: C) -> Self
+    pub const fn new<Request>(discover: D, completion: C) -> Self
     where
         D: Discover,
         D::Service: Service<Request>,

--- a/tower/src/load_shed/error.rs
+++ b/tower/src/load_shed/error.rs
@@ -14,7 +14,7 @@ pub struct Overloaded {
 
 impl Overloaded {
     /// Construct a new overloaded error
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Overloaded { _p: () }
     }
 }

--- a/tower/src/load_shed/layer.rs
+++ b/tower/src/load_shed/layer.rs
@@ -13,7 +13,7 @@ pub struct LoadShedLayer {
 
 impl LoadShedLayer {
     /// Creates a new layer.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         LoadShedLayer { _p: () }
     }
 }

--- a/tower/src/load_shed/mod.rs
+++ b/tower/src/load_shed/mod.rs
@@ -23,7 +23,7 @@ pub struct LoadShed<S> {
 
 impl<S> LoadShed<S> {
     /// Wraps a service in [`LoadShed`] middleware.
-    pub fn new(inner: S) -> Self {
+    pub const fn new(inner: S) -> Self {
         LoadShed {
             inner,
             is_ready: false,

--- a/tower/src/make/make_service/shared.rs
+++ b/tower/src/make/make_service/shared.rs
@@ -75,7 +75,7 @@ pub struct Shared<S> {
 
 impl<S> Shared<S> {
     /// Create a new [`Shared`] from a service.
-    pub fn new(service: S) -> Self {
+    pub const fn new(service: S) -> Self {
         Self { service }
     }
 }

--- a/tower/src/reconnect/mod.rs
+++ b/tower/src/reconnect/mod.rs
@@ -49,7 +49,7 @@ where
     M: Service<Target>,
 {
     /// Lazily connect and reconnect to a [`Service`].
-    pub fn new<S, Request>(mk_service: M, target: Target) -> Self {
+    pub const fn new<S, Request>(mk_service: M, target: Target) -> Self {
         Reconnect {
             mk_service,
             state: State::Idle,

--- a/tower/src/retry/layer.rs
+++ b/tower/src/retry/layer.rs
@@ -9,7 +9,7 @@ pub struct RetryLayer<P> {
 
 impl<P> RetryLayer<P> {
     /// Creates a new [`RetryLayer`] from a retry policy.
-    pub fn new(policy: P) -> Self {
+    pub const fn new(policy: P) -> Self {
         RetryLayer { policy }
     }
 }

--- a/tower/src/retry/mod.rs
+++ b/tower/src/retry/mod.rs
@@ -49,7 +49,7 @@ pin_project! {
 
 impl<P, S> Retry<P, S> {
     /// Retry the inner service depending on this [`Policy`].
-    pub fn new(policy: P, service: S) -> Self {
+    pub const fn new(policy: P, service: S) -> Self {
         Retry { policy, service }
     }
 

--- a/tower/src/spawn_ready/service.rs
+++ b/tower/src/spawn_ready/service.rs
@@ -26,7 +26,7 @@ enum Inner<S> {
 
 impl<S> SpawnReady<S> {
     /// Creates a new [`SpawnReady`] wrapping `service`.
-    pub fn new(service: S) -> Self {
+    pub const fn new(service: S) -> Self {
         Self {
             inner: Inner::Service(Some(service)),
         }

--- a/tower/src/timeout/error.rs
+++ b/tower/src/timeout/error.rs
@@ -8,7 +8,7 @@ pub struct Elapsed(pub(super) ());
 
 impl Elapsed {
     /// Construct a new elapsed error
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Elapsed(())
     }
 }

--- a/tower/src/timeout/layer.rs
+++ b/tower/src/timeout/layer.rs
@@ -10,7 +10,7 @@ pub struct TimeoutLayer {
 
 impl TimeoutLayer {
     /// Create a timeout from a duration
-    pub fn new(timeout: Duration) -> Self {
+    pub const fn new(timeout: Duration) -> Self {
         TimeoutLayer { timeout }
     }
 }

--- a/tower/src/timeout/mod.rs
+++ b/tower/src/timeout/mod.rs
@@ -25,7 +25,7 @@ pub struct Timeout<T> {
 
 impl<T> Timeout<T> {
     /// Creates a new [`Timeout`]
-    pub fn new(inner: T, timeout: Duration) -> Self {
+    pub const fn new(inner: T, timeout: Duration) -> Self {
         Timeout { inner, timeout }
     }
 

--- a/tower/src/util/and_then.rs
+++ b/tower/src/util/and_then.rs
@@ -74,7 +74,7 @@ pub struct AndThenLayer<F> {
 
 impl<S, F> AndThen<S, F> {
     /// Creates a new `AndThen` service.
-    pub fn new(inner: S, f: F) -> Self {
+    pub const fn new(inner: S, f: F) -> Self {
         AndThen { f, inner }
     }
 
@@ -110,7 +110,7 @@ where
 
 impl<F> AndThenLayer<F> {
     /// Creates a new [`AndThenLayer`] layer.
-    pub fn new(f: F) -> Self {
+    pub const fn new(f: F) -> Self {
         AndThenLayer { f }
     }
 }

--- a/tower/src/util/call_all/common.rs
+++ b/tower/src/util/call_all/common.rs
@@ -51,7 +51,7 @@ where
     S: Stream,
     Q: Drive<Svc::Future>,
 {
-    pub(crate) fn new(service: Svc, stream: S, queue: Q) -> CallAll<Svc, S, Q> {
+    pub(crate) const fn new(service: Svc, stream: S, queue: Q) -> CallAll<Svc, S, Q> {
         CallAll {
             service: Some(service),
             stream,

--- a/tower/src/util/future_service.rs
+++ b/tower/src/util/future_service.rs
@@ -101,7 +101,7 @@ impl<F, S> FutureService<F, S> {
     ///
     /// This will most likely come up if you're calling `future_service` with an async block. In that
     /// case you can use `Box::pin(async { ... })` as shown in the example.
-    pub fn new(future: F) -> Self {
+    pub const fn new(future: F) -> Self {
         Self {
             state: State::Future(future),
         }

--- a/tower/src/util/map_err.rs
+++ b/tower/src/util/map_err.rs
@@ -42,7 +42,7 @@ opaque_future! {
 
 impl<S, F> MapErr<S, F> {
     /// Creates a new [`MapErr`] service.
-    pub fn new(inner: S, f: F) -> Self {
+    pub const fn new(inner: S, f: F) -> Self {
         MapErr { f, inner }
     }
 
@@ -78,7 +78,7 @@ where
 
 impl<F> MapErrLayer<F> {
     /// Creates a new [`MapErrLayer`].
-    pub fn new(f: F) -> Self {
+    pub const fn new(f: F) -> Self {
         MapErrLayer { f }
     }
 }

--- a/tower/src/util/map_future.rs
+++ b/tower/src/util/map_future.rs
@@ -17,7 +17,7 @@ pub struct MapFuture<S, F> {
 
 impl<S, F> MapFuture<S, F> {
     /// Creates a new [`MapFuture`] service.
-    pub fn new(inner: S, f: F) -> Self {
+    pub const fn new(inner: S, f: F) -> Self {
         Self { inner, f }
     }
 
@@ -88,7 +88,7 @@ pub struct MapFutureLayer<F> {
 
 impl<F> MapFutureLayer<F> {
     /// Creates a new [`MapFutureLayer`] layer.
-    pub fn new(f: F) -> Self {
+    pub const fn new(f: F) -> Self {
         Self { f }
     }
 }

--- a/tower/src/util/map_request.rs
+++ b/tower/src/util/map_request.rs
@@ -26,7 +26,7 @@ where
 
 impl<S, F> MapRequest<S, F> {
     /// Creates a new [`MapRequest`] service.
-    pub fn new(inner: S, f: F) -> Self {
+    pub const fn new(inner: S, f: F) -> Self {
         MapRequest { inner, f }
     }
 
@@ -70,7 +70,7 @@ pub struct MapRequestLayer<F> {
 
 impl<F> MapRequestLayer<F> {
     /// Creates a new [`MapRequestLayer`].
-    pub fn new(f: F) -> Self {
+    pub const fn new(f: F) -> Self {
         MapRequestLayer { f }
     }
 }

--- a/tower/src/util/map_response.rs
+++ b/tower/src/util/map_response.rs
@@ -42,7 +42,7 @@ opaque_future! {
 
 impl<S, F> MapResponse<S, F> {
     /// Creates a new `MapResponse` service.
-    pub fn new(inner: S, f: F) -> Self {
+    pub const fn new(inner: S, f: F) -> Self {
         MapResponse { f, inner }
     }
 
@@ -78,7 +78,7 @@ where
 
 impl<F> MapResponseLayer<F> {
     /// Creates a new [`MapResponseLayer`] layer.
-    pub fn new(f: F) -> Self {
+    pub const fn new(f: F) -> Self {
         MapResponseLayer { f }
     }
 }

--- a/tower/src/util/map_result.rs
+++ b/tower/src/util/map_result.rs
@@ -42,7 +42,7 @@ opaque_future! {
 
 impl<S, F> MapResult<S, F> {
     /// Creates a new [`MapResult`] service.
-    pub fn new(inner: S, f: F) -> Self {
+    pub const fn new(inner: S, f: F) -> Self {
         MapResult { f, inner }
     }
 
@@ -79,7 +79,7 @@ where
 
 impl<F> MapResultLayer<F> {
     /// Creates a new [`MapResultLayer`] layer.
-    pub fn new(f: F) -> Self {
+    pub const fn new(f: F) -> Self {
         MapResultLayer { f }
     }
 }

--- a/tower/src/util/oneshot.rs
+++ b/tower/src/util/oneshot.rs
@@ -35,11 +35,11 @@ pin_project! {
 }
 
 impl<S: Service<Req>, Req> State<S, Req> {
-    fn not_ready(svc: S, req: Option<Req>) -> Self {
+    const fn not_ready(svc: S, req: Option<Req>) -> Self {
         Self::NotReady { svc, req }
     }
 
-    fn called(fut: S::Future) -> Self {
+    const fn called(fut: S::Future) -> Self {
         Self::Called { fut }
     }
 }
@@ -71,7 +71,7 @@ where
     S: Service<Req>,
 {
     #[allow(missing_docs)]
-    pub fn new(svc: S, req: Req) -> Self {
+    pub const fn new(svc: S, req: Req) -> Self {
         Oneshot {
             state: State::not_ready(svc, Some(req)),
         }

--- a/tower/src/util/optional/mod.rs
+++ b/tower/src/util/optional/mod.rs
@@ -23,7 +23,7 @@ pub struct Optional<T> {
 
 impl<T> Optional<T> {
     /// Create a new [`Optional`].
-    pub fn new<Request>(inner: Option<T>) -> Optional<T>
+    pub const fn new<Request>(inner: Option<T>) -> Optional<T>
     where
         T: Service<Request>,
         T::Error: Into<crate::BoxError>,

--- a/tower/src/util/ready.rs
+++ b/tower/src/util/ready.rs
@@ -26,7 +26,7 @@ where
     T: Service<Request>,
 {
     #[allow(missing_docs)]
-    pub fn new(service: T) -> Self {
+    pub const fn new(service: T) -> Self {
         Self {
             inner: Some(service),
             _p: PhantomData,

--- a/tower/src/util/then.rs
+++ b/tower/src/util/then.rs
@@ -38,7 +38,7 @@ pub struct ThenLayer<F> {
 
 impl<S, F> Then<S, F> {
     /// Creates a new `Then` service.
-    pub fn new(inner: S, f: F) -> Self {
+    pub const fn new(inner: S, f: F) -> Self {
         Then { f, inner }
     }
 
@@ -83,7 +83,7 @@ where
 
 impl<F> ThenLayer<F> {
     /// Creates a new [`ThenLayer`] layer.
-    pub fn new(f: F) -> Self {
+    pub const fn new(f: F) -> Self {
         ThenLayer { f }
     }
 }


### PR DESCRIPTION
The main reason was to allow to initialize the RateLimitLayer in a const context. So why not making ever new function const (wherever it's possible). :P