### PR TITLE
docs: Remove doc_auto_cfg config

### DIFF
--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -7,7 +7,7 @@
 #![forbid(unsafe_code)]
 #![allow(elided_lifetimes_in_paths, clippy::type_complexity)]
 #![cfg_attr(test, allow(clippy::float_cmp))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 // `rustdoc::broken_intra_doc_links` is checked on CI
 
 //! `async fn(Request) -> Result<Response, Error>`


### PR DESCRIPTION
`doc_auto_cfg` was merged into `doc_cfg` in https://github.com/rust-lang/rust/pull/138907.