### PR TITLE
feat(load/peak_ewma): expose round-trip time estimate

### DIFF
--- a/tower/src/load/peak_ewma.rs
+++ b/tower/src/load/peak_ewma.rs
@@ -107,6 +107,18 @@ impl<S, C> PeakEwma<S, C> {
             rtt_estimate: self.rtt_estimate.clone(),
         }
     }
+
+    /// Returns the current [`RttEstimate`] of the service.
+    ///
+    /// # Panics
+    ///
+    /// This value is stored in a mutex. If the mutex has become poisoned, this will panic.
+    pub fn rtt_estimate(&self) -> RttEstimate {
+        self.rtt_estimate
+            .lock()
+            .expect("mutex should not be poisoned")
+            .clone()
+    }
 }
 
 impl<S, C, Request> Service<Request> for PeakEwma<S, C>

--- a/tower/src/load/peak_ewma.rs
+++ b/tower/src/load/peak_ewma.rs
@@ -79,7 +79,7 @@ pub struct Handle {
 
 /// Holds the current RTT estimate and the last time this value was updated.
 #[derive(Debug)]
-struct RttEstimate {
+pub struct RttEstimate {
     update_at: Instant,
     rtt_ns: f64,
 }

--- a/tower/src/load/peak_ewma.rs
+++ b/tower/src/load/peak_ewma.rs
@@ -228,6 +228,16 @@ where
 // ===== impl RttEstimate =====
 
 impl RttEstimate {
+    /// Returns the [`Instant`] that this estimate was last updated.
+    pub fn updated_at(&self) -> Instant {
+        self.update_at
+    }
+
+    /// Returns the round-trip time estimate, in nanoseconds.
+    pub fn rtt_ns(&self) -> f64 {
+        self.rtt_ns
+    }
+
     fn new(rtt_ns: f64) -> Self {
         debug_assert!(0.0 < rtt_ns, "rtt must be positive");
         Self {

--- a/tower/src/load/peak_ewma.rs
+++ b/tower/src/load/peak_ewma.rs
@@ -78,7 +78,7 @@ pub struct Handle {
 }
 
 /// Holds the current RTT estimate and the last time this value was updated.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct RttEstimate {
     update_at: Instant,
     rtt_ns: f64,


### PR DESCRIPTION
this pull request proposes some extensions to the public interface of the `tower::load::peak_ewma` middleware.

today, this submodule provides a `tower::load::peak_ewma::PeakEwma<S, C>` service that implements `tower::load::Load`. this is useful for using peak latency as a component that influences load-balancing decisions in `tower::balance`.

today, users that may wish to build middleware that wish to build upon this exponentially-weighted moving average do not have a way to access the observed round-trip time (RTT) estimate. this prevents callers from, for example, injecting additional penalties for particular status codes, in order to steer traffic away from services returning 5XX or [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/429) responses.

this branch makes a few changes:
* expose `RttEstimate` in the public interface
* make `RttEstimate` a `Clone`able type
* add accessors to `RttEstimate`