### PR TITLE
fix(hedge): assert non-zero rotation period on construction

### DIFF
--- a/tower/src/hedge/mod.rs
+++ b/tower/src/hedge/mod.rs
@@ -85,6 +85,10 @@ pub struct SelectPolicy<P> {
 
 impl<S, P> Hedge<S, P> {
     /// Create a new hedge middleware.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `period` is zero.
     pub fn new<Request>(
         service: S,
         policy: P,

--- a/tower/src/hedge/mod.rs
+++ b/tower/src/hedge/mod.rs
@@ -97,6 +97,10 @@ impl<S, P> Hedge<S, P> {
         S::Error: Into<crate::BoxError>,
         P: Policy<Request> + Clone,
     {
+        assert!(
+            period > Duration::ZERO,
+            "histogram rotation period must be greater than zero"
+        );
         let histo = Arc::new(Mutex::new(RotatingHistogram::new(period)));
         Self::new_with_histo(service, policy, min_data_points, latency_percentile, histo)
     }
@@ -116,6 +120,11 @@ impl<S, P> Hedge<S, P> {
         S::Error: Into<crate::BoxError>,
         P: Policy<Request> + Clone,
     {
+        assert!(
+            period > Duration::ZERO,
+            "histogram rotation period must be greater than zero"
+        );
+
         let histo = Arc::new(Mutex::new(RotatingHistogram::new(period)));
         {
             let mut locked = histo.lock().unwrap();

--- a/tower/tests/hedge/main.rs
+++ b/tower/tests/hedge/main.rs
@@ -182,3 +182,26 @@ fn new_service<P: Policy<Req> + Clone>(policy: P) -> (mock::Spawn<Hedge<Mock, P>
 
     (mock::Spawn::new(service), handle)
 }
+
+#[test]
+#[should_panic(expected = "histogram rotation period must be greater than zero")]
+fn hedge_new_with_mock_latencies_zero_period_panics() {
+    let (service, _handle) = tower_test::mock::pair::<Req, Res>();
+    let mock_latencies: [u64; 2] = [10, 20];
+
+    let _service = Hedge::new_with_mock_latencies(
+        service,
+        TestPolicy,
+        10,
+        0.9,
+        Duration::ZERO,
+        &mock_latencies,
+    );
+}
+#[test]
+#[should_panic(expected = "histogram rotation period must be greater than zero")]
+fn hedge_new_zero_period_panics() {
+    let (service, _handle) = tower_test::mock::pair::<Req, Res>();
+
+    let _service = Hedge::new(service, TestPolicy, 10, 0.9, Duration::ZERO);
+}


### PR DESCRIPTION
## Description

This PR addresses an issue where `Hedge::new` and `Hedge::new_with_mock_latencies` accept a `Duration::ZERO` rotation period during configuration. This behavior subsequently causes an unrecoverable integer divide-by-zero panic in `RotatingHistogram::maybe_rotate` upon the first request invocation.

By validating the `period` parameter at the API boundary via an explicit assertion, this change ensures that invalid configurations fail-fast during initialization rather than causing runtime instability.

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Proposed Changes

* Added `assert!(period > Duration::ZERO, ...)` to `Hedge::new`.
* Added an identical guard to `Hedge::new_with_mock_latencies` to protect immediate history pre-population logic.
* Added synchronous regression tests to the `hedge` integration test suite covering both constructors.

## Verification Run

Executed the module integration tests locally across the workspace using:

```bash
cargo test --package tower --all-features

```

All 7 tests within `tests/hedge/main.rs` passed successfully alongside the rest of the workspace and doc-test suite.

Closes #862