### PR TITLE
chore: improve tower maintenance path

### DIFF
--- a/tower/src/timeout/mod.rs
+++ b/tower/src/timeout/mod.rs
@@ -68,3 +68,72 @@ where
         ResponseFuture::new(response, sleep)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        convert::Infallible,
+        future::Future,
+        pin::Pin,
+        task::{Context, Poll},
+        time::Duration,
+    };
+    use tokio::time::sleep;
+    use tower_service::Service;
+
+    struct SlowService(Duration);
+
+    impl Service<()> for SlowService {
+        type Response = ();
+        type Error = Infallible;
+        type Future = Pin<Box<dyn Future<Output = Result<(), Infallible>> + Send>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _req: ()) -> Self::Future {
+            let delay = self.0;
+            Box::pin(async move {
+                sleep(delay).await;
+                Ok(())
+            })
+        }
+    }
+
+    struct FastService;
+
+    impl Service<()> for FastService {
+        type Response = &'static str;
+        type Error = Infallible;
+        type Future = Pin<Box<dyn Future<Output = Result<&'static str, Infallible>> + Send>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _req: ()) -> Self::Future {
+            Box::pin(async move { Ok("ok") })
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn elapsed_error_when_timeout_exceeded() {
+        let mut svc = Timeout::new(SlowService(Duration::from_secs(10)), Duration::from_secs(1));
+
+        let res = svc.call(()).await;
+        assert!(res.is_err());
+
+        let err = res.unwrap_err();
+        assert!(err.downcast_ref::<error::Elapsed>().is_some());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn response_passes_through_when_under_timeout() {
+        let mut svc = Timeout::new(FastService, Duration::from_secs(1));
+
+        let res = svc.call(()).await;
+        assert_eq!(res.unwrap(), "ok");
+    }
+}


### PR DESCRIPTION
Summary:
- Add unit tests for the Timeout middleware covering the elapsed-error branch: verify that when the inner future exceeds the configured duration, the service returns an Elapsed error (downcastable via the boxed error), and that requests completing before the deadline pass through unchanged. The timeout module files are small and self-contained; tests can be added inline with #[cfg(test)] using tokio::time::pause for deterministic timing.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.