### PR TITLE
limit/rate: add rate() and is_limited() inspector methods on RateLimit service

### DIFF
--- a/tower/src/limit/rate/service.rs
+++ b/tower/src/limit/rate/service.rs
@@ -58,6 +58,16 @@ impl<T> RateLimit<T> {
     pub fn into_inner(self) -> T {
         self.inner
     }
+
+    /// Returns the rate configuration for this service.
+    pub fn rate(&self) -> &Rate {
+        &self.rate
+    }
+
+    /// Returns `true` if the rate limit is currently exceeded.
+    pub fn is_limited(&self) -> bool {
+        matches!(self.state, State::Limited)
+    }
 }
 
 impl<S, Request> Service<Request> for RateLimit<S>


### PR DESCRIPTION
### Summary
This PR adds public inspector methods `rate(&self)` and `is_limited(&self)` to `RateLimit<T>` in `tower/src/limit/rate/service.rs`.

### Rationale & Value
Currently, callers using `tower::limit::RateLimit` cannot inspect the rate configuration or check if the rate limiter is in `State::Limited` without polling the service.

Adding `rate(&self)` and `is_limited(&self)`:
- Exposes zero-cost state inspection for metrics, logging, and health checks.
- Avoids forcing unnecessary `poll_ready` state transitions when inspecting rate limiter status.