### PR TITLE
Retry middleware improvements for non-cloneable requests

### DIFF
--- a/tower/src/retry/mod.rs
+++ b/tower/src/retry/mod.rs
@@ -7,6 +7,7 @@ mod layer;
 mod policy;
 
 pub use self::layer::RetryLayer;
+pub use self::policy::Outcome;
 pub use self::policy::Policy;
 
 use self::future::ResponseFuture;
@@ -86,9 +87,10 @@ where
     }
 
     fn call(&mut self, request: Request) -> Self::Future {
-        let cloned = self.policy.clone_request(&request);
-        let future = self.service.call(request);
+        let cloneable = self.policy.create_cloneable_request(request);
+        let req = self.policy.clone_request(&cloneable);
+        let future = self.service.call(req);
 
-        ResponseFuture::new(cloned, self.clone(), future)
+        ResponseFuture::new(cloneable, self.clone(), future)
     }
 }

--- a/tower/tests/util/call_all.rs
+++ b/tower/tests/util/call_all.rs
@@ -5,7 +5,6 @@ use futures_util::{
     pin_mut,
 };
 use std::fmt;
-use std::future::Future;
 use std::task::{Context, Poll};
 use std::{cell::Cell, rc::Rc};
 use tokio_test::{assert_pending, assert_ready, task};


### PR DESCRIPTION
Hello,

I wasn't sure how to contribute to this project, so I hope this is a right place to start discussing.

Basically this revision solves real problem that I had with [tonic](https://github.com/hyperium/tonic), using [retry](https://github.com/tower-rs/tower/tree/b2c48b46a3110af844b667ace7e14caae70a8a33/tower/src/retry) middleware.
The core of the problem is that [tonic](https://github.com/hyperium/tonic) (a library that implements gRPC) uses HTTP2, which is by design is streaming protocol. For this reason it is not possible to "clone" tonic request by having just a reference to it.
In order to make request clone-able we need to fully consume it, and then reconstruct original object from consumed bytes.

This revision does exactly that.
1. consumes original request and stores it's content into new user defined `CloneableRequest`.
2. later, it recreates back original request from the contents of `CloneableRequest`.

There's some more discussion related to this:
* https://github.com/hyperium/tonic/issues/733
* #682

I think that it doesn't make sense to solve this issue at [tonic](https://github.com/hyperium/tonic) side, because it's doesn't make sense for tonic to have cloneable request (image situation where client is streaming multi-gibabyte file,  how would you consume it? where would you store it? it's not responsibility of tonic).
On the other hand, if you want to have retry mechanism, you must be aware that a request will be copied in order to be able to retry it.

Any feedback is welcome :)