### PR TITLE
tower-layer: drop versions from dev dependencies

### DIFF
--- a/tower-layer/Cargo.toml
+++ b/tower-layer/Cargo.toml
@@ -22,5 +22,5 @@ edition = "2018"
 [dependencies]
 
 [dev-dependencies]
-tower-service = { version = "0.3.0", path = "../tower-service" }
-tower = { version = "0.5.0", path = "../tower" }
+tower-service = { path = "../tower-service" }
+tower = { path = "../tower" }


### PR DESCRIPTION
## Context

As stated in the PR title.

This should resolve some quirks around publishing when bumping versions of those crates: in this case, trying to publish `tower-layer` before publishing `tower`, such that `tower@0.5.0` doesn't yet exist at the time of trying to publish `tower-layer`.

There's no real reason to tie dev dependencies to a specific version, since we would expect dev dependencies to be used during local development, on a feature branch or `master`, or whatever, when package versions are potentially in flux.