### PR TITLE
chore: add `Buffer` breaking change to changelog

### DIFF
--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **util**: **Breaking Change** `Either` now requires its two services to have the same error type. ([#637])
 - **util**: **Breaking Change** `Either` no longer implemenmts `Future`. ([#637])
 - **buffer**: **Breaking Change** `Buffer<S, Request>` is now generic over `Buffer<Request, S::Future>.` ([#654])
+- **buffer**: **Breaking Change** `Buffer`'s capacity now correctly matches the specified size. Previously, the
+  capacity was subtly off-by-one, because a slot was held even while the worker task was processing a message. ([#635])
 
 [#702]: https://github.com/tower-rs/tower/pull/702
 [#652]: https://github.com/tower-rs/tower/pull/652
@@ -66,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#741]: https://github.com/tower-rs/tower/pull/741
 [#637]: https://github.com/tower-rs/tower/pull/637
 [#654]: https://github.com/tower-rs/tower/pull/654
+[#635]: https://github.com/tower-rs/tower/pull/635
 
 # 0.4.12 (February 16, 2022)
 


### PR DESCRIPTION
in #635, some subtle breaking changes were made to how `Buffer` works.

this is documented in the description of that PR, here:

> I had to change some of the integration tests slightly as part of this
> change. This is because the buffer implementation using semaphore
> permits is _very subtly_ different from one using a bounded channel. In
> the `Semaphore`-based implementation, a semaphore permit is stored in
> the `Message` struct sent over the channel. This is so that the capacity
> is used as long as the message is in flight. However, when the worker
> task is processing a message that's been recieved from the channel,
> the permit is still not dropped. Essentially, the one message actively
> held by the worker task _also_ occupies one "slot" of capacity, so the
> actual channel capacity is one less than the value passed to the
> constructor, _once the first request has been sent to the worker_. The
> bounded MPSC changed this behavior so that capacity is only occupied
> while a request is actually in the channel, which broke some tests
> that relied on the old (and technically wrong) behavior.

bear particular attention to this:

> The bounded MPSC changed this behavior so that capacity is only
> occupied while a request is actually in the channel, which broke some
> tests that relied on the old (and technically wrong) behavior.

this is a change in behavior that might affect downstream callers.

this commit adds mention of these changes to the changelog, to help consumers navigate the upgrade from tower 0.4 to 0.5.