### PR TITLE
fix(retry): avoid truncating fractional retry_percent in TpsBudget

### DIFF
--- a/tower/src/retry/budget/tps_budget.rs
+++ b/tower/src/retry/budget/tps_budget.rs
@@ -78,13 +78,12 @@ impl TpsBudget {
             // If there is no percent, then you gain nothing from deposits.
             // Withdrawals can only be made against the reserve, over time.
             (0, 1)
-        } else if retry_percent <= 1.0 {
-            (1, (1.0 / retry_percent) as isize)
-        } else {
-            // Support for when retry_percent is between 1.0 and 1000.0,
-            // meaning for every deposit D, D * retry_percent withdrawals
-            // can be made.
+        } else if retry_percent <= 0.5 {
+            // Small fractional percents lose precision when 1/retry_percent is
+            // truncated to an isize, so scale deposits by 1000 here.
             (1000, (1000.0 / retry_percent) as isize)
+        } else {
+            (1, (1.0 / retry_percent) as isize)
         };
         let reserve = (min_per_sec as isize)
             .saturating_mul(ttl.as_secs() as isize) // ttl is between 1 and 60 seconds
@@ -256,5 +255,18 @@ mod tests {
         assert!(bgt.withdraw());
 
         assert!(!bgt.withdraw());
+    }
+
+    #[test]
+    fn tps_fractional_retry_percent_below_one() {
+        let bgt = TpsBudget::new(Duration::from_secs(1), 0, 0.6);
+        for _ in 0..10 {
+            bgt.deposit();
+        }
+        let allowed = (0..10).filter(|_| bgt.withdraw()).count();
+        assert!(
+            allowed <= 6,
+            "10 deposits at retry_percent=0.6 should allow at most 6 retries, got {allowed}"
+        );
     }
 }

--- a/tower/src/retry/budget/tps_budget.rs
+++ b/tower/src/retry/budget/tps_budget.rs
@@ -78,12 +78,12 @@ impl TpsBudget {
             // If there is no percent, then you gain nothing from deposits.
             // Withdrawals can only be made against the reserve, over time.
             (0, 1)
-        } else if retry_percent <= 0.5 {
-            // Small fractional percents lose precision when 1/retry_percent is
-            // truncated to an isize, so scale deposits by 1000 here.
-            (1000, (1000.0 / retry_percent) as isize)
         } else {
-            (1, (1.0 / retry_percent) as isize)
+            // Scale deposits by 1000 so fractional percentages (where
+            // 1/retry_percent truncates badly) and values > 1 both stay
+            // precise.  For example 0.6 -> (1000, 1666) gives exactly
+            // 6 retries per 10 deposits; 2.0 -> (1000, 500) gives 20.
+            (1000, (1000.0 / retry_percent) as isize)
         };
         let reserve = (min_per_sec as isize)
             .saturating_mul(ttl.as_secs() as isize) // ttl is between 1 and 60 seconds


### PR DESCRIPTION
`TpsBudget::new` used `(1, (1.0 / retry_percent) as isize)` for `retry_percent <= 1.0`, which truncates the reciprocal so e.g. `0.6` authorizes a full retry per deposit instead of 0.6. This reuses the existing 1000x deposit scaling for all positive percentages and adds a regression test. Closes #857.