### PR TITLE
fix(balance): clear cached P2C ready index after a discovery removal

### DIFF
--- a/tower/src/balance/p2c/service.rs
+++ b/tower/src/balance/p2c/service.rs
@@ -116,6 +116,13 @@ where
                 Some(Change::Remove(key)) => {
                     trace!("remove");
                     self.services.evict(&key);
+                    // `evict` removes from the ready set with `swap_remove`,
+                    // which can move a different endpoint into the slot a
+                    // previously-selected `ready_index` points at. Discard the
+                    // cached selection so `poll_ready` re-runs P2C over the
+                    // current ready set instead of dispatching to the
+                    // swapped-in endpoint.
+                    self.ready_index = None;
                 }
                 Some(Change::Insert(key, svc)) => {
                     trace!("insert");
@@ -206,8 +213,11 @@ where
     >;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // `ready_index` may have already been set by a prior invocation. These
-        // updates cannot disturb the order of existing ready services.
+        // `ready_index` may have already been set by a prior invocation. If a
+        // discovered removal evicts a service, `update_pending_from_discover`
+        // clears it, since eviction can reorder the ready set (via
+        // `swap_remove`) and leave the cached index pointing at a different
+        // endpoint.
         let _ = self.update_pending_from_discover(cx)?;
         self.promote_pending_to_ready(cx);
 

--- a/tower/src/balance/p2c/test.rs
+++ b/tower/src/balance/p2c/test.rs
@@ -193,11 +193,17 @@ async fn ready_index_reset_after_removal() {
     // Promote endpoints one per poll so the ready set is deterministically
     // ordered [a@0, b@1, c@2]. P2C selects `a` first (the only ready service)
     // and keeps it cached while it stays ready.
-    changes.borrow_mut().push_back(Change::Insert(0, endpoint(0, 0)));
+    changes
+        .borrow_mut()
+        .push_back(Change::Insert(0, endpoint(0, 0)));
     assert_ready_ok!(svc.poll_ready());
-    changes.borrow_mut().push_back(Change::Insert(1, endpoint(1, 1)));
+    changes
+        .borrow_mut()
+        .push_back(Change::Insert(1, endpoint(1, 1)));
     assert_ready_ok!(svc.poll_ready());
-    changes.borrow_mut().push_back(Change::Insert(2, endpoint(2, 10)));
+    changes
+        .borrow_mut()
+        .push_back(Change::Insert(2, endpoint(2, 10)));
     assert_ready_ok!(svc.poll_ready());
 
     // Remove the cached endpoint `a`. `evict` swap-removes index 0 and moves the

--- a/tower/src/balance/p2c/test.rs
+++ b/tower/src/balance/p2c/test.rs
@@ -123,3 +123,97 @@ async fn two_endpoints_with_equal_load() {
         "balancer must drop failed endpoints",
     );
 }
+
+// Regression test for #856: a discovery removal must invalidate the cached P2C
+// `ready_index`. Otherwise `ReadyCache::evict` (which uses `swap_remove`) can
+// move a different endpoint into the cached slot, and the next request is
+// dispatched to that swapped-in endpoint instead of a freshly-selected one.
+#[tokio::test]
+async fn ready_index_reset_after_removal() {
+    use crate::discover::Change;
+    use crate::util::rng::Rng;
+    use crate::Service;
+    use futures_core::Stream;
+    use std::cell::RefCell;
+    use std::collections::VecDeque;
+    use std::convert::Infallible;
+    use std::future::{ready, Ready};
+    use std::pin::Pin;
+    use std::rc::Rc;
+    use std::task::Context;
+
+    // An always-ready endpoint that reports its own id as the response, so we
+    // can observe which endpoint a request was routed to.
+    #[derive(Clone)]
+    struct IdSvc(usize);
+    impl Service<()> for IdSvc {
+        type Response = usize;
+        type Error = Infallible;
+        type Future = Ready<Result<usize, Infallible>>;
+
+        fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Infallible>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _: ()) -> Self::Future {
+            ready(Ok(self.0))
+        }
+    }
+
+    type Endpoint = load::Constant<IdSvc, usize>;
+
+    // A `Discover` we feed one change at a time, so endpoints are promoted to
+    // the ready set in a deterministic order.
+    struct Disco(Rc<RefCell<VecDeque<Change<usize, Endpoint>>>>);
+    impl Stream for Disco {
+        type Item = Result<Change<usize, Endpoint>, Infallible>;
+
+        fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            match self.0.borrow_mut().pop_front() {
+                Some(change) => Poll::Ready(Some(Ok(change))),
+                None => Poll::Pending,
+            }
+        }
+    }
+
+    // A zero RNG makes P2C deterministically sample ready indices 0 and len-1.
+    struct ZeroRng;
+    impl Rng for ZeroRng {
+        fn next_u64(&mut self) -> u64 {
+            0
+        }
+    }
+
+    let endpoint = |id: usize, load_val: usize| load::Constant::new(IdSvc(id), load_val);
+
+    let changes: Rc<RefCell<VecDeque<Change<usize, Endpoint>>>> =
+        Rc::new(RefCell::new(VecDeque::new()));
+    let mut svc = mock::Spawn::new(Balance::from_rng(Disco(changes.clone()), ZeroRng));
+
+    // Promote endpoints one per poll so the ready set is deterministically
+    // ordered [a@0, b@1, c@2]. P2C selects `a` first (the only ready service)
+    // and keeps it cached while it stays ready.
+    changes.borrow_mut().push_back(Change::Insert(0, endpoint(0, 0)));
+    assert_ready_ok!(svc.poll_ready());
+    changes.borrow_mut().push_back(Change::Insert(1, endpoint(1, 1)));
+    assert_ready_ok!(svc.poll_ready());
+    changes.borrow_mut().push_back(Change::Insert(2, endpoint(2, 10)));
+    assert_ready_ok!(svc.poll_ready());
+
+    // Remove the cached endpoint `a`. `evict` swap-removes index 0 and moves the
+    // last ready service (`c`) into that slot. Before the fix, the stale
+    // `ready_index` (0) is revalidated against `c` and the request is routed to
+    // `c`; after the fix, `ready_index` is cleared and P2C runs afresh.
+    changes.borrow_mut().push_back(Change::Remove(0));
+    assert_ready_ok!(svc.poll_ready());
+
+    // A fresh P2C over [c@0 (load 10), b@1 (load 1)] picks `b`. The stale-index
+    // bug would route to `c` instead.
+    let mut fut = task::spawn(svc.call(()));
+    assert_eq!(
+        assert_ready_ok!(fut.poll()),
+        1,
+        "request must be routed by a fresh P2C selection (b), not the endpoint \
+         swapped into the stale ready_index (c)"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #856.

`p2c::Balance` caches the P2C-selected endpoint as a numeric `ready_index`. When a subsequent `poll_ready` processes a `Change::Remove`, `update_pending_from_discover` calls `ReadyCache::evict`, which removes from the ready set with `swap_remove_full`. That can move a *different* endpoint into the slot the cached `ready_index` points at. `poll_ready` then revalidates the stale index with `check_ready_index` (which succeeds for whatever now occupies that slot) and `call` dispatches the request there — silently bypassing the P2C choice during endpoint churn.

This matches the warning already in `ready_cache`'s own docs:

> calls to `ReadyCache::poll_pending` and `ReadyCache::evict` may perturb the order of the ready set, so any cached indexes should be discarded after such a call.

## Fix

Clear `ready_index` whenever a removal evicts a service, so the next `poll_ready` re-runs P2C over the current ready set:

```rust
Some(Change::Remove(key)) => {
    trace!("remove");
    self.services.evict(&key);
    // `evict` removes from the ready set with `swap_remove`, which can move a
    // different endpoint into the slot a previously-selected `ready_index`
    // points at. Discard the cached selection so `poll_ready` re-runs P2C.
    self.ready_index = None;
}
```

I also corrected the `poll_ready` comment that claimed *"These updates cannot disturb the order of existing ready services"* — they can, via `swap_remove`.

## Why this minimal fix is sufficient

The only operation that reorders the *existing* ready set between caching `ready_index` and reusing it is `evict`'s `swap_remove_full`:

- `ReadyCache::poll_pending` only `insert`s into the ready `IndexMap` (appends new keys / updates existing in place — existing indices stay put).
- `Change::Insert` pushes to the *pending* set, never the ready set.
- `check_ready_index`'s not-ready/error arms and `call_ready_index` also `swap_remove`, but only *after* `ready_index` has been `.take()`n within the same `poll_ready` loop, each immediately followed by a fresh P2C selection — so no stale index survives across calls.

The issue notes a more robust alternative (cache the key instead of the index); that's a larger change and isn't required to close this bug, but happy to go that route if you'd prefer it.

## Tests

Not included in this commit. A deterministic regression test needs a dynamic `Discover` (to emit `Change::Remove` between `poll_ready` calls) plus a seeded `Rng`, which the current `p2c` tests don't have scaffolding for. Glad to follow up with that test (building the small test `Discover` + mock `Rng`) if you'd like it in this PR.