### PR TITLE
chore: update dead link in  `util/rng.rs`

### DIFF
--- a/tower/src/util/rng.rs
+++ b/tower/src/util/rng.rs
@@ -25,7 +25,7 @@ pub trait Rng {
     /// Generate a random [`f64`] between `[0, 1)`.
     fn next_f64(&mut self) -> f64 {
         // Borrowed from:
-        // https://github.com/rust-random/rand/blob/master/src/distributions/float.rs#L106
+        // https://github.com/rust-random/rand/blob/master/src/distr/float.rs#L108
         let float_size = std::mem::size_of::<f64>() as u32 * 8;
         let precision = 52 + 1;
         let scale = 1.0 / ((1u64 << precision) as f64);


### PR DESCRIPTION
HI! I fixed a broken link to the Rust rand crate's float implementation in `tower/src/util/rng.rs`. The file path changed in newer versions of the rand crate.