### PR TITLE
fix(steer): enforce fail-fast assertion for empty service iterators

### DIFF
--- a/tower/src/steer/mod.rs
+++ b/tower/src/steer/mod.rs
@@ -116,6 +116,10 @@ impl<S, F, Req> Steer<S, F, Req> {
     /// Note: the order of the [`Service`]'s is significant for [`Picker::pick`]'s return value.
     pub fn new(services: impl IntoIterator<Item = S>, router: F) -> Self {
         let services: Vec<_> = services.into_iter().collect();
+        assert!(
+            !services.is_empty(),
+            "steer must contain at least one service"
+        );
         let not_ready: VecDeque<_> = services.iter().enumerate().map(|(i, _)| i).collect();
         Self {
             router,

--- a/tower/src/steer/mod.rs
+++ b/tower/src/steer/mod.rs
@@ -113,6 +113,10 @@ pub struct Steer<S, F, Req> {
 impl<S, F, Req> Steer<S, F, Req> {
     /// Make a new [`Steer`] with a list of [`Service`]'s and a [`Picker`].
     ///
+    /// # Panics
+    ///
+    /// Panics if the `services` collection is empty
+    ///
     /// Note: the order of the [`Service`]'s is significant for [`Picker::pick`]'s return value.
     pub fn new(services: impl IntoIterator<Item = S>, router: F) -> Self {
         let services: Vec<_> = services.into_iter().collect();

--- a/tower/tests/steer/main.rs
+++ b/tower/tests/steer/main.rs
@@ -57,3 +57,15 @@ async fn pending_all_ready() {
         ),
     }
 }
+#[test]
+#[should_panic(expected = "steer must contain at least one service")]
+fn steer_new_zero_services_panics() {
+    use std::iter::empty;
+    use tower::steer::Steer;
+    use tower::util::BoxService;
+
+    let empty_services = empty::<BoxService<(), (), tower::BoxError>>();
+
+    // Explicitly annotate the Request type as () so inference succeeds
+    let _: Steer<_, _, ()> = Steer::new(empty_services, |_: &()| 0);
+}


### PR DESCRIPTION
Closes #859

Description
Initializing Steer with an empty collection of services leaves the routing middleware in an unresolvable invariant state. While poll_ready will trivially return Poll::Ready(Ok(())), any subsequent invocation of call will immediately panic because there are no underlying target services to route the request to.

This patch adds an explicit assert!(!services.is_empty(), ...) check to the Steer::new constructor, shifting an operational runtime risk into a fast, upfront failure.

Type of Change
Bug fix (non-breaking change enforcing defensive API boundaries)

Verification
Added a #[should_panic] integration test in tower/tests/steer/main.rs with explicit type hinting to satisfy the compiler's inference engine.

Verified workspace tests pass via cargo test --test steer --all-features.