### PR TITLE
docs(changelog): record the MSRV bump to 1.64.0 in 0.5.0

### DIFF
--- a/tower/CHANGELOG.md
+++ b/tower/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **filter**: Derive `Clone` for `AsyncFilterLayer` ([#731])
 - **general**: Update IndexMap ([#741])
 - **MSRV**: Increase MSRV to 1.63.0 ([#741])
+- **MSRV**: Increase MSRV to 1.64.0 ([#778])
 - **util**: **Breaking Change** `Either::A` and `Either::B` have been renamed `Either::Left` and `Either::Right`, respectively. ([#637])
 - **util**: **Breaking Change** `Either` now requires its two services to have the same error type. ([#637])
 - **util**: **Breaking Change** `Either` no longer implemenmts `Future`. ([#637])
@@ -85,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#716]: https://github.com/tower-rs/tower/pull/716
 [#731]: https://github.com/tower-rs/tower/pull/731
 [#741]: https://github.com/tower-rs/tower/pull/741
+[#778]: https://github.com/tower-rs/tower/pull/778
 [#637]: https://github.com/tower-rs/tower/pull/637
 [#654]: https://github.com/tower-rs/tower/pull/654
 [#635]: https://github.com/tower-rs/tower/pull/635


### PR DESCRIPTION
## Summary

Fixes #785.

`tower/Cargo.toml` has `rust-version = "1.64.0"`, but the CHANGELOG's last MSRV note (in the 0.5.0 section) only records the bump to 1.63.0 from #741.

Tracing the history, the 1.64.0 bump happened in the same 0.5.0 cycle but went undocumented: #741 raised MSRV to 1.63.0, and then **#778 ("use workspace dependencies", commit `85080a5`)** raised `rust-version` to **1.64.0**. That commit is contained in the `tower-0.5.0` tag, and `rust-version` has stayed at 1.64.0 ever since.

This adds the missing entry to the 0.5.0 changelog (keeping the existing #741/1.63.0 line, since both bumps really happened that cycle):

```diff
  - **MSRV**: Increase MSRV to 1.63.0 ([#741])
+ - **MSRV**: Increase MSRV to 1.64.0 ([#778])
```

plus the corresponding `[#778]` link reference. CHANGELOG-only change.

(For reference, #792 — "relax MSRV to 1.63" — was closed without merging, so documenting 1.64.0 matches the intended MSRV rather than reverting it.)