### PR TITLE
Upgrade indexmap to version 2.

### DIFF
--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -71,7 +71,7 @@ tower-service = { version = "0.3.1", path = "../tower-service" }
 futures-core = { version = "0.3", optional = true }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
 hdrhistogram = { version = "7.0", optional = true, default-features = false }
-indexmap = { version = "1.0.2", optional = true }
+indexmap = { version = "2.1.0", optional = true }
 slab = { version = "0.4", optional = true }
 tokio = { version = "1.6", optional = true, features = ["sync"] }
 tokio-stream = { version = "0.1.0", optional = true }

--- a/tower/src/ready_cache/cache.rs
+++ b/tower/src/ready_cache/cache.rs
@@ -4,7 +4,7 @@ use super::error;
 use futures_core::Stream;
 use futures_util::{stream::FuturesUnordered, task::AtomicWaker};
 pub use indexmap::Equivalent;
-use indexmap::IndexMap;
+use indexmap::{map::MutableKeys, IndexMap};
 use std::fmt;
 use std::future::Future;
 use std::hash::Hash;
@@ -194,7 +194,7 @@ where
 
     /// Obtains a mutable reference to a service in the ready set by index.
     pub fn get_ready_index_mut(&mut self, idx: usize) -> Option<(&mut K, &mut S)> {
-        self.ready.get_index_mut(idx).map(|(k, v)| (k, &mut v.0))
+        self.ready.get_index_mut2(idx).map(|(k, v)| (k, &mut v.0))
     }
 
     /// Returns an iterator over the ready keys and services.


### PR DESCRIPTION
This PR upgrades the dependency on the indexmap crate to version 2.0.

Checking the [release notes](https://github.com/bluss/indexmap/blob/master/RELEASES.md) I don't see any breaking changes that would affect this crate, but I'm still relatively new to Rust, so please don't take my word for it.