### PR TITLE
fix(filter): return AsyncFilterLayer from AsyncFilter::layer

### DIFF
--- a/tower/src/filter/mod.rs
+++ b/tower/src/filter/mod.rs
@@ -131,8 +131,8 @@ impl<T, U> AsyncFilter<T, U> {
     /// service with the given [`AsyncPredicate`].
     ///
     /// [`Layer`]: crate::Layer
-    pub fn layer(predicate: U) -> FilterLayer<U> {
-        FilterLayer::new(predicate)
+    pub fn layer(predicate: U) -> AsyncFilterLayer<U> {
+        AsyncFilterLayer::new(predicate)
     }
 
     /// Check a `Request` value against this filter's predicate.


### PR DESCRIPTION
## Summary

Fixes #597.

`AsyncFilter::layer` is documented to wrap services with an `AsyncFilter` built from an `AsyncPredicate`, but it returned `FilterLayer<U>` — the *synchronous* layer, which builds a `Filter` from a sync `Predicate`:

```rust
// before
pub fn layer(predicate: U) -> FilterLayer<U> {
    FilterLayer::new(predicate)
}
// after
pub fn layer(predicate: U) -> AsyncFilterLayer<U> {
    AsyncFilterLayer::new(predicate)
}
```

This is a copy/paste slip from the original filter rework (#508) — `AsyncFilter::layer` produced a layer that builds the wrong service type, making the constructor unusable for its stated purpose (an `AsyncPredicate` doesn't satisfy `FilterLayer`'s sync `Predicate` bound). It now mirrors `Filter::layer`.

## ⚠️ Breaking change

This changes the public return type of `AsyncFilter::layer` from `FilterLayer<U>` to `AsyncFilterLayer<U>`, so it's technically a semver-breaking change. In practice no working code could have depended on the old return — a `FilterLayer` built from an `AsyncPredicate` doesn't implement `Layer` usefully (the predicate doesn't satisfy the sync `Predicate` bound). Flagging it so you can decide whether it rides a minor release or a `0.6`. (Ref: the original report notes @hawkw considered it likely fine for a minor.)

## Notes

- `AsyncFilterLayer::new` has the same signature as `FilterLayer::new`, and `AsyncFilterLayer`'s `Layer` impl produces `AsyncFilter<S, U>` — so the corrected method is consistent with the rest of the module.
- Kept `layer` non-`const` to match the sibling `Filter::layer` (both are non-`const` even though the underlying `*Layer::new` constructors are `const`).
- Verified locally: `cargo check --workspace --all-features --all-targets` and the doc-test suite both pass, so the return-type change breaks no call sites.

I left this as the focused one-line fix; happy to add a doc/`check_service`-style test demonstrating `AsyncFilter::layer` builds a working async filter if you'd like one in this PR.