### PR TITLE
chore: remove redundant ready! wrapping in poll implementations

### DIFF
--- a/tower/src/limit/concurrency/future.rs
+++ b/tower/src/limit/concurrency/future.rs
@@ -5,7 +5,7 @@ use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
-    task::{ready, Context, Poll},
+    task::{Context, Poll},
 };
 use tokio::sync::OwnedSemaphorePermit;
 
@@ -35,6 +35,6 @@ where
     type Output = Result<T, E>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        Poll::Ready(ready!(self.project().inner.poll(cx)))
+        self.project().inner.poll(cx)
     }
 }

--- a/tower/src/load_shed/future.rs
+++ b/tower/src/load_shed/future.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{ready, Context, Poll};
+use std::task::{Context, Poll};
 
 use pin_project_lite::pin_project;
 
@@ -53,9 +53,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.project().state.project() {
-            ResponseStateProj::Called { fut } => {
-                Poll::Ready(ready!(fut.poll(cx)).map_err(Into::into))
-            }
+            ResponseStateProj::Called { fut } => fut.poll(cx).map_err(Into::into),
             ResponseStateProj::Overloaded => Poll::Ready(Err(Overloaded::new().into())),
         }
     }

--- a/tower/src/util/optional/future.rs
+++ b/tower/src/util/optional/future.rs
@@ -3,7 +3,7 @@ use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
-    task::{ready, Context, Poll},
+    task::{Context, Poll},
 };
 
 pin_project! {
@@ -32,7 +32,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.project().inner.as_pin_mut() {
-            Some(inner) => Poll::Ready(Ok(ready!(inner.poll(cx)).map_err(Into::into)?)),
+            Some(inner) => inner.poll(cx).map_err(Into::into),
             None => Poll::Ready(Err(error::None::new().into())),
         }
     }


### PR DESCRIPTION
Remove unnecessary `Poll::Ready(ready!(...))` wrappers in poll methods for **better readability**. Behavior is unchanged.