### PR TITLE
fix trait bounds on make `AsService` & `IntoService`

### DIFF
--- a/tower/src/make/make_service.rs
+++ b/tower/src/make/make_service.rs
@@ -189,13 +189,12 @@ where
     }
 }
 
-impl<M, S, Target, Request> Service<Target> for IntoService<M, Request>
+impl<M, Target, Request> Service<Target> for IntoService<M, Request>
 where
-    M: Service<Target, Response = S>,
-    S: Service<Request>,
+    M: MakeService<Target, Request>,
 {
-    type Response = M::Response;
-    type Error = M::Error;
+    type Response = M::Service;
+    type Error = M::MakeError;
     type Future = M::Future;
 
     #[inline]
@@ -230,13 +229,12 @@ where
     }
 }
 
-impl<M, S, Target, Request> Service<Target> for AsService<'_, M, Request>
+impl<M, Target, Request> Service<Target> for AsService<'_, M, Request>
 where
-    M: Service<Target, Response = S>,
-    S: Service<Request>,
+    M: MakeService<Target, Request>,
 {
-    type Response = M::Response;
-    type Error = M::Error;
+    type Response = M::Service;
+    type Error = M::MakeError;
     type Future = M::Future;
 
     #[inline]


### PR DESCRIPTION
The trait bounds on `AsService` & `IntoService` both require that `M: Service`, however this defeats the purpose of the types as if we already require that `M: Service` then all the `ServiceExt` methods would already be reachable on `M`.

This PR changes the bounds to `M: MakeService`.