### PR TITLE
docs: fix typos in doc comments

### DIFF
--- a/tower/src/hedge/mod.rs
+++ b/tower/src/hedge/mod.rs
@@ -1,4 +1,4 @@
-//! Pre-emptively retry requests which have been outstanding for longer
+//! Preemptively retry requests which have been outstanding for longer
 //! than a given latency percentile.
 
 #![warn(missing_debug_implementations, missing_docs, unreachable_pub)]
@@ -32,7 +32,7 @@ type Service<S, P> = select::Select<
     Delay<DelayPolicy, AsyncFilter<Latency<Histo, S>, PolicyPredicate<P>>>,
 >;
 
-/// A middleware that pre-emptively retries requests which have been outstanding
+/// A middleware that preemptively retries requests which have been outstanding
 /// for longer than a given latency percentile.  If either of the original
 /// future or the retry future completes, that value is used.
 #[derive(Debug)]

--- a/tower/src/load/completion.rs
+++ b/tower/src/load/completion.rs
@@ -10,7 +10,7 @@ use std::{
 /// Attaches `H`-typed completion tracker to `V` typed values.
 ///
 /// Handles (of type `H`) are intended to be RAII guards that primarily implement [`Drop`] and update
-/// load metric state as they are dropped. This trait allows implementors to "forward" the handle
+/// load metric state as they are dropped. This trait allows implementers to "forward" the handle
 /// to later parts of the request-handling pipeline, so that the handle is only dropped when the
 /// request has truly completed.
 ///

--- a/tower/src/retry/backoff.rs
+++ b/tower/src/retry/backoff.rs
@@ -17,7 +17,7 @@ use tokio::time;
 
 use crate::util::rng::{HasherRng, Rng};
 
-/// Trait used to construct [`Backoff`] trait implementors.
+/// Trait used to construct [`Backoff`] trait implementers.
 pub trait MakeBackoff {
     /// The backoff type produced by this maker.
     type Backoff: Backoff;
@@ -27,7 +27,7 @@ pub trait MakeBackoff {
 }
 
 /// A backoff trait where a single mutable reference represents a single
-/// backoff session. Implementors must also implement [`Clone`] which will
+/// backoff session. Implementers must also implement [`Clone`] which will
 /// reset the backoff back to the default state for the next session.
 pub trait Backoff {
     /// The future associated with each backoff. This usually will be some sort


### PR DESCRIPTION
Fix a few spelling mistakes in doc comments:

- `implementors` → `implementers` in `tower/src/retry/backoff.rs` and `tower/src/load/completion.rs`
- `Pre-emptively` / `pre-emptively` → `Preemptively` / `preemptively` in `tower/src/hedge/mod.rs`

Found with `codespell`.