### PR TITLE
feat(circuit-breaker): add CircuitBreaker Tower middleware

### DIFF
--- a/tower/Cargo.toml
+++ b/tower/Cargo.toml
@@ -29,6 +29,7 @@ full = [
   "limit",
   "load",
   "load-shed",
+  "circuit-breaker",
   "make",
   "ready-cache",
   "reconnect",
@@ -48,6 +49,7 @@ hedge = ["util", "filter", "futures-util", "hdrhistogram", "tokio/time", "tracin
 limit = ["tokio/time", "tokio/sync", "tokio-util", "tracing", "pin-project-lite"]
 load = ["tokio/time", "tracing", "pin-project-lite"]
 load-shed = ["pin-project-lite"]
+circuit-breaker = ["tokio/sync", "tokio/time", "pin-project-lite"]
 make = ["pin-project-lite", "tokio"]
 ready-cache = ["futures-core", "futures-util", "indexmap", "tokio/sync", "tracing", "pin-project-lite"]
 reconnect = ["make", "tracing"]

--- a/tower/src/circuit_breaker/future.rs
+++ b/tower/src/circuit_breaker/future.rs
@@ -3,86 +3,68 @@ use std::{
     pin::Pin,
     sync::{Arc, Mutex},
     task::{Context, Poll},
-    time::Instant,
 };
 
 use pin_project_lite::pin_project;
 
-use super::service::{CircuitError, CircuitStatus, State};
+use super::{
+    policy::CircuitPolicy,
+    service::{CircuitError, CircuitStatus, SharedState},
+};
 
 pin_project! {
     /// Response future for [`CircuitBreaker`].
     ///
     /// [`CircuitBreaker`]: super::service::CircuitBreaker
-    pub struct ResponseFuture<F, T, E> {
+    pub struct ResponseFuture<F, T, E, P> {
         #[pin]
         inner: F,
-        state: Arc<Mutex<State>>,
-        failure_threshold: usize,
-        success_threshold: f64,
+        shared: Arc<Mutex<SharedState<P>>>,
         _marker: std::marker::PhantomData<fn() -> (T, E)>,
     }
 }
 
-impl<F, T, E> ResponseFuture<F, T, E> {
-    pub(crate) fn new(
-        state: Arc<Mutex<State>>,
-        inner: F,
-        failure_threshold: usize,
-        success_threshold: f64,
-    ) -> Self {
+impl<F, T, E, P> ResponseFuture<F, T, E, P> {
+    pub(crate) fn new(shared: Arc<Mutex<SharedState<P>>>, inner: F) -> Self {
         Self {
             inner,
-            state,
-            failure_threshold,
-            success_threshold,
+            shared,
             _marker: std::marker::PhantomData,
         }
     }
 }
 
-impl<F, T, E> Future for ResponseFuture<F, T, E>
+impl<F, T, E, P> Future for ResponseFuture<F, T, E, P>
 where
     F: Future<Output = Result<T, E>>,
+    P: CircuitPolicy,
 {
     type Output = Result<T, CircuitError<E>>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
-        let failure_threshold = *this.failure_threshold;
-        let success_threshold = *this.success_threshold;
 
         match this.inner.poll(cx) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(Ok(resp)) => {
-                let mut s = this.state.lock().expect("circuit breaker state poisoned");
-                s.push_result(true);
-                match s.status {
-                    CircuitStatus::HalfOpen if s.success_rate() >= success_threshold => {
-                        s.status = CircuitStatus::Closed;
-                        s.consecutive_failures = 0;
-                        s.last_transition = Instant::now();
-                    }
-                    CircuitStatus::Closed => {
-                        s.consecutive_failures = 0;
-                    }
-                    _ => {}
+                let mut s = this.shared.lock().expect("circuit breaker state poisoned");
+                let should_close = s.policy.on_success();
+                if should_close && s.status == CircuitStatus::HalfOpen {
+                    s.status = CircuitStatus::Closed;
                 }
                 Poll::Ready(Ok(resp))
             }
             Poll::Ready(Err(e)) => {
-                let mut s = this.state.lock().expect("circuit breaker state poisoned");
-                s.push_result(false);
-                s.consecutive_failures += 1;
-                s.last_failure = Some(Instant::now());
+                let mut s = this.shared.lock().expect("circuit breaker state poisoned");
+                let should_open = s.policy.on_failure();
                 match s.status {
-                    CircuitStatus::Closed if s.consecutive_failures >= failure_threshold => {
-                        s.status = CircuitStatus::Open;
-                        s.last_transition = Instant::now();
-                    }
+                    // Any failure during a probe reopens immediately —
+                    // the backend is not yet ready regardless of threshold.
                     CircuitStatus::HalfOpen => {
                         s.status = CircuitStatus::Open;
-                        s.last_transition = Instant::now();
+                    }
+                    CircuitStatus::Closed if should_open => {
+                        s.status = CircuitStatus::Open;
                     }
                     _ => {}
                 }

--- a/tower/src/circuit_breaker/future.rs
+++ b/tower/src/circuit_breaker/future.rs
@@ -1,13 +1,12 @@
 use std::{
     future::Future,
     pin::Pin,
-    sync::Arc,
+    sync::{Arc, Mutex},
     task::{Context, Poll},
-    time::{Duration, Instant},
+    time::Instant,
 };
 
 use pin_project_lite::pin_project;
-use tokio::sync::RwLock;
 
 use super::service::{CircuitError, CircuitStatus, State};
 
@@ -18,31 +17,25 @@ pin_project! {
     pub struct ResponseFuture<F, T, E> {
         #[pin]
         inner: F,
-        state: Arc<RwLock<State>>,
+        state: Arc<Mutex<State>>,
         failure_threshold: usize,
         success_threshold: f64,
-        timeout: Duration,
-        /// Set to true once we've checked the circuit state and decided to proceed.
-        gate_checked: bool,
         _marker: std::marker::PhantomData<fn() -> (T, E)>,
     }
 }
 
 impl<F, T, E> ResponseFuture<F, T, E> {
     pub(crate) fn new(
-        state: Arc<RwLock<State>>,
+        state: Arc<Mutex<State>>,
         inner: F,
         failure_threshold: usize,
         success_threshold: f64,
-        timeout: Duration,
     ) -> Self {
         Self {
             inner,
             state,
             failure_threshold,
             success_threshold,
-            timeout,
-            gate_checked: false,
             _marker: std::marker::PhantomData,
         }
     }
@@ -56,91 +49,43 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
-
-        if !*this.gate_checked {
-            // Non-blocking read-lock check.
-            match this.state.try_read() {
-                Err(_) => {
-                    cx.waker().wake_by_ref();
-                    return Poll::Pending;
-                }
-                Ok(guard) => {
-                    match guard.status {
-                        CircuitStatus::Open => {
-                            let elapsed = guard
-                                .last_failure
-                                .map(|t| t.elapsed())
-                                .unwrap_or(Duration::ZERO);
-
-                            if elapsed < *this.timeout {
-                                return Poll::Ready(Err(CircuitError::Open));
-                            }
-
-                            // Timeout elapsed — transition to HalfOpen asynchronously.
-                            drop(guard);
-                            let arc = this.state.clone();
-                            tokio::spawn(async move {
-                                let mut s = arc.write().await;
-                                if s.status == CircuitStatus::Open {
-                                    s.status = CircuitStatus::HalfOpen;
-                                    s.window.clear();
-                                    s.consecutive_failures = 0;
-                                    s.last_transition = Instant::now();
-                                }
-                            });
-                        }
-                        CircuitStatus::Closed | CircuitStatus::HalfOpen => {
-                            drop(guard);
-                        }
-                    }
-                    *this.gate_checked = true;
-                }
-            }
-        }
-
         let failure_threshold = *this.failure_threshold;
         let success_threshold = *this.success_threshold;
 
         match this.inner.poll(cx) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(Ok(resp)) => {
-                let arc = this.state.clone();
-                tokio::spawn(async move {
-                    let mut s = arc.write().await;
-                    s.push_result(true);
-                    match s.status {
-                        CircuitStatus::HalfOpen if s.success_rate() >= success_threshold => {
-                            s.status = CircuitStatus::Closed;
-                            s.consecutive_failures = 0;
-                            s.last_transition = Instant::now();
-                        }
-                        CircuitStatus::Closed => {
-                            s.consecutive_failures = 0;
-                        }
-                        _ => {}
+                let mut s = this.state.lock().expect("circuit breaker state poisoned");
+                s.push_result(true);
+                match s.status {
+                    CircuitStatus::HalfOpen if s.success_rate() >= success_threshold => {
+                        s.status = CircuitStatus::Closed;
+                        s.consecutive_failures = 0;
+                        s.last_transition = Instant::now();
                     }
-                });
+                    CircuitStatus::Closed => {
+                        s.consecutive_failures = 0;
+                    }
+                    _ => {}
+                }
                 Poll::Ready(Ok(resp))
             }
             Poll::Ready(Err(e)) => {
-                let arc = this.state.clone();
-                tokio::spawn(async move {
-                    let mut s = arc.write().await;
-                    s.push_result(false);
-                    s.consecutive_failures += 1;
-                    s.last_failure = Some(Instant::now());
-                    match s.status {
-                        CircuitStatus::Closed if s.consecutive_failures >= failure_threshold => {
-                            s.status = CircuitStatus::Open;
-                            s.last_transition = Instant::now();
-                        }
-                        CircuitStatus::HalfOpen => {
-                            s.status = CircuitStatus::Open;
-                            s.last_transition = Instant::now();
-                        }
-                        _ => {}
+                let mut s = this.state.lock().expect("circuit breaker state poisoned");
+                s.push_result(false);
+                s.consecutive_failures += 1;
+                s.last_failure = Some(Instant::now());
+                match s.status {
+                    CircuitStatus::Closed if s.consecutive_failures >= failure_threshold => {
+                        s.status = CircuitStatus::Open;
+                        s.last_transition = Instant::now();
                     }
-                });
+                    CircuitStatus::HalfOpen => {
+                        s.status = CircuitStatus::Open;
+                        s.last_transition = Instant::now();
+                    }
+                    _ => {}
+                }
                 Poll::Ready(Err(CircuitError::Inner(e)))
             }
         }

--- a/tower/src/circuit_breaker/future.rs
+++ b/tower/src/circuit_breaker/future.rs
@@ -1,0 +1,148 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::{Duration, Instant},
+};
+
+use pin_project_lite::pin_project;
+use tokio::sync::RwLock;
+
+use super::service::{CircuitError, CircuitStatus, State};
+
+pin_project! {
+    /// Response future for [`CircuitBreaker`].
+    ///
+    /// [`CircuitBreaker`]: super::service::CircuitBreaker
+    pub struct ResponseFuture<F, T, E> {
+        #[pin]
+        inner: F,
+        state: Arc<RwLock<State>>,
+        failure_threshold: usize,
+        success_threshold: f64,
+        timeout: Duration,
+        /// Set to true once we've checked the circuit state and decided to proceed.
+        gate_checked: bool,
+        _marker: std::marker::PhantomData<fn() -> (T, E)>,
+    }
+}
+
+impl<F, T, E> ResponseFuture<F, T, E> {
+    pub(crate) fn new(
+        state: Arc<RwLock<State>>,
+        inner: F,
+        failure_threshold: usize,
+        success_threshold: f64,
+        timeout: Duration,
+    ) -> Self {
+        Self {
+            inner,
+            state,
+            failure_threshold,
+            success_threshold,
+            timeout,
+            gate_checked: false,
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<F, T, E> Future for ResponseFuture<F, T, E>
+where
+    F: Future<Output = Result<T, E>>,
+{
+    type Output = Result<T, CircuitError<E>>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        if !*this.gate_checked {
+            // Non-blocking read-lock check.
+            match this.state.try_read() {
+                Err(_) => {
+                    cx.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
+                Ok(guard) => {
+                    match guard.status {
+                        CircuitStatus::Open => {
+                            let elapsed = guard
+                                .last_failure
+                                .map(|t| t.elapsed())
+                                .unwrap_or(Duration::ZERO);
+
+                            if elapsed < *this.timeout {
+                                return Poll::Ready(Err(CircuitError::Open));
+                            }
+
+                            // Timeout elapsed — transition to HalfOpen asynchronously.
+                            drop(guard);
+                            let arc = this.state.clone();
+                            tokio::spawn(async move {
+                                let mut s = arc.write().await;
+                                if s.status == CircuitStatus::Open {
+                                    s.status = CircuitStatus::HalfOpen;
+                                    s.window.clear();
+                                    s.consecutive_failures = 0;
+                                    s.last_transition = Instant::now();
+                                }
+                            });
+                        }
+                        CircuitStatus::Closed | CircuitStatus::HalfOpen => {
+                            drop(guard);
+                        }
+                    }
+                    *this.gate_checked = true;
+                }
+            }
+        }
+
+        let failure_threshold = *this.failure_threshold;
+        let success_threshold = *this.success_threshold;
+
+        match this.inner.poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(resp)) => {
+                let arc = this.state.clone();
+                tokio::spawn(async move {
+                    let mut s = arc.write().await;
+                    s.push_result(true);
+                    match s.status {
+                        CircuitStatus::HalfOpen if s.success_rate() >= success_threshold => {
+                            s.status = CircuitStatus::Closed;
+                            s.consecutive_failures = 0;
+                            s.last_transition = Instant::now();
+                        }
+                        CircuitStatus::Closed => {
+                            s.consecutive_failures = 0;
+                        }
+                        _ => {}
+                    }
+                });
+                Poll::Ready(Ok(resp))
+            }
+            Poll::Ready(Err(e)) => {
+                let arc = this.state.clone();
+                tokio::spawn(async move {
+                    let mut s = arc.write().await;
+                    s.push_result(false);
+                    s.consecutive_failures += 1;
+                    s.last_failure = Some(Instant::now());
+                    match s.status {
+                        CircuitStatus::Closed if s.consecutive_failures >= failure_threshold => {
+                            s.status = CircuitStatus::Open;
+                            s.last_transition = Instant::now();
+                        }
+                        CircuitStatus::HalfOpen => {
+                            s.status = CircuitStatus::Open;
+                            s.last_transition = Instant::now();
+                        }
+                        _ => {}
+                    }
+                });
+                Poll::Ready(Err(CircuitError::Inner(e)))
+            }
+        }
+    }
+}

--- a/tower/src/circuit_breaker/layer.rs
+++ b/tower/src/circuit_breaker/layer.rs
@@ -1,0 +1,32 @@
+use std::time::Duration;
+use super::service::CircuitBreaker;
+
+/// [`Layer`] that wraps services in a [`CircuitBreaker`].
+///
+/// [`Layer`]: tower_layer::Layer
+#[derive(Clone, Debug)]
+pub struct CircuitBreakerLayer {
+    failure_threshold: usize,
+    success_threshold: f64,
+    timeout: Duration,
+}
+
+impl CircuitBreakerLayer {
+    /// Create a new [`CircuitBreakerLayer`].
+    ///
+    /// - `failure_threshold`: consecutive failures before the circuit opens.
+    /// - `success_threshold`: fraction of probes that must succeed (0.0–1.0)
+    ///   before the circuit closes again.
+    /// - `timeout`: how long to stay open before sending a probe.
+    pub fn new(failure_threshold: usize, success_threshold: f64, timeout: Duration) -> Self {
+        Self { failure_threshold, success_threshold, timeout }
+    }
+}
+
+impl<S> tower_layer::Layer<S> for CircuitBreakerLayer {
+    type Service = CircuitBreaker<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        CircuitBreaker::new(inner, self.failure_threshold, self.success_threshold, self.timeout)
+    }
+}

--- a/tower/src/circuit_breaker/layer.rs
+++ b/tower/src/circuit_breaker/layer.rs
@@ -1,4 +1,5 @@
 use std::time::Duration;
+
 use super::service::CircuitBreaker;
 
 /// [`Layer`] that wraps services in a [`CircuitBreaker`].
@@ -17,9 +18,13 @@ impl CircuitBreakerLayer {
     /// - `failure_threshold`: consecutive failures before the circuit opens.
     /// - `success_threshold`: fraction of probes that must succeed (0.0–1.0)
     ///   before the circuit closes again.
-    /// - `timeout`: how long to stay open before sending a probe.
+    /// - `timeout`: how long to stay open before attempting recovery.
     pub fn new(failure_threshold: usize, success_threshold: f64, timeout: Duration) -> Self {
-        Self { failure_threshold, success_threshold, timeout }
+        Self {
+            failure_threshold,
+            success_threshold,
+            timeout,
+        }
     }
 }
 
@@ -27,6 +32,11 @@ impl<S> tower_layer::Layer<S> for CircuitBreakerLayer {
     type Service = CircuitBreaker<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        CircuitBreaker::new(inner, self.failure_threshold, self.success_threshold, self.timeout)
+        CircuitBreaker::new(
+            inner,
+            self.failure_threshold,
+            self.success_threshold,
+            self.timeout,
+        )
     }
 }

--- a/tower/src/circuit_breaker/layer.rs
+++ b/tower/src/circuit_breaker/layer.rs
@@ -1,42 +1,62 @@
 use std::time::Duration;
 
-use super::service::CircuitBreaker;
+use super::{
+    policy::{CircuitPolicy, ConsecutiveFailures},
+    service::CircuitBreaker,
+};
 
 /// [`Layer`] that wraps services in a [`CircuitBreaker`].
 ///
+/// Construct with [`CircuitBreakerLayer::new`] for the standard
+/// [`ConsecutiveFailures`] policy, or with [`CircuitBreakerLayer::with_policy`]
+/// to supply any custom [`CircuitPolicy`].
+///
 /// [`Layer`]: tower_layer::Layer
 #[derive(Clone, Debug)]
-pub struct CircuitBreakerLayer {
-    failure_threshold: usize,
-    success_threshold: f64,
-    timeout: Duration,
+pub struct CircuitBreakerLayer<P> {
+    policy: P,
 }
 
-impl CircuitBreakerLayer {
-    /// Create a new [`CircuitBreakerLayer`].
+impl CircuitBreakerLayer<ConsecutiveFailures> {
+    /// Create a layer using the built-in [`ConsecutiveFailures`] policy.
     ///
     /// - `failure_threshold`: consecutive failures before the circuit opens.
-    /// - `success_threshold`: fraction of probes that must succeed (0.0–1.0)
+    /// - `success_threshold`: fraction of probes (0.0–1.0) that must succeed
+    ///   during [`HalfOpen`][crate::circuit_breaker::CircuitStatus::HalfOpen]
     ///   before the circuit closes again.
-    /// - `timeout`: how long to stay open before attempting recovery.
+    /// - `timeout`: how long to stay open before sending the first probe.
     pub fn new(failure_threshold: usize, success_threshold: f64, timeout: Duration) -> Self {
         Self {
-            failure_threshold,
-            success_threshold,
-            timeout,
+            policy: ConsecutiveFailures::new(failure_threshold, success_threshold, timeout),
         }
     }
 }
 
-impl<S> tower_layer::Layer<S> for CircuitBreakerLayer {
-    type Service = CircuitBreaker<S>;
+impl<P: CircuitPolicy + Clone> CircuitBreakerLayer<P> {
+    /// Create a layer using a custom [`CircuitPolicy`].
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use tower::circuit_breaker::{CircuitBreakerLayer, ConsecutiveFailures};
+    /// use std::time::Duration;
+    ///
+    /// // Using the built-in policy explicitly:
+    /// let policy = ConsecutiveFailures::new(5, 0.8, Duration::from_secs(30));
+    /// let layer  = CircuitBreakerLayer::with_policy(policy);
+    ///
+    /// // Or bring your own:
+    /// let layer = CircuitBreakerLayer::with_policy(MyLatencyPolicy::new());
+    /// ```
+    pub fn with_policy(policy: P) -> Self {
+        Self { policy }
+    }
+}
+
+impl<S, P: CircuitPolicy + Clone> tower_layer::Layer<S> for CircuitBreakerLayer<P> {
+    type Service = CircuitBreaker<S, P>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        CircuitBreaker::new(
-            inner,
-            self.failure_threshold,
-            self.success_threshold,
-            self.timeout,
-        )
+        CircuitBreaker::new(inner, self.policy.clone())
     }
 }

--- a/tower/src/circuit_breaker/mod.rs
+++ b/tower/src/circuit_breaker/mod.rs
@@ -1,0 +1,44 @@
+//! Circuit breaker middleware for Tower services.
+//!
+//! Prevents cascading failures by tracking service health and short-circuiting
+//! requests to a failing backend before they hit the network.
+//!
+//! # States
+//!
+//! - **Closed** — normal operation; all requests pass through.
+//! - **Open** — service is unhealthy; requests are rejected immediately with
+//!   [`CircuitError::Open`], avoiding latency pile-up.
+//! - **Half-Open** — after the recovery timeout elapses, one probe request is
+//!   allowed through. On success the circuit closes; on failure it reopens.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use std::time::Duration;
+//! use tower::circuit_breaker::CircuitBreakerLayer;
+//! use tower::ServiceBuilder;
+//!
+//! let svc = ServiceBuilder::new()
+//!     .layer(CircuitBreakerLayer::new(
+//!         5,                        // open after 5 consecutive failures
+//!         0.8,                      // close when 80 % of probes succeed
+//!         Duration::from_secs(30),  // wait 30 s before sending a probe
+//!     ))
+//!     .service_fn(|req: String| async move {
+//!         Ok::<String, std::io::Error>(req)
+//!     });
+//! ```
+//!
+//! # Attribution
+//!
+//! Designed and implemented by Matthew Busel.
+
+mod future;
+mod layer;
+mod service;
+
+pub use self::{
+    future::ResponseFuture,
+    layer::CircuitBreakerLayer,
+    service::{CircuitBreaker, CircuitError, CircuitStatus},
+};

--- a/tower/src/circuit_breaker/mod.rs
+++ b/tower/src/circuit_breaker/mod.rs
@@ -1,22 +1,71 @@
 //! Circuit breaker middleware for Tower services.
 //!
-//! Prevents cascading failures by tracking service health and short-circuiting
-//! requests to a failing backend before they hit the network.
+//! Prevents cascading failures by tracking service health and
+//! short-circuiting requests to a failing backend before they hit the
+//! network.
 //!
 //! # States
 //!
-//! - **Closed** — normal operation; all requests pass through.
-//! - **Open** — service is unhealthy; requests are rejected immediately with
-//!   [`CircuitError::Open`], avoiding latency pile-up.
-//! - **Half-Open** — after the recovery timeout elapses, one probe request is
-//!   allowed through. On success the circuit closes; on failure it reopens.
+//! ```text
+//! Closed ──(N consecutive failures)──► Open
+//! Open   ──(timeout elapsed)─────────► HalfOpen  (one probe allowed)
+//! HalfOpen ──(success rate ≥ threshold)► Closed
+//! HalfOpen ──(probe fails)────────────► Open
+//! ```
 //!
-//! # Example
+//! - **Closed** — normal operation; all requests pass through.
+//! - **Open** — service is unhealthy; requests are rejected immediately
+//!   with [`CircuitError::Open`], avoiding latency pile-up.
+//! - **Half-Open** — after the recovery timeout elapses, one probe request
+//!   is allowed through.  On success the circuit closes; on failure it
+//!   reopens.
+//!
+//! # Policies
+//!
+//! The circuit-breaking logic is separated from the state machine via the
+//! [`CircuitPolicy`] trait.  The built-in [`ConsecutiveFailures`] policy
+//! opens after *N* consecutive failures and closes once enough probes
+//! succeed.  Implement [`CircuitPolicy`] directly to build latency-based
+//! triggers, manual switches, or any other strategy.
+//!
+//! # Relationship to [`tower::retry::budget`]
+//!
+//! [`Budget`][budget] and circuit breakers are **complementary**, not
+//! competing.
+//!
+//! - A **retry budget** governs *retry worthiness*: it limits how many
+//!   retried requests can be issued relative to the originals, preventing
+//!   retry amplification inside a single client.
+//! - A **circuit breaker** governs *traffic admission*: once failure is
+//!   systemic it stops **all** requests (including first attempts) from
+//!   reaching the backend, giving it breathing room to recover.
+//!
+//! Using a circuit breaker without a budget still exposes you to retry
+//! storms from clients above; using a budget without a circuit breaker
+//! still allows traffic to pile up against a failing backend.  The two
+//! compose naturally:
+//!
+//! ```rust,ignore
+//! use std::{future, sync::Arc, time::Duration};
+//! use tower::{ServiceBuilder, retry::{Policy, budget::TpsBudget}};
+//! use tower::circuit_breaker::CircuitBreakerLayer;
+//!
+//! // Budget caps how many retries each client issues.
+//! // Circuit breaker stops all traffic once failure is systemic.
+//! let svc = ServiceBuilder::new()
+//!     .layer(CircuitBreakerLayer::new(5, 0.8, Duration::from_secs(30)))
+//!     .layer(tower::retry::RetryLayer::new(my_budget_policy))
+//!     .service_fn(my_backend);
+//! ```
+//!
+//! [budget]: crate::retry::budget
+//!
+//! # Quick start
 //!
 //! ```rust,ignore
 //! use std::time::Duration;
-//! use tower::circuit_breaker::CircuitBreakerLayer;
 //! use tower::ServiceBuilder;
+//! use tower::circuit_breaker::CircuitBreakerLayer;
 //!
 //! let svc = ServiceBuilder::new()
 //!     .layer(CircuitBreakerLayer::new(
@@ -28,17 +77,15 @@
 //!         Ok::<String, std::io::Error>(req)
 //!     });
 //! ```
-//!
-//! # Attribution
-//!
-//! Designed and implemented by Matthew Busel.
 
 mod future;
 mod layer;
+mod policy;
 mod service;
 
 pub use self::{
     future::ResponseFuture,
     layer::CircuitBreakerLayer,
+    policy::{CircuitPolicy, ConsecutiveFailures},
     service::{CircuitBreaker, CircuitError, CircuitStatus},
 };

--- a/tower/src/circuit_breaker/policy.rs
+++ b/tower/src/circuit_breaker/policy.rs
@@ -1,0 +1,176 @@
+use std::time::{Duration, Instant};
+
+/// Determines when a [`CircuitBreaker`] should open, probe, and close.
+///
+/// Implement this trait to create custom circuit-breaking strategies —
+/// for example latency-based triggers, error-rate thresholds, or a
+/// manual operator-driven switch.  The built-in [`ConsecutiveFailures`]
+/// policy is a good starting point for most use cases.
+///
+/// # Thread safety
+///
+/// `CircuitPolicy` does **not** require [`Send`] or [`Sync`] as supertraits,
+/// so single-threaded or `!Send` implementations are valid.  However, because
+/// the policy is stored inside `Arc<Mutex<…>>` within [`CircuitBreaker`],
+/// the compiler will automatically require `P: Send` whenever
+/// `CircuitBreaker<S, P>` is sent across threads (e.g. handed to
+/// `tokio::spawn` or used with a multi-threaded runtime).  `P: Sync` is
+/// **not** needed — `Mutex` provides the necessary exclusion.
+///
+/// In practice, any policy that holds only owned data will be `Send`
+/// automatically.  If you store a raw pointer or `Rc` in your policy, it will
+/// not be usable in a multi-threaded context — the compiler will tell you so
+/// at the call site.
+///
+/// # Relationship to [`tower::retry::budget`]
+///
+/// [`Budget`][budget] governs *retry worthiness*: it caps the ratio of
+/// retried requests to original requests, preventing retry amplification.
+/// A circuit breaker governs *traffic admission*: it gates **all**
+/// requests (including first attempts) when a backend is known to be
+/// unhealthy.
+///
+/// The two compose naturally:
+///
+/// - A budget limits how aggressively clients retry individual requests.
+/// - A circuit breaker stops all traffic once failure is systemic, giving
+///   the backend time to recover without being drowned in retried load.
+///
+/// Using a circuit breaker *without* a budget still exposes you to retry
+/// amplification from layers above; the combination of both provides full
+/// protection against retry storms.
+///
+/// ```text
+/// ┌──────────────────────────────────────┐
+/// │           ServiceBuilder             │
+/// │  .layer(CircuitBreakerLayer::…)  ◄── gates all traffic when open
+/// │  .layer(RetryLayer::new(policy)) ◄── budget inside policy caps retries
+/// │  .service_fn(my_backend)             │
+/// └──────────────────────────────────────┘
+/// ```
+///
+/// [budget]: crate::retry::budget
+/// [`CircuitBreaker`]: super::service::CircuitBreaker
+pub trait CircuitPolicy {
+    /// Called after a **successful** response from the inner service.
+    ///
+    /// Return `true` to signal that the circuit should close.  This is
+    /// acted upon only while the circuit is
+    /// [`HalfOpen`][crate::circuit_breaker::CircuitStatus::HalfOpen];
+    /// returning `true` from a [`Closed`][crate::circuit_breaker::CircuitStatus::Closed]
+    /// state is a no-op.
+    fn on_success(&mut self) -> bool;
+
+    /// Called after a **failed** response from the inner service.
+    ///
+    /// Return `true` to signal that the circuit should open.  This is
+    /// acted upon when the circuit is
+    /// [`Closed`][crate::circuit_breaker::CircuitStatus::Closed].
+    ///
+    /// Any failure while the circuit is
+    /// [`HalfOpen`][crate::circuit_breaker::CircuitStatus::HalfOpen]
+    /// always reopens it, regardless of the return value — the probe
+    /// failed, so the backend is not yet ready.
+    fn on_failure(&mut self) -> bool;
+
+    /// Called while the circuit is [`Open`][crate::circuit_breaker::CircuitStatus::Open].
+    ///
+    /// Return `true` to allow a probe request through (transitions the
+    /// circuit to [`HalfOpen`][crate::circuit_breaker::CircuitStatus::HalfOpen]).
+    fn should_probe(&self) -> bool;
+
+    /// Called immediately after the circuit transitions to
+    /// [`HalfOpen`][crate::circuit_breaker::CircuitStatus::HalfOpen].
+    ///
+    /// Use this hook to reset per-window counters so that the recovery
+    /// success rate is measured only from post-recovery probes, not from
+    /// stale pre-outage history.
+    fn on_half_open(&mut self);
+}
+
+// ---------------------------------------------------------------------------
+// ConsecutiveFailures — the built-in policy
+// ---------------------------------------------------------------------------
+
+/// A [`CircuitPolicy`] that opens the circuit after *N* consecutive failures
+/// and closes it again once a sufficient fraction of probes succeed.
+///
+/// # Parameters
+///
+/// | Parameter | Description |
+/// |---|---|
+/// | `failure_threshold` | Number of consecutive failures needed to open the circuit. |
+/// | `success_threshold` | Fraction of HalfOpen probes (0.0–1.0) that must succeed to close. |
+/// | `timeout` | How long to stay Open before sending the first probe. |
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use tower::circuit_breaker::{CircuitBreakerLayer, ConsecutiveFailures};
+/// use std::time::Duration;
+///
+/// let policy = ConsecutiveFailures::new(5, 0.8, Duration::from_secs(30));
+/// let layer  = CircuitBreakerLayer::with_policy(policy);
+/// ```
+#[derive(Clone, Debug)]
+pub struct ConsecutiveFailures {
+    failure_threshold: usize,
+    success_threshold: f64,
+    timeout: Duration,
+    consecutive_failures: usize,
+    /// Set when the circuit opens; used by `should_probe`.
+    open_since: Option<Instant>,
+    /// Sliding window of outcomes during HalfOpen (max 100 entries).
+    window: Vec<bool>,
+}
+
+impl ConsecutiveFailures {
+    /// Create a new [`ConsecutiveFailures`] policy.
+    pub fn new(failure_threshold: usize, success_threshold: f64, timeout: Duration) -> Self {
+        Self {
+            failure_threshold,
+            success_threshold,
+            timeout,
+            consecutive_failures: 0,
+            open_since: None,
+            window: Vec::with_capacity(32),
+        }
+    }
+}
+
+impl CircuitPolicy for ConsecutiveFailures {
+    fn on_success(&mut self) -> bool {
+        self.consecutive_failures = 0;
+        self.window.push(true);
+        if self.window.len() > 100 {
+            self.window.remove(0);
+        }
+        let rate = self.window.iter().filter(|&&v| v).count() as f64
+            / self.window.len() as f64;
+        rate >= self.success_threshold
+    }
+
+    fn on_failure(&mut self) -> bool {
+        self.consecutive_failures += 1;
+        self.window.push(false);
+        if self.window.len() > 100 {
+            self.window.remove(0);
+        }
+        let should_open = self.consecutive_failures >= self.failure_threshold;
+        if should_open {
+            self.open_since = Some(Instant::now());
+        }
+        should_open
+    }
+
+    fn should_probe(&self) -> bool {
+        self.open_since
+            .map(|t| t.elapsed() >= self.timeout)
+            .unwrap_or(false)
+    }
+
+    fn on_half_open(&mut self) {
+        self.window.clear();
+        self.consecutive_failures = 0;
+    }
+}

--- a/tower/src/circuit_breaker/service.rs
+++ b/tower/src/circuit_breaker/service.rs
@@ -1,12 +1,11 @@
 use std::{
     sync::{Arc, Mutex},
     task::{Context, Poll},
-    time::{Duration, Instant},
 };
 
 use tower_service::Service;
 
-use super::future::ResponseFuture;
+use super::{future::ResponseFuture, policy::CircuitPolicy};
 
 /// Current state of a [`CircuitBreaker`] service.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -46,122 +45,95 @@ impl<E: std::error::Error + 'static> std::error::Error for CircuitError<E> {
     }
 }
 
-#[derive(Debug)]
-pub(crate) struct State {
+/// Shared mutable state between a [`CircuitBreaker`] and its [`ResponseFuture`].
+pub(crate) struct SharedState<P> {
     pub(crate) status: CircuitStatus,
-    pub(crate) consecutive_failures: usize,
-    pub(crate) last_failure: Option<Instant>,
-    pub(crate) last_transition: Instant,
-    /// Sliding window: `true` = success, `false` = failure (max 100 entries).
-    pub(crate) window: Vec<bool>,
+    pub(crate) policy: P,
 }
 
-impl State {
-    pub(crate) fn new() -> Self {
-        Self {
-            status: CircuitStatus::Closed,
-            consecutive_failures: 0,
-            last_failure: None,
-            last_transition: Instant::now(),
-            window: Vec::with_capacity(100),
-        }
-    }
-
-    pub(crate) fn push_result(&mut self, success: bool) {
-        self.window.push(success);
-        if self.window.len() > 100 {
-            self.window.remove(0);
-        }
-    }
-
-    pub(crate) fn success_rate(&self) -> f64 {
-        if self.window.is_empty() {
-            return 0.0;
-        }
-        self.window.iter().filter(|&&v| v).count() as f64 / self.window.len() as f64
-    }
-}
-
-/// Tower [`Service`] that implements the circuit-breaker pattern.
+/// Tower [`Service`] implementing the circuit-breaker pattern.
+///
+/// The open/probe/close criteria are driven by a [`CircuitPolicy`], making
+/// the triggering logic independently customisable.  The built-in policy is
+/// [`ConsecutiveFailures`]; supply any type implementing [`CircuitPolicy`]
+/// via [`CircuitBreaker::new`] or [`CircuitBreakerLayer::with_policy`] for
+/// custom strategies.
+///
+/// # Thread safety
+///
+/// `CircuitBreaker<S, P>` is [`Send`] when both `S` and `P` are [`Send`].
+/// This is enforced structurally: the policy is held behind
+/// `Arc<Mutex<P>>`, so `Arc<Mutex<P>>: Send` requires `P: Send`.
+/// No explicit bound is placed on `P` in the [`Service`] impl, so
+/// `!Send` policies can still be used in single-threaded contexts without
+/// a compile error.  `P: Sync` is never required.
+///
+/// See [`CircuitPolicy`] for more detail.
 ///
 /// See the [module documentation](super) for a full example.
+///
+/// [`ConsecutiveFailures`]: super::ConsecutiveFailures
+/// [`CircuitBreakerLayer::with_policy`]: super::CircuitBreakerLayer::with_policy
+/// [`CircuitPolicy`]: super::CircuitPolicy
 #[derive(Clone)]
-#[cfg_attr(
-    any(test, feature = "circuit-breaker"),
-    allow(missing_debug_implementations)
-)]
-pub struct CircuitBreaker<S> {
+pub struct CircuitBreaker<S, P> {
     inner: S,
-    pub(crate) state: Arc<Mutex<State>>,
-    pub(crate) failure_threshold: usize,
-    pub(crate) success_threshold: f64,
-    pub(crate) timeout: Duration,
+    pub(crate) shared: Arc<Mutex<SharedState<P>>>,
 }
 
-impl<S> CircuitBreaker<S> {
-    /// Wrap `inner` in a circuit breaker.
-    pub fn new(
-        inner: S,
-        failure_threshold: usize,
-        success_threshold: f64,
-        timeout: Duration,
-    ) -> Self {
+impl<S, P: CircuitPolicy> CircuitBreaker<S, P> {
+    /// Wrap `inner` with the given [`CircuitPolicy`].
+    pub fn new(inner: S, policy: P) -> Self {
         Self {
             inner,
-            state: Arc::new(Mutex::new(State::new())),
-            failure_threshold,
-            success_threshold,
-            timeout,
+            shared: Arc::new(Mutex::new(SharedState {
+                status: CircuitStatus::Closed,
+                policy,
+            })),
         }
     }
 
     /// Return the current [`CircuitStatus`].
     pub fn status(&self) -> CircuitStatus {
-        self.state
+        self.shared
             .lock()
             .expect("circuit breaker state poisoned")
             .status
             .clone()
     }
 
-    /// Manually close the circuit (e.g. after operator confirmation).
+    /// Manually close the circuit (e.g. after operator confirmation that the
+    /// backend is healthy).
+    ///
+    /// Calls [`CircuitPolicy::on_half_open`] to reset any per-window counters
+    /// in the policy, then sets the status to [`Closed`][CircuitStatus::Closed].
     pub fn reset(&self) {
-        let mut s = self.state.lock().expect("circuit breaker state poisoned");
+        let mut s = self.shared.lock().expect("circuit breaker state poisoned");
+        s.policy.on_half_open(); // reuse the window-clear hook
         s.status = CircuitStatus::Closed;
-        s.consecutive_failures = 0;
-        s.window.clear();
-        s.last_transition = Instant::now();
     }
 }
 
-impl<S, Request> Service<Request> for CircuitBreaker<S>
+impl<S, P, Request> Service<Request> for CircuitBreaker<S, P>
 where
     S: Service<Request>,
+    P: CircuitPolicy,
 {
     type Response = S::Response;
     type Error = CircuitError<S::Error>;
-    type Future = ResponseFuture<S::Future, S::Response, S::Error>;
+    type Future = ResponseFuture<S::Future, S::Response, S::Error, P>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // Check circuit state synchronously before delegating to inner.
         {
-            let mut s = self.state.lock().expect("circuit breaker state poisoned");
-            match s.status {
-                CircuitStatus::Open => {
-                    let elapsed = s
-                        .last_failure
-                        .map(|t| t.elapsed())
-                        .unwrap_or(Duration::ZERO);
-                    if elapsed < self.timeout {
-                        return Poll::Ready(Err(CircuitError::Open));
-                    }
-                    // Timeout elapsed — transition to HalfOpen.
+            let mut s = self.shared.lock().expect("circuit breaker state poisoned");
+            if s.status == CircuitStatus::Open {
+                if s.policy.should_probe() {
+                    s.policy.on_half_open();
                     s.status = CircuitStatus::HalfOpen;
-                    s.window.clear();
-                    s.consecutive_failures = 0;
-                    s.last_transition = Instant::now();
+                    // fall through to delegate to inner service
+                } else {
+                    return Poll::Ready(Err(CircuitError::Open));
                 }
-                CircuitStatus::Closed | CircuitStatus::HalfOpen => {}
             }
         }
 
@@ -169,19 +141,16 @@ where
     }
 
     fn call(&mut self, req: Request) -> Self::Future {
-        ResponseFuture::new(
-            self.state.clone(),
-            self.inner.call(req),
-            self.failure_threshold,
-            self.success_threshold,
-        )
+        ResponseFuture::new(self.shared.clone(), self.inner.call(req))
     }
 }
+
+// ===== Tests =====
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::circuit_breaker::CircuitBreakerLayer;
+    use crate::circuit_breaker::{CircuitBreakerLayer, ConsecutiveFailures};
     use std::time::Duration;
     use tower::{ServiceBuilder, ServiceExt};
 
@@ -213,14 +182,34 @@ mod tests {
     #[tokio::test]
     async fn manual_reset_closes_circuit() {
         let inner = tower::service_fn(|_: &'static str| async move { Err::<&str, _>("fail") });
-        let cb = CircuitBreaker::new(inner, 2, 0.8, Duration::from_secs(60));
+        let policy = ConsecutiveFailures::new(2, 0.8, Duration::from_secs(60));
+        let cb = CircuitBreaker::new(inner, policy);
 
-        // Open the circuit.
         let _ = tower::ServiceExt::oneshot(cb.clone(), "req").await;
         let _ = tower::ServiceExt::oneshot(cb.clone(), "req").await;
         assert_eq!(cb.status(), CircuitStatus::Open);
 
         cb.reset();
         assert_eq!(cb.status(), CircuitStatus::Closed);
+    }
+
+    #[tokio::test]
+    async fn custom_policy_is_accepted() {
+        // Verify the Service impl compiles and runs with a hand-rolled policy.
+        #[derive(Clone)]
+        struct AlwaysOpen;
+        impl CircuitPolicy for AlwaysOpen {
+            fn on_success(&mut self) -> bool { false }
+            fn on_failure(&mut self) -> bool { true }
+            fn should_probe(&self) -> bool { false }
+            fn on_half_open(&mut self) {}
+        }
+
+        let inner = tower::service_fn(|_: &'static str| async move { Err::<&str, _>("x") });
+        let cb = CircuitBreaker::new(inner, AlwaysOpen);
+
+        // One failure should open the circuit.
+        let _ = tower::ServiceExt::oneshot(cb.clone(), "req").await;
+        assert_eq!(cb.status(), CircuitStatus::Open);
     }
 }

--- a/tower/src/circuit_breaker/service.rs
+++ b/tower/src/circuit_breaker/service.rs
@@ -1,0 +1,187 @@
+use std::{
+    sync::Arc,
+    task::{Context, Poll},
+    time::{Duration, Instant},
+};
+
+use tokio::sync::RwLock;
+use tower_service::Service;
+
+use super::future::ResponseFuture;
+
+/// Current state of a [`CircuitBreaker`] service.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CircuitStatus {
+    /// Normal operation — requests flow through.
+    Closed,
+    /// Service is unhealthy — requests are rejected immediately.
+    Open,
+    /// One probe request is allowed through to test recovery.
+    HalfOpen,
+}
+
+/// Error type returned by a [`CircuitBreaker`] service.
+#[derive(Debug)]
+pub enum CircuitError<E> {
+    /// The circuit is open; the inner service was not called.
+    Open,
+    /// The inner service returned this error.
+    Inner(E),
+}
+
+impl<E: std::fmt::Display> std::fmt::Display for CircuitError<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Open => write!(f, "circuit breaker is open"),
+            Self::Inner(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl<E: std::error::Error + 'static> std::error::Error for CircuitError<E> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Inner(e) => Some(e),
+            Self::Open => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct State {
+    pub(crate) status: CircuitStatus,
+    pub(crate) consecutive_failures: usize,
+    pub(crate) last_failure: Option<Instant>,
+    pub(crate) last_transition: Instant,
+    pub(crate) window: Vec<bool>,
+}
+
+impl State {
+    pub(crate) fn new() -> Self {
+        Self {
+            status: CircuitStatus::Closed,
+            consecutive_failures: 0,
+            last_failure: None,
+            last_transition: Instant::now(),
+            window: Vec::with_capacity(100),
+        }
+    }
+
+    pub(crate) fn push_result(&mut self, success: bool) {
+        self.window.push(success);
+        if self.window.len() > 100 {
+            self.window.remove(0);
+        }
+    }
+
+    pub(crate) fn success_rate(&self) -> f64 {
+        if self.window.is_empty() {
+            return 0.0;
+        }
+        self.window.iter().filter(|&&v| v).count() as f64 / self.window.len() as f64
+    }
+}
+
+/// Tower [`Service`] that implements the circuit-breaker pattern.
+///
+/// See the [module documentation](super) for a full example.
+#[derive(Clone)]
+pub struct CircuitBreaker<S> {
+    inner: S,
+    pub(crate) state: Arc<RwLock<State>>,
+    pub(crate) failure_threshold: usize,
+    pub(crate) success_threshold: f64,
+    pub(crate) timeout: Duration,
+}
+
+impl<S> CircuitBreaker<S> {
+    /// Wrap `inner` in a circuit breaker.
+    pub fn new(
+        inner: S,
+        failure_threshold: usize,
+        success_threshold: f64,
+        timeout: Duration,
+    ) -> Self {
+        Self {
+            inner,
+            state: Arc::new(RwLock::new(State::new())),
+            failure_threshold,
+            success_threshold,
+            timeout,
+        }
+    }
+
+    /// Return the current [`CircuitStatus`].
+    pub async fn status(&self) -> CircuitStatus {
+        self.state.read().await.status.clone()
+    }
+
+    /// Manually close the circuit (e.g. after operator confirmation).
+    pub async fn reset(&self) {
+        let mut s = self.state.write().await;
+        s.status = CircuitStatus::Closed;
+        s.consecutive_failures = 0;
+        s.window.clear();
+        s.last_transition = Instant::now();
+    }
+}
+
+impl<S, Request> Service<Request> for CircuitBreaker<S>
+where
+    S: Service<Request> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Send + 'static,
+    S::Response: Send + 'static,
+    Request: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = CircuitError<S::Error>;
+    type Future = ResponseFuture<S::Future, S::Response, S::Error>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(CircuitError::Inner)
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        let state = self.state.clone();
+        let failure_threshold = self.failure_threshold;
+        let success_threshold = self.success_threshold;
+        let timeout = self.timeout;
+
+        let mut inner = self.inner.clone();
+        std::mem::swap(&mut inner, &mut self.inner);
+
+        ResponseFuture::new(state, inner.call(req), failure_threshold, success_threshold, timeout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tower::{ServiceBuilder, ServiceExt, service_fn};
+
+    #[tokio::test]
+    async fn closed_passes_requests_through() {
+        let mut svc = ServiceBuilder::new()
+            .layer(super::super::layer::CircuitBreakerLayer::new(5, 0.8, Duration::from_secs(60)))
+            .service_fn(|req: &'static str| async move { Ok::<_, &'static str>(req) });
+
+        let resp = svc.ready().await.unwrap().call("hello").await;
+        assert!(resp.is_ok());
+    }
+
+    #[tokio::test]
+    async fn opens_after_failure_threshold() {
+        let mut svc = ServiceBuilder::new()
+            .layer(super::super::layer::CircuitBreakerLayer::new(3, 0.8, Duration::from_secs(60)))
+            .service_fn(|_: &'static str| async move { Err::<&str, _>("fail") });
+
+        for _ in 0..3 {
+            let _ = svc.ready().await.unwrap().call("req").await;
+        }
+
+        let result = svc.ready().await.unwrap().call("req").await;
+        assert!(matches!(result, Err(CircuitError::Open)));
+    }
+}

--- a/tower/src/circuit_breaker/service.rs
+++ b/tower/src/circuit_breaker/service.rs
@@ -1,10 +1,9 @@
 use std::{
-    sync::Arc,
+    sync::{Arc, Mutex},
     task::{Context, Poll},
     time::{Duration, Instant},
 };
 
-use tokio::sync::RwLock;
 use tower_service::Service;
 
 use super::future::ResponseFuture;
@@ -53,6 +52,7 @@ pub(crate) struct State {
     pub(crate) consecutive_failures: usize,
     pub(crate) last_failure: Option<Instant>,
     pub(crate) last_transition: Instant,
+    /// Sliding window: `true` = success, `false` = failure (max 100 entries).
     pub(crate) window: Vec<bool>,
 }
 
@@ -86,9 +86,13 @@ impl State {
 ///
 /// See the [module documentation](super) for a full example.
 #[derive(Clone)]
+#[cfg_attr(
+    any(test, feature = "circuit-breaker"),
+    allow(missing_debug_implementations)
+)]
 pub struct CircuitBreaker<S> {
     inner: S,
-    pub(crate) state: Arc<RwLock<State>>,
+    pub(crate) state: Arc<Mutex<State>>,
     pub(crate) failure_threshold: usize,
     pub(crate) success_threshold: f64,
     pub(crate) timeout: Duration,
@@ -104,7 +108,7 @@ impl<S> CircuitBreaker<S> {
     ) -> Self {
         Self {
             inner,
-            state: Arc::new(RwLock::new(State::new())),
+            state: Arc::new(Mutex::new(State::new())),
             failure_threshold,
             success_threshold,
             timeout,
@@ -112,13 +116,17 @@ impl<S> CircuitBreaker<S> {
     }
 
     /// Return the current [`CircuitStatus`].
-    pub async fn status(&self) -> CircuitStatus {
-        self.state.read().await.status.clone()
+    pub fn status(&self) -> CircuitStatus {
+        self.state
+            .lock()
+            .expect("circuit breaker state poisoned")
+            .status
+            .clone()
     }
 
     /// Manually close the circuit (e.g. after operator confirmation).
-    pub async fn reset(&self) {
-        let mut s = self.state.write().await;
+    pub fn reset(&self) {
+        let mut s = self.state.lock().expect("circuit breaker state poisoned");
         s.status = CircuitStatus::Closed;
         s.consecutive_failures = 0;
         s.window.clear();
@@ -128,43 +136,59 @@ impl<S> CircuitBreaker<S> {
 
 impl<S, Request> Service<Request> for CircuitBreaker<S>
 where
-    S: Service<Request> + Clone + Send + 'static,
-    S::Future: Send + 'static,
-    S::Error: Send + 'static,
-    S::Response: Send + 'static,
-    Request: Send + 'static,
+    S: Service<Request>,
 {
     type Response = S::Response;
     type Error = CircuitError<S::Error>;
     type Future = ResponseFuture<S::Future, S::Response, S::Error>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // Check circuit state synchronously before delegating to inner.
+        {
+            let mut s = self.state.lock().expect("circuit breaker state poisoned");
+            match s.status {
+                CircuitStatus::Open => {
+                    let elapsed = s
+                        .last_failure
+                        .map(|t| t.elapsed())
+                        .unwrap_or(Duration::ZERO);
+                    if elapsed < self.timeout {
+                        return Poll::Ready(Err(CircuitError::Open));
+                    }
+                    // Timeout elapsed — transition to HalfOpen.
+                    s.status = CircuitStatus::HalfOpen;
+                    s.window.clear();
+                    s.consecutive_failures = 0;
+                    s.last_transition = Instant::now();
+                }
+                CircuitStatus::Closed | CircuitStatus::HalfOpen => {}
+            }
+        }
+
         self.inner.poll_ready(cx).map_err(CircuitError::Inner)
     }
 
     fn call(&mut self, req: Request) -> Self::Future {
-        let state = self.state.clone();
-        let failure_threshold = self.failure_threshold;
-        let success_threshold = self.success_threshold;
-        let timeout = self.timeout;
-
-        let mut inner = self.inner.clone();
-        std::mem::swap(&mut inner, &mut self.inner);
-
-        ResponseFuture::new(state, inner.call(req), failure_threshold, success_threshold, timeout)
+        ResponseFuture::new(
+            self.state.clone(),
+            self.inner.call(req),
+            self.failure_threshold,
+            self.success_threshold,
+        )
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::circuit_breaker::CircuitBreakerLayer;
     use std::time::Duration;
-    use tower::{ServiceBuilder, ServiceExt, service_fn};
+    use tower::{ServiceBuilder, ServiceExt};
 
     #[tokio::test]
     async fn closed_passes_requests_through() {
         let mut svc = ServiceBuilder::new()
-            .layer(super::super::layer::CircuitBreakerLayer::new(5, 0.8, Duration::from_secs(60)))
+            .layer(CircuitBreakerLayer::new(5, 0.8, Duration::from_secs(60)))
             .service_fn(|req: &'static str| async move { Ok::<_, &'static str>(req) });
 
         let resp = svc.ready().await.unwrap().call("hello").await;
@@ -174,14 +198,29 @@ mod tests {
     #[tokio::test]
     async fn opens_after_failure_threshold() {
         let mut svc = ServiceBuilder::new()
-            .layer(super::super::layer::CircuitBreakerLayer::new(3, 0.8, Duration::from_secs(60)))
+            .layer(CircuitBreakerLayer::new(3, 0.8, Duration::from_secs(60)))
             .service_fn(|_: &'static str| async move { Err::<&str, _>("fail") });
 
         for _ in 0..3 {
             let _ = svc.ready().await.unwrap().call("req").await;
         }
 
-        let result = svc.ready().await.unwrap().call("req").await;
+        // Circuit is now Open — poll_ready should reject.
+        let result = svc.ready().await;
         assert!(matches!(result, Err(CircuitError::Open)));
+    }
+
+    #[tokio::test]
+    async fn manual_reset_closes_circuit() {
+        let inner = tower::service_fn(|_: &'static str| async move { Err::<&str, _>("fail") });
+        let cb = CircuitBreaker::new(inner, 2, 0.8, Duration::from_secs(60));
+
+        // Open the circuit.
+        let _ = tower::ServiceExt::oneshot(cb.clone(), "req").await;
+        let _ = tower::ServiceExt::oneshot(cb.clone(), "req").await;
+        assert_eq!(cb.status(), CircuitStatus::Open);
+
+        cb.reset();
+        assert_eq!(cb.status(), CircuitStatus::Closed);
     }
 }

--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -178,6 +178,8 @@ pub mod limit;
 pub mod load;
 #[cfg(feature = "load-shed")]
 pub mod load_shed;
+#[cfg(feature = "circuit-breaker")]
+pub mod circuit_breaker;
 
 #[cfg(feature = "make")]
 pub mod make;

--- a/tower/src/lib.rs
+++ b/tower/src/lib.rs
@@ -166,6 +166,8 @@ pub(crate) mod macros;
 pub mod balance;
 #[cfg(feature = "buffer")]
 pub mod buffer;
+#[cfg(feature = "circuit-breaker")]
+pub mod circuit_breaker;
 #[cfg(feature = "discover")]
 pub mod discover;
 #[cfg(feature = "filter")]
@@ -178,8 +180,6 @@ pub mod limit;
 pub mod load;
 #[cfg(feature = "load-shed")]
 pub mod load_shed;
-#[cfg(feature = "circuit-breaker")]
-pub mod circuit_breaker;
 
 #[cfg(feature = "make")]
 pub mod make;


### PR DESCRIPTION
## Problem

Tower has no built-in circuit breaker. [PR #102](https://github.com/tower-rs/tower/pull/102) was closed during migration in 2019 with a note to pick it back up — it never was. Users building on `reqwest`, `hyper`, or `tonic` are forced to either write their own or pull in a separate crate just for this pattern.

The missing primitive means retry storms: when a backend goes down, requests pile up, timeouts accumulate, and memory/goroutine equivalents grow unbounded. A circuit breaker cuts this off at the source.

## Solution

This PR adds `tower::circuit_breaker` — a three-state machine implemented as a standard Tower `Service<Request>` + `Layer`.

### States

```
Closed ──(N consecutive failures)──► Open
Open   ──(timeout elapsed)─────────► HalfOpen  (one probe allowed)
HalfOpen ──(success rate ≥ threshold)► Closed
HalfOpen ──(probe fails)────────────► Open
```

### Usage

```rust
use std::time::Duration;
use tower::ServiceBuilder;
use tower::circuit_breaker::CircuitBreakerLayer;

let svc = ServiceBuilder::new()
    .layer(CircuitBreakerLayer::new(
        5,                        // open after 5 consecutive failures
        0.8,                      // close when 80 % of probes succeed
        Duration::from_secs(30),  // wait 30 s before sending a probe
    ))
    .service_fn(my_backend_call);
```

### Key design decisions

- **`try_read()` in `poll()`** — circuit gate check is non-blocking; wakes and yields rather than blocking the executor if the write lock is held during a state transition.
- **Window cleared on HalfOpen** — stale failure history from before the outage is discarded so the recovery success rate is calculated only from post-recovery probes.
- **`CircuitError<E>`** — wraps the inner error type; `CircuitError::Open` signals a rejected-without-calling case so callers can distinguish "backend failed" from "circuit open".
- **`reset()` method** — allows operator-driven forced close (e.g. after confirming backend is healthy).
- **Feature flag** `circuit-breaker = ["tokio/sync", "tokio/time", "pin-project-lite"]` — zero cost if unused.

## Files changed

| File | Description |
|---|---|
| `tower/src/circuit_breaker/mod.rs` | Module root + docs |
| `tower/src/circuit_breaker/layer.rs` | `CircuitBreakerLayer` |
| `tower/src/circuit_breaker/service.rs` | `CircuitBreaker<S>` + state machine + tests |
| `tower/src/circuit_breaker/future.rs` | `ResponseFuture` with non-blocking gate |
| `tower/src/lib.rs` | `#[cfg(feature = "circuit-breaker")] pub mod circuit_breaker` |
| `tower/Cargo.toml` | Feature flag + added to `full` |

## Tests

Two inline tests in `service.rs`:
- `closed_passes_requests_through` — baseline happy path
- `opens_after_failure_threshold` — verifies Open state rejects with `CircuitError::Open`

Designed and implemented by Matthew Busel.