### PR TITLE
`no-std` compatiblity for underlying traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ released at least six months ago. The current MSRV is 1.64.0.
 
 ## `no_std`
 
-`tower` itself is _not_ `no_std` compatible, but `tower-layer` is.
+`tower` itself is _not_ `no_std` compatible, but `tower-layer` and `tower-service` are.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Tower will keep a rolling MSRV (minimum supported Rust version) policy of **at
 least** 6 months. When increasing the MSRV, the new Rust version must have been
 released at least six months ago. The current MSRV is 1.64.0.
 
+## `no_std`
+
+`tower` itself is _not_ `no_std` compatible, but `tower-layer` is.
+
 ## Getting Started
 
 If you're brand new to Tower and want to start with the basics we recommend you

--- a/tower-layer/README.md
+++ b/tower-layer/README.md
@@ -30,6 +30,8 @@ reusable components that can be applied to very different kinds of services;
 for example, it can be applied to services operating on different protocols,
 and to both the client and server side of a network transaction.
 
+`tower-layer` is `no_std` compatible.
+
 ## License
 
 This project is licensed under the [MIT license](LICENSE).

--- a/tower-layer/src/identity.rs
+++ b/tower-layer/src/identity.rs
@@ -1,5 +1,5 @@
 use super::Layer;
-use std::fmt;
+use core::fmt;
 
 /// A no-op middleware.
 ///

--- a/tower-layer/src/layer_fn.rs
+++ b/tower-layer/src/layer_fn.rs
@@ -1,5 +1,5 @@
 use super::Layer;
-use std::fmt;
+use core::fmt;
 
 /// Returns a new [`LayerFn`] that implements [`Layer`] by calling the
 /// given function.
@@ -13,10 +13,10 @@ use std::fmt;
 /// # Example
 /// ```rust
 /// # use tower::Service;
-/// # use std::task::{Poll, Context};
+/// # use core::task::{Poll, Context};
 /// # use tower_layer::{Layer, layer_fn};
-/// # use std::fmt;
-/// # use std::convert::Infallible;
+/// # use core::fmt;
+/// # use core::convert::Infallible;
 /// #
 /// // A middleware that logs requests before forwarding them to another service
 /// pub struct LogService<S> {
@@ -88,7 +88,7 @@ where
 impl<F> fmt::Debug for LayerFn<F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("LayerFn")
-            .field("f", &format_args!("{}", std::any::type_name::<F>()))
+            .field("f", &format_args!("{}", core::any::type_name::<F>()))
             .finish()
     }
 }
@@ -96,6 +96,7 @@ impl<F> fmt::Debug for LayerFn<F> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::{format, string::ToString};
 
     #[allow(dead_code)]
     #[test]

--- a/tower-layer/src/lib.rs
+++ b/tower-layer/src/lib.rs
@@ -16,6 +16,11 @@
 //!
 //! [`Service`]: https://docs.rs/tower/*/tower/trait.Service.html
 
+#![no_std]
+
+#[cfg(test)]
+extern crate alloc;
+
 mod identity;
 mod layer_fn;
 mod stack;
@@ -41,9 +46,9 @@ pub use self::{
 ///
 /// ```rust
 /// # use tower_service::Service;
-/// # use std::task::{Poll, Context};
+/// # use core::task::{Poll, Context};
 /// # use tower_layer::Layer;
-/// # use std::fmt;
+/// # use core::fmt;
 ///
 /// pub struct LogLayer {
 ///     target: &'static str,

--- a/tower-layer/src/stack.rs
+++ b/tower-layer/src/stack.rs
@@ -1,5 +1,5 @@
 use super::Layer;
-use std::fmt;
+use core::fmt;
 
 /// Two middlewares chained together.
 #[derive(Clone)]

--- a/tower-service/README.md
+++ b/tower-service/README.md
@@ -45,6 +45,11 @@ middleware may take actions such as modify the request.
 
 [`Service`]: https://docs.rs/tower-service/latest/tower_service/trait.Service.html
 [Tower]: https://crates.io/crates/tower
+
+## `no_std`
+
+`tower-service` is `no_std` compatible.
+
 ## License
 
 This project is licensed under the [MIT license](LICENSE).

--- a/tower-service/README.md
+++ b/tower-service/README.md
@@ -48,7 +48,7 @@ middleware may take actions such as modify the request.
 
 ## `no_std`
 
-`tower-service` is `no_std` compatible.
+`tower-service` is `no_std` compatible, but it (currently) requires the `alloc` crate.
 
 ## License
 

--- a/tower-service/src/lib.rs
+++ b/tower-service/src/lib.rs
@@ -13,8 +13,16 @@
 //! request / response clients and servers. It is simple but powerful and is
 //! used as the foundation for the rest of Tower.
 
-use std::future::Future;
-use std::task::{Context, Poll};
+#![no_std]
+
+extern crate alloc;
+
+use alloc::boxed::Box;
+
+use core::future::Future;
+use core::marker::Sized;
+use core::result::Result;
+use core::task::{Context, Poll};
 
 /// An asynchronous function from a `Request` to a `Response`.
 ///
@@ -273,7 +281,7 @@ use std::task::{Context, Poll};
 /// }
 /// ```
 ///
-/// You should instead use [`std::mem::replace`] to take the service that was ready:
+/// You should instead use [`core::mem::replace`] to take the service that was ready:
 ///
 /// ```rust
 /// # use std::pin::Pin;


### PR DESCRIPTION
Hi there,

First of all, thank you for Tower. So many cool projects have come from it!

To be clear: this PR *does not* make the main `tower` crate, nor its Filter, Make, Steer, etc. `no_std` compatible. This is not the goal, nor do I expect this from the `tower` team.

I'd like to be able to use the base `tower-service` and `tower-layer` crates in an embedded context—in this case, one which does not have a standard library. While the code in `tower-layer` and `tower-service` are simple (and permissively licensed enough) to just copy over, it'd be nice to share in the ecosystem, and occasionally publish reusable `no_std` compatible services when I can.

This PR:

- makes `tower-service` and `tower-layer` `no_std` compatible,
- adds a active-by-default `std` feature to `tower-service` in order to optionally link the external `alloc` crate for the `Box` implementation, and
- makes `tower-layer` `no_std` compatible unconditionally, as it does not depend on any `alloc` features.

Please let me know if this is something you'd consider.