### PR TITLE
Prepare release of v0.5.1

### DIFF
--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 0.5.1
+
+- Fix minimum version of `tower-layer` dependency ([#787])
+
+[#787]: https://github.com/tower-rs/tower/pull/787
+
 # 0.5.0
 
 ### Fixed

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "tower"
 # When releasing to crates.io:
-# - Update doc url
-#   - Cargo.toml
-#   - README.md
+# - Update README.md
 # - Update CHANGELOG.md.
 # - Create "vX.X.X" git tag.
 version = "0.5.0"
@@ -12,7 +10,6 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tower-rs/tower"
 homepage = "https://github.com/tower-rs/tower"
-documentation = "https://docs.rs/tower/0.5.0"
 description = """
 Tower is a library of modular and reusable components for building robust
 clients and servers.

--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -4,7 +4,7 @@ name = "tower"
 # - Update README.md
 # - Update CHANGELOG.md.
 # - Create "vX.X.X" git tag.
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Tower Maintainers <team@tower-rs.com>"]
 license = "MIT"
 readme = "README.md"

--- a/tower/README.md
+++ b/tower/README.md
@@ -141,14 +141,14 @@ To get started using all of Tower's optional middleware, add this to your
 `Cargo.toml`:
 
 ```toml
-tower = { version = "0.5.0", features = ["full"] }
+tower = { version = "0.5.1", features = ["full"] }
 ```
 
 Alternatively, you can only enable some features. For example, to enable
 only the [`retry`] and [`timeout`][timeouts] middleware, write:
 
 ```toml
-tower = { version = "0.5.0", features = ["retry", "timeout"] }
+tower = { version = "0.5.1", features = ["retry", "timeout"] }
 ```
 
 See [here][all_layers] for a complete list of all middleware provided by


### PR DESCRIPTION
And simplify the release process a tiny little bit by getting rid of the `documentation` field in `Cargo.toml`.