### PR TITLE
fix(buffer): assert non-zero bound on construction

### DIFF
--- a/tower/src/buffer/layer.rs
+++ b/tower/src/buffer/layer.rs
@@ -34,6 +34,7 @@ impl<Request> BufferLayer<Request> {
     /// [`call`]: crate::Service::call
     /// [`poll_ready`]: crate::Service::poll_ready
     pub const fn new(bound: usize) -> Self {
+        assert!(bound > 0, "buffer bound must be greater than zero");
         BufferLayer {
             bound,
             _p: PhantomData,

--- a/tower/src/buffer/layer.rs
+++ b/tower/src/buffer/layer.rs
@@ -20,6 +20,12 @@ impl<Request> BufferLayer<Request> {
     /// `bound` gives the maximal number of requests that can be queued for the service before
     /// backpressure is applied to callers.
     ///
+    ///
+    /// # Panics
+    ///
+    /// Panics if `bound` is zero.
+    ///
+    ///
     /// # A note on choosing a `bound`
     ///
     /// When [`Buffer`]'s implementation of [`poll_ready`] returns [`Poll::Ready`], it reserves a

--- a/tower/src/buffer/service.rs
+++ b/tower/src/buffer/service.rs
@@ -70,6 +70,7 @@ where
         S::Error: Into<crate::BoxError> + Send + Sync,
         Req: Send + 'static,
     {
+        assert!(bound > 0, "buffer bound must be greater than zero");
         let (tx, rx) = mpsc::channel(bound);
         let (handle, worker) = Worker::new(service, rx);
         let buffer = Self {

--- a/tower/src/buffer/service.rs
+++ b/tower/src/buffer/service.rs
@@ -33,6 +33,10 @@ where
     /// The default Tokio executor is used to run the given service, which means that this method
     /// must be called while on the Tokio runtime.
     ///
+    /// # Panics
+    ///
+    /// Panics if `bound` is zero.
+    ///
     /// # A note on choosing a `bound`
     ///
     /// When [`Buffer`]'s implementation of [`poll_ready`] returns [`Poll::Ready`], it reserves a
@@ -63,6 +67,10 @@ where
     /// This is useful if you do not want to spawn directly onto the tokio runtime
     /// but instead want to use your own executor. This will return the [`Buffer`] and
     /// the background `Worker` that you can then spawn.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `bound` is zero.
     pub fn pair<S>(service: S, bound: usize) -> (Self, Worker<S, Req>)
     where
         S: Service<Req, Future = F> + Send + 'static,

--- a/tower/tests/buffer/main.rs
+++ b/tower/tests/buffer/main.rs
@@ -457,3 +457,20 @@ fn new_service_with_bound(bound: usize) -> (mock::Spawn<MockBuffer>, Handle) {
         svc
     })
 }
+
+#[test]
+#[should_panic(expected = "buffer bound must be greater than zero")]
+fn buffer_new_zero_bound_panics() {
+    let (service, _handle) = mock::pair::<(), ()>();
+    let _ = Buffer::new(service, 0);
+}
+
+#[test]
+#[should_panic(expected = "buffer bound must be greater than zero")]
+fn buffer_layer_zero_bound_panics() {
+    use tower::Layer;
+
+    let (service, _handle) = mock::pair::<(), ()>();
+    let layer = tower::buffer::BufferLayer::new(0);
+    let _ = layer.layer(service);
+}


### PR DESCRIPTION
Closes #861

Description
Initializing Buffer or BufferLayer with a capacity bound of 0 creates an invalid configuration state. This bypasses initial validation and causes an unrecoverable runtime panic down the line when the underlying mpsc::channel allocation is executed.

This patch adds a defensive assert!(bound > 0, ...) boundary guard to both the BufferLayer::new and Buffer::pair constructors. This shifts a latent runtime crash into a predictable, fail-fast initialization panic.

Type of Change
Bug fix (non-breaking change enforcing defensive API boundaries)

Verification
Added #[should_panic] integration tests to tower/tests/buffer/main.rs to verify that both direct instantiation and layer application fail safely when configured with a bound of 0.

Verified workspace tests pass via cargo test --test buffer --all-features.