### PR TITLE
fix(load): release completion handle when the response future resolves to Err

### DIFF
--- a/tower/src/load/completion.rs
+++ b/tower/src/load/completion.rs
@@ -76,9 +76,17 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
-        let rsp = ready!(this.future.poll(cx))?;
-        let h = this.handle.take().expect("handle");
-        Poll::Ready(Ok(this.completion.track_completion(h, rsp)))
+
+        match ready!(this.future.poll(cx)) {
+            Ok(rsp) => {
+                let h = this.handle.take().expect("handle");
+                Poll::Ready(Ok(this.completion.track_completion(h, rsp)))
+            }
+            Err(err) => {
+                drop(this.handle.take().expect("handle"));
+                Poll::Ready(Err(err))
+            }
+        }
     }
 }
 

--- a/tower/src/load/peak_ewma.rs
+++ b/tower/src/load/peak_ewma.rs
@@ -392,6 +392,56 @@ mod tests {
         assert!(svc.load() < Cost(100_000.0));
     }
 
+    // Regression test for #858: a request that resolves to `Err` must stop
+    // contributing to load as soon as the response future resolves, not only
+    // when the future object is dropped.
+    #[tokio::test]
+    async fn completes_on_error() {
+        time::pause();
+
+        struct ErrSvc;
+        impl Service<()> for ErrSvc {
+            type Response = ();
+            type Error = ();
+            type Future = future::Ready<Result<(), ()>>;
+
+            fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), ()>> {
+                Poll::Ready(Ok(()))
+            }
+
+            fn call(&mut self, (): ()) -> Self::Future {
+                future::ready(Err(()))
+            }
+        }
+
+        let mut svc = PeakEwma::new(
+            ErrSvc,
+            Duration::from_millis(10),
+            NANOS_PER_MILLI * 1_000.0,
+            CompleteOnResponse,
+        );
+
+        let baseline = svc.load();
+        let mut fut = task::spawn(svc.call(()));
+        let pending = svc.load();
+        assert!(pending > baseline, "an in-flight request should raise load");
+
+        // Poll the failed response to completion. The future object is kept
+        // alive afterwards.
+        assert!(matches!(fut.poll(), Poll::Ready(Err(()))));
+
+        // With the fix, the failed response releases its load handle at
+        // completion, so it no longer counts as pending even though `fut` has
+        // not been dropped.
+        let after = svc.load();
+        assert!(
+            after < pending,
+            "a failed request must stop counting as pending once its response resolves"
+        );
+
+        drop(fut);
+    }
+
     #[test]
     fn nanos() {
         assert_eq!(super::nanos(Duration::new(0, 0)), 0.0);

--- a/tower/src/load/pending_requests.rs
+++ b/tower/src/load/pending_requests.rs
@@ -216,4 +216,39 @@ mod tests {
         drop(i0);
         assert_eq!(svc.load(), Count(0));
     }
+
+    // Regression test for #858: a request that resolves to `Err` must stop
+    // counting as pending as soon as its response future resolves, not only
+    // once the future object is dropped.
+    #[test]
+    fn failed_response_completes_immediately() {
+        use tokio_test::task;
+
+        struct ErrSvc;
+        impl Service<()> for ErrSvc {
+            type Response = ();
+            type Error = ();
+            type Future = future::Ready<Result<(), ()>>;
+
+            fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), ()>> {
+                Poll::Ready(Ok(()))
+            }
+
+            fn call(&mut self, (): ()) -> Self::Future {
+                future::ready(Err(()))
+            }
+        }
+
+        let mut svc = PendingRequests::new(ErrSvc, CompleteOnResponse);
+        assert_eq!(svc.load(), Count(0));
+
+        let mut fut = task::spawn(svc.call(()));
+        assert_eq!(svc.load(), Count(1));
+
+        assert!(matches!(fut.poll(), Poll::Ready(Err(()))));
+
+        // The request has completed (with an error), so it must no longer be
+        // counted as pending -- even though `fut` has not been dropped yet.
+        assert_eq!(svc.load(), Count(0));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #858.

`TrackCompletionFuture::poll` only took the load-tracking `Handle` on the success path:

```rust
let rsp = ready!(this.future.poll(cx))?;   // `?` returns early on Err
let h = this.handle.take().expect("handle");
```

When the inner response future resolved to `Err`, `?` returned before `handle.take()` ran, so the `Handle` stayed alive until the *outer future object* was dropped rather than when the request actually completed. Both `PendingRequests` and `PeakEwma` track load through this `Handle`'s `Drop`, so a failed request kept counting as pending — and, for `PeakEwma`, delayed its RTT sample — until drop time. Callers that hold onto completed error futures (logging, retries, batching) can therefore make an endpoint look busier or slower than it really is.

## Fix

Match on the polled result and release the handle on both branches:

```rust
match ready!(this.future.poll(cx)) {
    Ok(rsp) => {
        let h = this.handle.take().expect("handle");
        Poll::Ready(Ok(this.completion.track_completion(h, rsp)))
    }
    Err(err) => {
        drop(this.handle.take().expect("handle"));
        Poll::Ready(Err(err))
    }
}
```

The success path is unchanged (the `Ok` arm is identical to the previous two lines); only the error path's timing changes — the handle is now released as soon as the response future resolves, regardless of outcome. This single change fixes both `PendingRequests` and `PeakEwma`, since both route their futures through `TrackCompletionFuture`.

Dropping the handle (rather than forwarding it) is the only option on the error path: `TrackCompletion::track_completion(&self, handle, value: V)` requires the *success* value `V`, which doesn't exist on `Err`. A handle can therefore only ever be forwarded into a successful response; on error, the RAII `Drop` is the intended completion signal.

One thing worth a maintainer's eye: as before, `PeakEwma` records an RTT sample for failed requests when the handle drops — this PR only corrects *when* that happens (at response completion instead of at future-drop). If folding failed-request latencies into the EWMA is undesirable, that's a separate change.

## Tests

Adds a `PendingRequests` regression test (`failed_response_completes_immediately`) asserting that load returns to `Count(0)` as soon as the failed response future resolves, while the future is still held. It fails before this change and passes after.