### PR TITLE
add ServiceBuilder::boxed_clone_sync helper

### DIFF
--- a/tower/src/builder/mod.rs
+++ b/tower/src/builder/mod.rs
@@ -789,6 +789,68 @@ impl<L> ServiceBuilder<L> {
     {
         self.layer(crate::util::BoxCloneService::layer())
     }
+
+    /// This wraps the inner service with the [`Layer`] returned by [`BoxCloneSyncServiceLayer`].
+    ///
+    /// This is similar to the [`boxed_clone`] method, but it requires that `Self` implement
+    /// [`Sync`], and the returned boxed service implements [`Sync`].
+    ///
+    /// See [`BoxCloneSyncService`] for more details.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use tower::{Service, ServiceBuilder, BoxError, util::BoxCloneSyncService};
+    /// use std::time::Duration;
+    /// #
+    /// # struct Request;
+    /// # struct Response;
+    /// # impl Response {
+    /// #     fn new() -> Self { Self }
+    /// # }
+    ///
+    /// let service: BoxCloneSyncService<Request, Response, BoxError> = ServiceBuilder::new()
+    ///     .load_shed()
+    ///     .concurrency_limit(64)
+    ///     .timeout(Duration::from_secs(10))
+    ///     .boxed_clone_sync()
+    ///     .service_fn(|req: Request| async {
+    ///         Ok::<_, BoxError>(Response::new())
+    ///     });
+    /// # let service = assert_service(service);
+    ///
+    /// // The boxed service can still be cloned.
+    /// service.clone();
+    /// # fn assert_service<S, R>(svc: S) -> S
+    /// # where S: Service<R> { svc }
+    /// ```
+    ///
+    /// [`BoxCloneSyncServiceLayer`]: crate::util::BoxCloneSyncServiceLayer
+    /// [`BoxCloneSyncService`]: crate::util::BoxCloneSyncService
+    /// [`boxed_clone`]: Self::boxed_clone
+    #[cfg(feature = "util")]
+    pub fn boxed_clone_sync<S, R>(
+        self,
+    ) -> ServiceBuilder<
+        Stack<
+            crate::util::BoxCloneSyncServiceLayer<
+                S,
+                R,
+                <L::Service as Service<R>>::Response,
+                <L::Service as Service<R>>::Error,
+            >,
+            Identity,
+        >,
+    >
+    where
+        L: Layer<S> + Send + Sync + 'static,
+        L::Service: Service<R> + Clone + Send + Sync + 'static,
+        <L::Service as Service<R>>::Future: Send + Sync + 'static,
+    {
+        let layer = self.into_inner();
+
+        ServiceBuilder::new().layer(crate::util::BoxCloneSyncServiceLayer::new(layer))
+    }
 }
 
 impl<L: fmt::Debug> fmt::Debug for ServiceBuilder<L> {


### PR DESCRIPTION
As requested in: https://github.com/tower-rs/tower/pull/777

Adding the `ServiceBuilder::boxed_clone_sync()` method to match `boxed_clone` and `boxed()`.

Note that in this case, I used the named, `BoxCloneSyncServiceLayer`, rather than the layer fn returned by `BoxedCloneSyncService::layer()`. I don't really see a good reason to prefer the latter. I think the reason that other helpers use that, is historical (named layer didn't exist yet).

Probably we should migrate everything over, but that seems likely to be a breaking change so I held off. Glad to cut an issue on that if you concur.

The only testing was via a doctest. This matches the other helper.